### PR TITLE
Protect management endpoints and add defense tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # Byte-compiled / optimized / DLL files
 RedisBlocklistMiddlewareApp/bin
 RedisBlocklistMiddlewareApp/obj
+RedisBlocklistMiddlewareApp.Tests/bin
+RedisBlocklistMiddlewareApp.Tests/obj
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - A bounded suspicious-request queue with a background analysis worker.
 - Redis-backed request-frequency tracking for simple escalation decisions.
 - A deterministic tarpit endpoint that returns synthetic HTML and recursive links.
-- A lightweight event feed at `/defense/events` for recent decisions.
+- A lightweight authenticated event feed at `/defense/events` for recent decisions.
 
 ## Current Scope
 
@@ -20,8 +20,9 @@ See [docs/architecture.md](docs/architecture.md) for the current architecture an
 ## Implemented Endpoints
 
 - `GET /health`
-- `GET /defense/events`
 - `GET /anti-scrape-tarpit/{path}`
+
+`GET /defense/events` is only exposed when `DefenseEngine:Management:ApiKey` is configured.
 
 ## Near-Term Roadmap
 
@@ -38,9 +39,10 @@ Key areas:
 
 - `DefenseEngine:Redis`
 - `DefenseEngine:Heuristics`
+- `DefenseEngine:Management`
 - `DefenseEngine:Queue`
 - `DefenseEngine:Tarpit`
 
 ## Status
 
-This remains work in progress. The environment available to this agent does not include the .NET SDK, so build verification must be done in a machine that has `dotnet` installed.
+This remains work in progress. The solution now builds with `dotnet`, but release readiness still depends on completing the blocker queue in [docs/release_blockers.md](docs/release_blockers.md).

--- a/RedisBlocklistMiddlewareApp.Tests/ClientIpResolverTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ClientIpResolverTests.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class ClientIpResolverTests
+{
+    [Fact]
+    public void Resolve_ReturnsNull_WhenRemoteIpIsMissing()
+    {
+        var resolver = new ClientIpResolver();
+        var context = new DefaultHttpContext();
+
+        var result = resolver.Resolve(context);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Resolve_NormalizesIpv4MappedIpv6Addresses()
+    {
+        var resolver = new ClientIpResolver();
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse("::ffff:203.0.113.10");
+
+        var result = resolver.Resolve(context);
+
+        Assert.Equal("203.0.113.10", result);
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/DefenseEventStoreTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/DefenseEventStoreTests.cs
@@ -1,0 +1,54 @@
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class DefenseEventStoreTests
+{
+    [Fact]
+    public void GetRecent_ReturnsMostRecentEventsFirst()
+    {
+        var store = new DefenseEventStore();
+        store.Add(CreateDecision("198.51.100.1", "/first"));
+        store.Add(CreateDecision("198.51.100.2", "/second"));
+        store.Add(CreateDecision("198.51.100.3", "/third"));
+
+        var recent = store.GetRecent(2);
+
+        Assert.Equal(2, recent.Count);
+        Assert.Equal("/third", recent[0].Path);
+        Assert.Equal("/second", recent[1].Path);
+    }
+
+    [Fact]
+    public void GetRecent_ClampsToMaxCapacity()
+    {
+        var store = new DefenseEventStore();
+
+        for (var i = 0; i < 205; i++)
+        {
+            store.Add(CreateDecision($"198.51.100.{i}", $"/item-{i}"));
+        }
+
+        var recent = store.GetRecent(500);
+
+        Assert.Equal(200, recent.Count);
+        Assert.Equal("/item-204", recent[0].Path);
+        Assert.Equal("/item-5", recent[^1].Path);
+    }
+
+    private static DefenseDecision CreateDecision(string ipAddress, string path)
+    {
+        var observedAt = DateTimeOffset.UtcNow;
+        return new DefenseDecision(
+            ipAddress,
+            "observed",
+            10,
+            1,
+            path,
+            ["signal"],
+            "summary",
+            observedAt,
+            observedAt);
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
@@ -1,0 +1,163 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class ManagementEndpointTests
+{
+    [Fact]
+    public async Task ApiKeyFilter_ReturnsUnauthorized_WhenHeaderIsMissing()
+    {
+        var filter = CreateFilter();
+        var context = new TestEndpointFilterInvocationContext(new DefaultHttpContext());
+
+        var result = await filter.InvokeAsync(context, _ => ValueTask.FromResult<object?>(Results.Ok()));
+
+        await AssertStatusCodeAsync(result, StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task ApiKeyFilter_ReturnsUnauthorized_WhenHeaderIsWrong()
+    {
+        var filter = CreateFilter();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = "wrong-key";
+        var context = new TestEndpointFilterInvocationContext(httpContext);
+
+        var result = await filter.InvokeAsync(context, _ => ValueTask.FromResult<object?>(Results.Ok()));
+
+        await AssertStatusCodeAsync(result, StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task ApiKeyFilter_AllowsRequest_WhenHeaderMatches()
+    {
+        var filter = CreateFilter();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = "test-management-key";
+        var context = new TestEndpointFilterInvocationContext(httpContext);
+
+        var result = await filter.InvokeAsync(context, _ => ValueTask.FromResult<object?>(Results.Ok()));
+
+        await AssertStatusCodeAsync(result, StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public void GetAdvertisedEndpoints_HidesEvents_WhenManagementApiKeyIsMissing()
+    {
+        var endpoints = Program.GetAdvertisedEndpoints(new DefenseEngineOptions());
+
+        Assert.False(endpoints.ContainsKey("events"));
+    }
+
+    [Fact]
+    public void GetAdvertisedEndpoints_IncludesEvents_WhenManagementApiKeyIsConfigured()
+    {
+        var options = new DefenseEngineOptions
+        {
+            Management = new ManagementOptions
+            {
+                ApiKey = "test-management-key"
+            }
+        };
+
+        var endpoints = Program.GetAdvertisedEndpoints(options);
+
+        Assert.Equal("/defense/events", endpoints["events"]);
+    }
+
+    [Fact]
+    public void MapManagementEndpoints_DoesNotRegisterDefenseEvents_WhenManagementApiKeyIsMissing()
+    {
+        var app = CreateApp();
+
+        Program.MapManagementEndpoints(app, new DefenseEngineOptions());
+        var endpoints = GetRouteEndpoints(app);
+
+        Assert.DoesNotContain(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/events");
+    }
+
+    [Fact]
+    public void MapManagementEndpoints_RegistersDefenseEvents_WhenManagementApiKeyIsConfigured()
+    {
+        var app = CreateApp();
+        var options = new DefenseEngineOptions
+        {
+            Management = new ManagementOptions
+            {
+                ApiKey = "test-management-key"
+            }
+        };
+
+        Program.MapManagementEndpoints(app, options);
+        var endpoints = GetRouteEndpoints(app);
+
+        Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/events");
+    }
+
+    private static ApiKeyEndpointFilter CreateFilter()
+    {
+        var options = Options.Create(new DefenseEngineOptions
+        {
+            Management = new ManagementOptions
+            {
+                ApiKeyHeaderName = "X-API-Key",
+                ApiKey = "test-management-key"
+            }
+        });
+
+        return new ApiKeyEndpointFilter(options);
+    }
+
+    private static WebApplication CreateApp()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddSingleton<ApiKeyEndpointFilter>();
+        builder.Services.AddSingleton<IDefenseEventStore, DefenseEventStore>();
+        return builder.Build();
+    }
+
+    private static IReadOnlyList<RouteEndpoint> GetRouteEndpoints(WebApplication app)
+    {
+        return ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(dataSource => dataSource.Endpoints)
+            .OfType<RouteEndpoint>()
+            .ToArray();
+    }
+
+    private static async Task AssertStatusCodeAsync(object? result, int expectedStatusCode)
+    {
+        Assert.NotNull(result);
+        var httpContext = new DefaultHttpContext();
+        httpContext.RequestServices = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+        var typedResult = Assert.IsAssignableFrom<IResult>(result);
+
+        await typedResult.ExecuteAsync(httpContext);
+
+        Assert.Equal(expectedStatusCode, httpContext.Response.StatusCode);
+    }
+
+    private sealed class TestEndpointFilterInvocationContext : EndpointFilterInvocationContext
+    {
+        public TestEndpointFilterInvocationContext(HttpContext httpContext)
+        {
+            HttpContext = httpContext;
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments { get; } = [];
+
+        public override T GetArgument<T>(int index)
+        {
+            return (T)Arguments[index]!;
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj
+++ b/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RedisBlocklistMiddlewareApp\RedisBlocklistMiddlewareApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
@@ -1,0 +1,274 @@
+using System.IO;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class RedisBlocklistMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_BypassesHealthRequests()
+    {
+        var blocklist = new FakeBlocklistService { IsBlockedResult = true };
+        var queue = new FakeSuspiciousRequestQueue();
+        var eventStore = new FakeDefenseEventStore();
+        var clientIpResolver = new FakeClientIpResolver("198.51.100.10");
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            blocklist,
+            new FakeRequestSignalEvaluator(new RequestSignalEvaluation(false, string.Empty, [])),
+            queue,
+            eventStore,
+            clientIpResolver);
+        var context = CreateContext("/health");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextState.WasCalled);
+        Assert.Equal(0, blocklist.IsBlockedCallCount);
+        Assert.Empty(queue.Requests);
+        Assert.Empty(eventStore.Decisions);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReturnsForbidden_ForBlockedClientIp()
+    {
+        var blocklist = new FakeBlocklistService { IsBlockedResult = true };
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            blocklist,
+            new FakeRequestSignalEvaluator(new RequestSignalEvaluation(false, string.Empty, [])),
+            new FakeSuspiciousRequestQueue(),
+            new FakeDefenseEventStore(),
+            new FakeClientIpResolver("198.51.100.10"));
+        var context = CreateContext("/products");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+        Assert.False(nextState.WasCalled);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_BlocksImmediately_AndPersistsDecision()
+    {
+        var blocklist = new FakeBlocklistService();
+        var eventStore = new FakeDefenseEventStore();
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            blocklist,
+            new FakeRequestSignalEvaluator(
+                new RequestSignalEvaluation(
+                    true,
+                    "known_bad_user_agent",
+                    ["known_bad_user_agent:GPTBot"])),
+            new FakeSuspiciousRequestQueue(),
+            eventStore,
+            new FakeClientIpResolver("198.51.100.20"));
+        var context = CreateContext("/products");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+        Assert.False(nextState.WasCalled);
+        Assert.Single(blocklist.BlockCalls);
+        Assert.Single(eventStore.Decisions);
+        Assert.Equal("blocked", eventStore.Decisions[0].Action);
+        Assert.Equal("/products", eventStore.Decisions[0].Path);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QueuesSuspiciousRequests_AndRewritesIntoTarpit()
+    {
+        var queue = new FakeSuspiciousRequestQueue();
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            new FakeBlocklistService(),
+            new FakeRequestSignalEvaluator(
+                new RequestSignalEvaluation(
+                    false,
+                    string.Empty,
+                    ["missing_accept_language"])),
+            queue,
+            new FakeDefenseEventStore(),
+            new FakeClientIpResolver("198.51.100.30"));
+        var context = CreateContext("/probe");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextState.WasCalled);
+        Assert.Equal("/anti-scrape-tarpit/probe", nextState.PathSeenByNext);
+        Assert.Single(queue.Requests);
+        Assert.Equal("/probe", queue.Requests[0].Path);
+        Assert.Equal("missing_accept_language", context.Request.Headers["X-Tarpit-Reason"].ToString());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_LeavesPathUntouched_WhenTarpitRewriteIsDisabled()
+    {
+        var queue = new FakeSuspiciousRequestQueue();
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            new FakeBlocklistService(),
+            new FakeRequestSignalEvaluator(
+                new RequestSignalEvaluation(
+                    false,
+                    string.Empty,
+                    ["generic_accept_any"])),
+            queue,
+            new FakeDefenseEventStore(),
+            new FakeClientIpResolver("198.51.100.40"),
+            options =>
+            {
+                options.Heuristics.TarpitSuspiciousRequests = false;
+            });
+        var context = CreateContext("/catalog");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextState.WasCalled);
+        Assert.Equal("/catalog", nextState.PathSeenByNext);
+        Assert.Single(queue.Requests);
+    }
+
+    private static RedisBlocklistMiddleware CreateMiddleware(
+        NextDelegateState nextState,
+        IBlocklistService blocklistService,
+        IRequestSignalEvaluator signalEvaluator,
+        ISuspiciousRequestQueue queue,
+        IDefenseEventStore eventStore,
+        IClientIpResolver clientIpResolver,
+        Action<DefenseEngineOptions>? configure = null)
+    {
+        var options = new DefenseEngineOptions();
+        configure?.Invoke(options);
+
+        return new RedisBlocklistMiddleware(
+            async context =>
+            {
+                nextState.WasCalled = true;
+                nextState.PathSeenByNext = context.Request.Path.Value;
+                await Task.CompletedTask;
+            },
+            NullLogger<RedisBlocklistMiddleware>.Instance,
+            blocklistService,
+            signalEvaluator,
+            queue,
+            eventStore,
+            clientIpResolver,
+            Options.Create(options));
+    }
+
+    private static DefaultHttpContext CreateContext(string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Request.Method = HttpMethods.Get;
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private sealed class NextDelegateState
+    {
+        public bool WasCalled { get; set; }
+
+        public string? PathSeenByNext { get; set; }
+    }
+
+    private sealed class FakeBlocklistService : IBlocklistService
+    {
+        public bool IsBlockedResult { get; set; }
+
+        public int IsBlockedCallCount { get; private set; }
+
+        public List<(string IpAddress, string Reason, IReadOnlyCollection<string> Signals)> BlockCalls { get; } = [];
+
+        public Task<bool> IsBlockedAsync(string ipAddress, CancellationToken cancellationToken)
+        {
+            IsBlockedCallCount++;
+            return Task.FromResult(IsBlockedResult);
+        }
+
+        public Task BlockAsync(
+            string ipAddress,
+            string reason,
+            IReadOnlyCollection<string> signals,
+            CancellationToken cancellationToken)
+        {
+            BlockCalls.Add((ipAddress, reason, signals));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeRequestSignalEvaluator : IRequestSignalEvaluator
+    {
+        private readonly RequestSignalEvaluation _evaluation;
+
+        public FakeRequestSignalEvaluator(RequestSignalEvaluation evaluation)
+        {
+            _evaluation = evaluation;
+        }
+
+        public RequestSignalEvaluation Evaluate(HttpContext context)
+        {
+            return _evaluation;
+        }
+    }
+
+    private sealed class FakeSuspiciousRequestQueue : ISuspiciousRequestQueue
+    {
+        public List<SuspiciousRequest> Requests { get; } = [];
+
+        public ValueTask<bool> QueueAsync(SuspiciousRequest request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return ValueTask.FromResult(true);
+        }
+
+        public async IAsyncEnumerable<SuspiciousRequest> ReadAllAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    private sealed class FakeDefenseEventStore : IDefenseEventStore
+    {
+        public List<DefenseDecision> Decisions { get; } = [];
+
+        public void Add(DefenseDecision decision)
+        {
+            Decisions.Add(decision);
+        }
+
+        public IReadOnlyList<DefenseDecision> GetRecent(int count)
+        {
+            return Decisions.Take(count).ToArray();
+        }
+    }
+
+    private sealed class FakeClientIpResolver : IClientIpResolver
+    {
+        private readonly string? _ipAddress;
+
+        public FakeClientIpResolver(string? ipAddress)
+        {
+            _ipAddress = ipAddress;
+        }
+
+        public string? Resolve(HttpContext context)
+        {
+            return _ipAddress;
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/RequestSignalEvaluatorTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/RequestSignalEvaluatorTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class RequestSignalEvaluatorTests
+{
+    [Fact]
+    public void Evaluate_BlocksImmediately_ForKnownBadUserAgent()
+    {
+        var evaluator = CreateEvaluator();
+        var context = CreateContext("/products", userAgent: "Mozilla/5.0 GPTBot/1.0");
+
+        var result = evaluator.Evaluate(context);
+
+        Assert.True(result.BlockImmediately);
+        Assert.Equal("known_bad_user_agent", result.BlockReason);
+        Assert.Contains("known_bad_user_agent:GPTBot", result.Signals);
+    }
+
+    [Fact]
+    public void Evaluate_AddsExpectedSignals_ForSuspiciousAnonymousRequest()
+    {
+        var evaluator = CreateEvaluator();
+        var context = CreateContext(
+            "/wp-admin/export",
+            userAgent: string.Empty,
+            accept: "*/*",
+            includeAcceptLanguage: false,
+            queryString: "?" + new string('a', 201));
+
+        var result = evaluator.Evaluate(context);
+
+        Assert.False(result.BlockImmediately);
+        Assert.Equal(
+            [
+                "empty_user_agent",
+                "missing_accept_language",
+                "generic_accept_any",
+                "suspicious_path:/wp-admin",
+                "long_query_string"
+            ],
+            result.Signals);
+    }
+
+    [Fact]
+    public void Evaluate_RespectsDisabledChecks()
+    {
+        var evaluator = CreateEvaluator(options =>
+        {
+            options.Heuristics.CheckEmptyUserAgent = false;
+            options.Heuristics.CheckMissingAcceptLanguage = false;
+            options.Heuristics.CheckGenericAcceptHeader = false;
+        });
+        var context = CreateContext(
+            "/landing",
+            userAgent: string.Empty,
+            accept: "*/*",
+            includeAcceptLanguage: false);
+
+        var result = evaluator.Evaluate(context);
+
+        Assert.Empty(result.Signals);
+    }
+
+    private static RequestSignalEvaluator CreateEvaluator(Action<DefenseEngineOptions>? configure = null)
+    {
+        var options = new DefenseEngineOptions();
+        configure?.Invoke(options);
+        return new RequestSignalEvaluator(Options.Create(options));
+    }
+
+    private static DefaultHttpContext CreateContext(
+        string path,
+        string userAgent,
+        string accept = "text/html",
+        bool includeAcceptLanguage = true,
+        string queryString = "")
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Request.QueryString = new QueryString(queryString);
+        context.Request.Headers.UserAgent = userAgent;
+        context.Request.Headers.Accept = accept;
+
+        if (includeAcceptLanguage)
+        {
+            context.Request.Headers.AcceptLanguage = "en-US";
+        }
+
+        return context;
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/TarpitPageServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/TarpitPageServiceTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class TarpitPageServiceTests
+{
+    [Fact]
+    public void GeneratePage_IsDeterministic_ForSamePathAndClientIp()
+    {
+        var service = CreateService();
+
+        var first = service.GeneratePage("archive/index", "198.51.100.50");
+        var second = service.GeneratePage("archive/index", "198.51.100.50");
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void GeneratePage_HtmlEncodesDisplayedPath()
+    {
+        var service = CreateService();
+
+        var page = service.GeneratePage("<script>alert(1)</script>", "198.51.100.50");
+
+        Assert.Contains("&lt;script&gt;alert(1)&lt;/script&gt;", page);
+        Assert.DoesNotContain("Session path: /<script>alert(1)</script>", page);
+    }
+
+    [Fact]
+    public void GeneratePage_UsesConfiguredTarpitPrefixInLinks()
+    {
+        var service = CreateService(options =>
+        {
+            options.Tarpit.PathPrefix = "/custom-tarpit";
+            options.Tarpit.LinkCount = 2;
+            options.Tarpit.ParagraphCount = 1;
+        });
+
+        var page = service.GeneratePage("nested/path", "198.51.100.50");
+
+        Assert.Contains("href=\"/custom-tarpit/nested/path/", page);
+    }
+
+    private static TarpitPageService CreateService(Action<DefenseEngineOptions>? configure = null)
+    {
+        var options = new DefenseEngineOptions();
+        configure?.Invoke(options);
+        return new TarpitPageService(Options.Create(options));
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
@@ -10,6 +10,8 @@ public sealed class DefenseEngineOptions
 
     public NetworkingOptions Networking { get; set; } = new();
 
+    public ManagementOptions Management { get; set; } = new();
+
     public QueueOptions Queue { get; set; } = new();
 
     public TarpitOptions Tarpit { get; set; } = new();
@@ -84,6 +86,13 @@ public sealed class HeuristicOptions
 public sealed class NetworkingOptions
 {
     public string[] TrustedProxies { get; set; } = [];
+}
+
+public sealed class ManagementOptions
+{
+    public string ApiKeyHeaderName { get; set; } = "X-API-Key";
+
+    public string ApiKey { get; set; } = string.Empty;
 }
 
 public sealed class QueueOptions

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -30,6 +30,12 @@ builder.Services
 
         options.Tarpit.PathPrefix = options.Tarpit.PathPrefix.TrimEnd('/');
 
+        options.Management.ApiKeyHeaderName = string.IsNullOrWhiteSpace(options.Management.ApiKeyHeaderName)
+            ? "X-API-Key"
+            : options.Management.ApiKeyHeaderName.Trim();
+
+        options.Management.ApiKey = options.Management.ApiKey.Trim();
+
         if (!options.Redis.BlocklistKeyPrefix.EndsWith(':'))
         {
             options.Redis.BlocklistKeyPrefix += ":";
@@ -65,11 +71,13 @@ builder.Services.AddSingleton<ISuspiciousRequestQueue, SuspiciousRequestQueue>()
 builder.Services.AddSingleton<IRequestSignalEvaluator, RequestSignalEvaluator>();
 builder.Services.AddSingleton<ITarpitPageService, TarpitPageService>();
 builder.Services.AddSingleton<IClientIpResolver, ClientIpResolver>();
+builder.Services.AddSingleton<ApiKeyEndpointFilter>();
 builder.Services.AddHostedService<DefenseAnalysisService>();
 
 var app = builder.Build();
 var runtimeOptions = app.Services.GetRequiredService<IOptions<DefenseEngineOptions>>().Value;
 var tarpitRoutePattern = $"{runtimeOptions.Tarpit.PathPrefix}/{{**path}}";
+var advertisedEndpoints = Program.GetAdvertisedEndpoints(runtimeOptions);
 
 app.UseForwardedHeaders();
 app.UseMiddleware<RedisBlocklistMiddleware>();
@@ -78,12 +86,7 @@ app.MapGet("/", () => Results.Ok(new
 {
     service = "ai-scraping-defense-dotnet",
     mode = "foundation",
-    endpoints = new
-    {
-        health = "/health",
-        events = "/defense/events",
-        tarpit = $"{runtimeOptions.Tarpit.PathPrefix}/{{path}}"
-    }
+    endpoints = advertisedEndpoints
 }));
 
 app.MapGet("/health", async (
@@ -111,12 +114,7 @@ app.MapGet("/health", async (
     }
 });
 
-app.MapGet("/defense/events", (
-    IDefenseEventStore store,
-    int count = 50) =>
-{
-    return Results.Ok(store.GetRecent(count));
-});
+Program.MapManagementEndpoints(app, runtimeOptions);
 
 app.MapGet(tarpitRoutePattern, async (
     HttpContext context,
@@ -145,3 +143,45 @@ app.Run(async context =>
 });
 
 app.Run();
+
+public partial class Program
+{
+    public static IReadOnlyDictionary<string, string> GetAdvertisedEndpoints(DefenseEngineOptions runtimeOptions)
+    {
+        var endpoints = new Dictionary<string, string>
+        {
+            ["health"] = "/health",
+            ["tarpit"] = $"{runtimeOptions.Tarpit.PathPrefix}/{{path}}"
+        };
+
+        if (ShouldExposeManagementEndpoints(runtimeOptions))
+        {
+            endpoints["events"] = "/defense/events";
+        }
+
+        return endpoints;
+    }
+
+    public static void MapManagementEndpoints(
+        IEndpointRouteBuilder app,
+        DefenseEngineOptions runtimeOptions)
+    {
+        if (!ShouldExposeManagementEndpoints(runtimeOptions))
+        {
+            return;
+        }
+
+        app.MapGet("/defense/events", (
+            IDefenseEventStore store,
+            int count = 50) =>
+        {
+            return Results.Ok(store.GetRecent(count));
+        })
+        .AddEndpointFilter<ApiKeyEndpointFilter>();
+    }
+
+    public static bool ShouldExposeManagementEndpoints(DefenseEngineOptions runtimeOptions)
+    {
+        return !string.IsNullOrWhiteSpace(runtimeOptions.Management.ApiKey);
+    }
+}

--- a/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
+++ b/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
@@ -34,33 +34,58 @@ The appsettings.json file provides configuration values used by the ASP.NET Core
     * "redis-sentinel-master,serviceName=yourServiceName,password=yourPassword" (For Sentinel)  
   * **Action Needed:** You **MUST** update the placeholder value with the correct connection string for your Redis server, including the password if applicable.
 
-### **Redis**
+### **DefenseEngine**
 
-* **Purpose:** Contains custom configuration settings specifically used by the RedisBlocklistMiddleware.cs. These values are read using IConfiguration in the middleware's constructor.  
-* **BlocklistKeyPrefix**: **(Required)** Defines the prefix prepended to the IP address when checking for a blocklist key in Redis.  
-  * Example Value: "blocklist:"  
-  * Resulting Key Checked: blocklist:ip:1.2.3.4 (as constructed in the middleware code)  
-  * **Action Needed:** Ensure this prefix **exactly matches** the prefix used by the Python ai\_service when it *adds* IPs to the blocklist. Consistency is crucial.  
-* **DbBlocklist**: **(Required)** Specifies the numeric Redis database index (typically 0-15) where the blocklist keys are stored.  
-  * Example Value: 2  
-  * **Action Needed:** Ensure this database number matches the REDIS\_DB\_BLOCKLIST environment variable used by the Python services.
+* **Purpose:** Contains the .NET-native defense configuration used by the ASP.NET Core service.
 
-### **Heuristics**
+#### **DefenseEngine:Redis**
 
-* **Purpose:** Contains settings for the heuristic checks performed by the RedisBlocklistMiddleware after the Redis blocklist check.  
-* **KnownBadUaSubstrings**: **(Required)** An array of strings. If any of these substrings (matched case-insensitively) are found within the request's User-Agent header, the middleware will immediately block the request with a 403 Forbidden status. Add or remove entries based on observed malicious traffic patterns.  
-* **TarpitRewritePath**: **(Required)** Specifies the base URL path *within your IIS site* where the Tarpit API application is hosted (e.g., /anti-scrape-tarpit/). When the middleware decides to tarpit a request based on other heuristics, it will internally rewrite the request to {TarpitRewritePath}{OriginalPath}.  
-  * **Action Needed:** Ensure this value correctly points to your Tarpit application's configured base URL path within IIS and typically ends with a /.  
-* **CheckEmptyUa**: **(Optional, Default: true)** If true, requests with a missing or empty User-Agent header will be rewritten to the TarpitRewritePath.  
-* **CheckMissingAcceptLanguage**: **(Optional, Default: true)** If true, requests missing the Accept-Language header will be rewritten to the TarpitRewritePath (potentially excluding asset requests depending on middleware logic).  
-* **CheckGenericAccept**: **(Optional, Default: true)** If true, requests where the Accept header is exactly \*/\* will be rewritten to the TarpitRewritePath (potentially excluding asset requests).
+* **ConnectionString**: Redis connection string used by the blocklist and frequency services.
+* **BlocklistKeyPrefix**: Prefix used for Redis keys that represent blocked IP addresses.
+* **FrequencyKeyPrefix**: Prefix used for Redis keys that track suspicious request frequency.
+* **BlocklistDatabase**: Redis database index used for the blocklist.
+* **FrequencyDatabase**: Redis database index used for suspicious request frequency counters.
+* **BlockDurationMinutes**: How long an automated block remains active.
+* **FrequencyWindowSeconds**: TTL applied to the rolling suspicious-request frequency counter.
+
+#### **DefenseEngine:Heuristics**
+
+* **KnownBadUserAgents**: User-Agent substrings that trigger an immediate block.
+* **SuspiciousPathSubstrings**: URL path fragments that contribute to suspicious-request scoring.
+* **CheckEmptyUserAgent**: Flags requests with an empty or missing User-Agent.
+* **CheckMissingAcceptLanguage**: Flags requests that omit `Accept-Language`.
+* **CheckGenericAcceptHeader**: Flags requests that send `Accept: */*`.
+* **TarpitSuspiciousRequests**: Rewrites suspicious requests into the tarpit path instead of allowing the original route to handle them.
+* **BlockScoreThreshold**: Score at which the queued analysis service converts suspicious traffic into a block.
+* **FrequencyBlockThreshold**: Number of suspicious requests per window that triggers blocking.
+
+#### **DefenseEngine:Networking**
+
+* **TrustedProxies**: Explicit reverse-proxy IPs whose forwarded headers should be trusted.
+
+#### **DefenseEngine:Management**
+
+* **ApiKeyHeaderName**: Header name required for authenticated management endpoints.
+* **ApiKey**: Shared secret required to access `/defense/events`. If blank, the endpoint is not exposed.
+
+#### **DefenseEngine:Queue**
+
+* **Capacity**: Maximum number of suspicious requests buffered for background analysis.
+
+#### **DefenseEngine:Tarpit**
+
+* **PathPrefix**: Prefix used for the deterministic tarpit endpoint.
+* **Seed**: Seed used to keep generated tarpit pages deterministic.
+* **LinkCount**: Number of recursive links rendered in each tarpit page.
+* **ParagraphCount**: Number of generated paragraphs rendered in each tarpit page.
+* **ResponseDelayMilliseconds**: Artificial delay applied before returning tarpit content.
 
 ## **Overrides**
 
 Remember that settings in appsettings.json can be overridden by:
 
 1. appsettings.Development.json (or other environment-specific files).  
-2. Environment variables (e.g., ConnectionStrings\_\_RedisConnection=your\_string, Redis\_\_DbBlocklist=3, Heuristics\_\_CheckEmptyUa=false). Environment variables often use \_\_ (double underscore) to denote hierarchy.  
+2. Environment variables (e.g., `ConnectionStrings__RedisConnection=your_string`, `DefenseEngine__Management__ApiKey=change-me`). Environment variables often use `__` (double underscore) to denote hierarchy.  
 3. Command-line arguments.
 
 Check your hosting environment (like the web.config for IIS deployment) to see how environment variables might be set, potentially overriding these JSON values.

--- a/RedisBlocklistMiddlewareApp/Services/ApiKeyEndpointFilter.cs
+++ b/RedisBlocklistMiddlewareApp/Services/ApiKeyEndpointFilter.cs
@@ -1,0 +1,47 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class ApiKeyEndpointFilter : IEndpointFilter
+{
+    private readonly string _headerName;
+    private readonly byte[] _expectedApiKeyBytes;
+
+    public ApiKeyEndpointFilter(IOptions<DefenseEngineOptions> options)
+    {
+        _headerName = options.Value.Management.ApiKeyHeaderName;
+        _expectedApiKeyBytes = Encoding.UTF8.GetBytes(options.Value.Management.ApiKey);
+    }
+
+    public ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        if (!context.HttpContext.Request.Headers.TryGetValue(_headerName, out var suppliedApiKey))
+        {
+            return ValueTask.FromResult<object?>(Results.Unauthorized());
+        }
+
+        var suppliedApiKeyBytes = Encoding.UTF8.GetBytes(suppliedApiKey.ToString());
+        if (!FixedTimeEquals(_expectedApiKeyBytes, suppliedApiKeyBytes))
+        {
+            return ValueTask.FromResult<object?>(Results.Unauthorized());
+        }
+
+        return next(context);
+    }
+
+    private static bool FixedTimeEquals(byte[] expected, byte[] supplied)
+    {
+        if (expected.Length != supplied.Length)
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(expected, supplied);
+    }
+}

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -62,6 +62,10 @@
     "Networking": {
       "TrustedProxies": []
     },
+    "Management": {
+      "ApiKeyHeaderName": "X-API-Key",
+      "ApiKey": ""
+    },
     "Queue": {
       "Capacity": 1024
     },

--- a/anti-scraping-defense-iis.sln
+++ b/anti-scraping-defense-iis.sln
@@ -1,19 +1,46 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedisBlocklistMiddlewareApp", "RedisBlocklistMiddlewareApp\RedisBlocklistMiddlewareApp.csproj", "{4A336096-1DA9-4AAA-B974-D563B1CECEBC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedisBlocklistMiddlewareApp.Tests", "RedisBlocklistMiddlewareApp.Tests\RedisBlocklistMiddlewareApp.Tests.csproj", "{89AFAC57-9886-4C6D-A883-7947967447D6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Debug|x64.Build.0 = Debug|Any CPU
+		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Debug|x86.Build.0 = Debug|Any CPU
 		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Release|x64.ActiveCfg = Release|Any CPU
+		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Release|x64.Build.0 = Release|Any CPU
+		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Release|x86.ActiveCfg = Release|Any CPU
+		{4A336096-1DA9-4AAA-B974-D563B1CECEBC}.Release|x86.Build.0 = Release|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Debug|x64.Build.0 = Debug|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Debug|x86.Build.0 = Debug|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Release|x64.ActiveCfg = Release|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Release|x64.Build.0 = Release|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Release|x86.ActiveCfg = Release|Any CPU
+		{89AFAC57-9886-4C6D-A883-7947967447D6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/release_blockers.md
+++ b/docs/release_blockers.md
@@ -1,0 +1,40 @@
+# Release Blocker Checklist
+
+This document turns release readiness into a tracked execution queue. Each blocker is intended to move through the same workflow:
+
+1. Problem
+2. GitHub issue
+3. Code
+4. PR
+5. Bot review
+6. Fix review findings
+7. Move to next blocker
+
+## Blocker Queue
+
+| Order | Status | Blocker | Why it blocks release |
+| --- | --- | --- | --- |
+| 1 | In Progress | Protect operational endpoints and event data with authentication/authorization | The current stack exposes defense telemetry and recent decisions publicly. |
+| 2 | Todo | Make proxy/client IP handling production-safe by default | Misconfigured forwarding can block reverse proxies or misattribute attacks. |
+| 3 | Todo | Replace in-memory event storage with durable audit/event persistence | A security product needs restart-safe auditability and investigation history. |
+| 4 | Todo | Replace lossy queue behavior with durable or backpressure-aware intake | Dropping suspicious events under load undermines the product during attacks. |
+| 5 | Todo | Add automated tests for edge filtering, tarpit routing, auth, and persistence | A successful build alone is not release confidence. |
+| 6 | Todo | Add production configuration validation and startup fail-fast checks | Default localhost Redis and empty trusted-proxy config are not market-safe defaults. |
+| 7 | Todo | Add operational observability and admin controls | Release needs authenticated admin access, metrics, and actionable diagnostics. |
+| 8 | Todo | Close parity gaps required for the first commercial scope | The repo still declares itself a foundation/WIP rather than a releasable product. |
+
+## Blocker 1
+
+### Problem
+
+The application exposes `/defense/events` with no authentication, and the payload includes IP addresses, paths, scores, and defense signals. That is sensitive operational security data and should not be publicly accessible.
+
+### Definition of Done
+
+- `/defense/events` requires authentication.
+- The auth mechanism is configurable and documented.
+- Unauthorized requests receive `401` or `403`.
+- Authenticated requests continue to work.
+- Health remains available without exposing sensitive internals.
+- The change is validated by automated tests.
+- Core request inspection behavior has regression coverage so future release blockers can build on a stable test baseline.


### PR DESCRIPTION
## Summary
- protect the  management feed behind a configurable API key and hide it when unconfigured
- add a release-blocker checklist document to track the sequential hardening flow
- add a defense-focused test project with coverage for management auth, middleware behavior, request signal evaluation, tarpit generation, client IP resolution, and event retention

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

Closes #9