### PR TITLE
Validate proxy mode and trusted client IP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ Key areas:
 
 - `DefenseEngine:Redis`
 - `DefenseEngine:Heuristics`
+- `DefenseEngine:Networking`
 - `DefenseEngine:Management`
 - `DefenseEngine:Queue`
 - `DefenseEngine:Tarpit`
+
+For direct edge deployments, leave `DefenseEngine:Networking:ClientIpResolutionMode` as `Direct`. If the app is behind a reverse proxy or CDN, switch it to `TrustedProxy` and populate `DefenseEngine:Networking:TrustedProxies` with the proxy IPs you explicitly trust.
 
 ## Status
 

--- a/RedisBlocklistMiddlewareApp.Tests/NetworkingConfigurationTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/NetworkingConfigurationTests.cs
@@ -1,0 +1,181 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class NetworkingConfigurationTests
+{
+    [Fact]
+    public void Validator_AllowsDirectModeWithoutTrustedProxies()
+    {
+        var validator = new DefenseEngineOptionsValidator();
+        var options = new DefenseEngineOptions
+        {
+            Networking = new NetworkingOptions
+            {
+                ClientIpResolutionMode = ClientIpResolutionModes.Direct,
+                TrustedProxies = []
+            }
+        };
+
+        var result = validator.Validate(null, options);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validator_RejectsUnknownClientIpResolutionMode()
+    {
+        var validator = new DefenseEngineOptionsValidator();
+        var options = new DefenseEngineOptions
+        {
+            Networking = new NetworkingOptions
+            {
+                ClientIpResolutionMode = "ProxyMaybe",
+                TrustedProxies = []
+            }
+        };
+
+        var result = validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures!, failure => failure.Contains("ClientIpResolutionMode", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validator_RejectsTrustedProxyModeWithoutTrustedProxies()
+    {
+        var validator = new DefenseEngineOptionsValidator();
+        var options = new DefenseEngineOptions
+        {
+            Networking = new NetworkingOptions
+            {
+                ClientIpResolutionMode = ClientIpResolutionModes.TrustedProxy,
+                TrustedProxies = []
+            }
+        };
+
+        var result = validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures!, failure => failure.Contains("must contain at least one IP address", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validator_RejectsDirectModeWhenTrustedProxiesAreConfigured()
+    {
+        var validator = new DefenseEngineOptionsValidator();
+        var options = new DefenseEngineOptions
+        {
+            Networking = new NetworkingOptions
+            {
+                ClientIpResolutionMode = ClientIpResolutionModes.Direct,
+                TrustedProxies = ["203.0.113.10"]
+            }
+        };
+
+        var result = validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures!, failure => failure.Contains("must be empty", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validator_RejectsInvalidTrustedProxyAddresses()
+    {
+        var validator = new DefenseEngineOptionsValidator();
+        var options = new DefenseEngineOptions
+        {
+            Networking = new NetworkingOptions
+            {
+                ClientIpResolutionMode = ClientIpResolutionModes.TrustedProxy,
+                TrustedProxies = ["not-an-ip"]
+            }
+        };
+
+        var result = validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures!, failure => failure.Contains("not-an-ip", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validator_AllowsTrustedProxyModeWithValidProxyAddresses()
+    {
+        var validator = new DefenseEngineOptionsValidator();
+        var options = new DefenseEngineOptions
+        {
+            Networking = new NetworkingOptions
+            {
+                ClientIpResolutionMode = ClientIpResolutionModes.TrustedProxy,
+                TrustedProxies = ["203.0.113.10", "2001:db8::10"]
+            }
+        };
+
+        var result = validator.Validate(null, options);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void ForwardedHeadersSetup_DisablesForwardingInDirectMode()
+    {
+        var setup = CreateSetup(new DefenseEngineOptions
+        {
+            Networking = new NetworkingOptions
+            {
+                ClientIpResolutionMode = ClientIpResolutionModes.Direct,
+                TrustedProxies = []
+            }
+        });
+        var options = new ForwardedHeadersOptions();
+
+        setup.Configure(options);
+
+        Assert.Equal(ForwardedHeaders.None, options.ForwardedHeaders);
+        Assert.Empty(options.KnownProxies);
+    }
+
+    [Fact]
+    public void ForwardedHeadersSetup_ConfiguresTrustedProxiesInTrustedProxyMode()
+    {
+        var setup = CreateSetup(new DefenseEngineOptions
+        {
+            Networking = new NetworkingOptions
+            {
+                ClientIpResolutionMode = ClientIpResolutionModes.TrustedProxy,
+                TrustedProxies = ["203.0.113.10", "2001:db8::10"]
+            }
+        });
+        var options = new ForwardedHeadersOptions();
+
+        setup.Configure(options);
+
+        Assert.Equal(ForwardedHeaders.XForwardedFor, options.ForwardedHeaders);
+        Assert.Contains(IPAddress.Parse("203.0.113.10"), options.KnownProxies);
+        Assert.Contains(IPAddress.Parse("2001:db8::10"), options.KnownProxies);
+    }
+
+    [Fact]
+    public void Program_UsesForwardedHeadersOnlyInTrustedProxyMode()
+    {
+        Assert.False(Program.ShouldUseForwardedHeaders(new DefenseEngineOptions()));
+
+        Assert.True(Program.ShouldUseForwardedHeaders(new DefenseEngineOptions
+        {
+            Networking = new NetworkingOptions
+            {
+                ClientIpResolutionMode = ClientIpResolutionModes.TrustedProxy,
+                TrustedProxies = ["203.0.113.10"]
+            }
+        }));
+    }
+
+    private static ForwardedHeadersOptionsSetup CreateSetup(DefenseEngineOptions options)
+    {
+        return new ForwardedHeadersOptionsSetup(Options.Create(options));
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj
+++ b/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
@@ -85,7 +85,16 @@ public sealed class HeuristicOptions
 
 public sealed class NetworkingOptions
 {
+    public string ClientIpResolutionMode { get; set; } = ClientIpResolutionModes.Direct;
+
     public string[] TrustedProxies { get; set; } = [];
+}
+
+public static class ClientIpResolutionModes
+{
+    public const string Direct = "Direct";
+
+    public const string TrustedProxy = "TrustedProxy";
 }
 
 public sealed class ManagementOptions

--- a/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptionsValidator.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptionsValidator.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using Microsoft.Extensions.Options;
+
+namespace RedisBlocklistMiddlewareApp.Configuration;
+
+public sealed class DefenseEngineOptionsValidator : IValidateOptions<DefenseEngineOptions>
+{
+    public ValidateOptionsResult Validate(string? name, DefenseEngineOptions options)
+    {
+        var errors = new List<string>();
+        var networking = options.Networking;
+
+        if (!string.Equals(networking.ClientIpResolutionMode, ClientIpResolutionModes.Direct, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(networking.ClientIpResolutionMode, ClientIpResolutionModes.TrustedProxy, StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add(
+                $"DefenseEngine:Networking:ClientIpResolutionMode must be '{ClientIpResolutionModes.Direct}' or '{ClientIpResolutionModes.TrustedProxy}'.");
+        }
+
+        var invalidTrustedProxies = networking.TrustedProxies
+            .Where(proxy => !IPAddress.TryParse(proxy, out _))
+            .ToArray();
+
+        if (invalidTrustedProxies.Length > 0)
+        {
+            errors.Add(
+                $"DefenseEngine:Networking:TrustedProxies contains invalid IP addresses: {string.Join(", ", invalidTrustedProxies)}.");
+        }
+
+        if (string.Equals(networking.ClientIpResolutionMode, ClientIpResolutionModes.TrustedProxy, StringComparison.OrdinalIgnoreCase) &&
+            networking.TrustedProxies.Length == 0)
+        {
+            errors.Add(
+                "DefenseEngine:Networking:TrustedProxies must contain at least one IP address when ClientIpResolutionMode is 'TrustedProxy'.");
+        }
+
+        if (string.Equals(networking.ClientIpResolutionMode, ClientIpResolutionModes.Direct, StringComparison.OrdinalIgnoreCase) &&
+            networking.TrustedProxies.Length > 0)
+        {
+            errors.Add(
+                "DefenseEngine:Networking:TrustedProxies must be empty when ClientIpResolutionMode is 'Direct'.");
+        }
+
+        return errors.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(errors);
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Configuration/ForwardedHeadersOptionsSetup.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/ForwardedHeadersOptionsSetup.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Options;
+
+namespace RedisBlocklistMiddlewareApp.Configuration;
+
+public sealed class ForwardedHeadersOptionsSetup : IConfigureOptions<ForwardedHeadersOptions>
+{
+    private readonly DefenseEngineOptions _options;
+
+    public ForwardedHeadersOptionsSetup(IOptions<DefenseEngineOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public void Configure(ForwardedHeadersOptions options)
+    {
+        options.ForwardedHeaders = ForwardedHeaders.None;
+        options.ForwardLimit = 1;
+        options.KnownNetworks.Clear();
+        options.KnownProxies.Clear();
+
+        if (!string.Equals(
+                _options.Networking.ClientIpResolutionMode,
+                ClientIpResolutionModes.TrustedProxy,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+
+        foreach (var trustedProxyAddress in _options.Networking.TrustedProxies)
+        {
+            if (IPAddress.TryParse(trustedProxyAddress, out var trustedProxy))
+            {
+                options.KnownProxies.Add(trustedProxy);
+            }
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -4,17 +4,15 @@ using Microsoft.Extensions.Options;
 using RedisBlocklistMiddlewareApp;
 using RedisBlocklistMiddlewareApp.Configuration;
 using RedisBlocklistMiddlewareApp.Services;
-using System.Net;
 
 var builder = WebApplication.CreateBuilder(args);
 var redisConnectionString = builder.Configuration.GetConnectionString("RedisConnection");
-var trustedProxyAddresses = builder.Configuration
-    .GetSection($"{DefenseEngineOptions.SectionName}:Networking:TrustedProxies")
-    .Get<string[]>() ?? [];
 
+builder.Services.AddSingleton<IValidateOptions<DefenseEngineOptions>, DefenseEngineOptionsValidator>();
 builder.Services
     .AddOptions<DefenseEngineOptions>()
     .Bind(builder.Configuration.GetSection(DefenseEngineOptions.SectionName))
+    .ValidateOnStart()
     .PostConfigure(options =>
     {
         if (!string.IsNullOrWhiteSpace(redisConnectionString) &&
@@ -36,6 +34,16 @@ builder.Services
 
         options.Management.ApiKey = options.Management.ApiKey.Trim();
 
+        options.Networking.ClientIpResolutionMode = string.IsNullOrWhiteSpace(options.Networking.ClientIpResolutionMode)
+            ? ClientIpResolutionModes.Direct
+            : options.Networking.ClientIpResolutionMode.Trim();
+
+        options.Networking.TrustedProxies = options.Networking.TrustedProxies
+            .Where(proxy => !string.IsNullOrWhiteSpace(proxy))
+            .Select(proxy => proxy.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
         if (!options.Redis.BlocklistKeyPrefix.EndsWith(':'))
         {
             options.Redis.BlocklistKeyPrefix += ":";
@@ -47,21 +55,7 @@ builder.Services
         }
     });
 
-builder.Services.Configure<ForwardedHeadersOptions>(options =>
-{
-    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
-    options.ForwardLimit = 1;
-    options.KnownNetworks.Clear();
-    options.KnownProxies.Clear();
-
-    foreach (var trustedProxyAddress in trustedProxyAddresses)
-    {
-        if (IPAddress.TryParse(trustedProxyAddress, out var trustedProxy))
-        {
-            options.KnownProxies.Add(trustedProxy);
-        }
-    }
-});
+builder.Services.AddSingleton<IConfigureOptions<ForwardedHeadersOptions>, ForwardedHeadersOptionsSetup>();
 
 builder.Services.AddSingleton<IRedisConnectionProvider, RedisConnectionProvider>();
 builder.Services.AddSingleton<IBlocklistService, RedisBlocklistService>();
@@ -79,7 +73,11 @@ var runtimeOptions = app.Services.GetRequiredService<IOptions<DefenseEngineOptio
 var tarpitRoutePattern = $"{runtimeOptions.Tarpit.PathPrefix}/{{**path}}";
 var advertisedEndpoints = Program.GetAdvertisedEndpoints(runtimeOptions);
 
-app.UseForwardedHeaders();
+if (Program.ShouldUseForwardedHeaders(runtimeOptions))
+{
+    app.UseForwardedHeaders();
+}
+
 app.UseMiddleware<RedisBlocklistMiddleware>();
 
 app.MapGet("/", () => Results.Ok(new
@@ -183,5 +181,13 @@ public partial class Program
     public static bool ShouldExposeManagementEndpoints(DefenseEngineOptions runtimeOptions)
     {
         return !string.IsNullOrWhiteSpace(runtimeOptions.Management.ApiKey);
+    }
+
+    public static bool ShouldUseForwardedHeaders(DefenseEngineOptions runtimeOptions)
+    {
+        return string.Equals(
+            runtimeOptions.Networking.ClientIpResolutionMode,
+            ClientIpResolutionModes.TrustedProxy,
+            StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
+++ b/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
@@ -61,7 +61,8 @@ The appsettings.json file provides configuration values used by the ASP.NET Core
 
 #### **DefenseEngine:Networking**
 
-* **TrustedProxies**: Explicit reverse-proxy IPs whose forwarded headers should be trusted.
+* **ClientIpResolutionMode**: Controls whether the app trusts only the direct socket peer (`Direct`) or enables `X-Forwarded-For` processing from explicitly trusted proxies (`TrustedProxy`).
+* **TrustedProxies**: Explicit reverse-proxy IPs whose forwarded headers should be trusted. This list must be empty in `Direct` mode and must be populated in `TrustedProxy` mode.
 
 #### **DefenseEngine:Management**
 

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -60,6 +60,7 @@
       "FrequencyBlockThreshold": 8
     },
     "Networking": {
+      "ClientIpResolutionMode": "Direct",
       "TrustedProxies": []
     },
     "Management": {

--- a/docs/release_blockers.md
+++ b/docs/release_blockers.md
@@ -14,8 +14,8 @@ This document turns release readiness into a tracked execution queue. Each block
 
 | Order | Status | Blocker | Why it blocks release |
 | --- | --- | --- | --- |
-| 1 | In Progress | Protect operational endpoints and event data with authentication/authorization | The current stack exposes defense telemetry and recent decisions publicly. |
-| 2 | Todo | Make proxy/client IP handling production-safe by default | Misconfigured forwarding can block reverse proxies or misattribute attacks. |
+| 1 | Done | Protect operational endpoints and event data with authentication/authorization | The current stack exposes defense telemetry and recent decisions publicly. |
+| 2 | In Progress | Make proxy/client IP handling production-safe by default | Misconfigured forwarding can block reverse proxies or misattribute attacks. |
 | 3 | Todo | Replace in-memory event storage with durable audit/event persistence | A security product needs restart-safe auditability and investigation history. |
 | 4 | Todo | Replace lossy queue behavior with durable or backpressure-aware intake | Dropping suspicious events under load undermines the product during attacks. |
 | 5 | Todo | Add automated tests for edge filtering, tarpit routing, auth, and persistence | A successful build alone is not release confidence. |
@@ -38,3 +38,16 @@ The application exposes `/defense/events` with no authentication, and the payloa
 - Health remains available without exposing sensitive internals.
 - The change is validated by automated tests.
 - Core request inspection behavior has regression coverage so future release blockers can build on a stable test baseline.
+
+## Blocker 2
+
+### Problem
+
+The application currently relies on forwarded-header trust configuration that is easy to misapply in real proxy/CDN deployments. Without an explicit operating mode and validated trusted proxy list, the service can attribute requests to the wrong IP address and block infrastructure instead of the real client.
+
+### Definition of Done
+
+- Client IP resolution mode is explicit and documented.
+- Trusted proxy configuration is validated on startup.
+- Forwarded headers are only enabled when the app is explicitly placed into trusted-proxy mode.
+- The behavior is covered by automated tests.


### PR DESCRIPTION
## Summary
- add explicit Direct vs TrustedProxy client IP resolution modes and validate them on startup
- enable forwarded headers only when trusted-proxy mode is configured with explicit proxy IPs
- add networking configuration tests and update docs/release checklist

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

Closes #12