### PR TITLE
Use backpressure instead of dropping suspicious requests

### DIFF
--- a/RedisBlocklistMiddlewareApp.Tests/SuspiciousRequestQueueTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/SuspiciousRequestQueueTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class SuspiciousRequestQueueTests
+{
+    [Fact]
+    public async Task QueueAsync_WaitsForCapacityInsteadOfDroppingOldestRequest()
+    {
+        var queue = CreateQueue(capacity: 1);
+        var first = CreateRequest("198.51.100.1", "/first");
+        var second = CreateRequest("198.51.100.2", "/second");
+
+        Assert.True(await queue.QueueAsync(first, CancellationToken.None));
+
+        using var secondWriteCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var secondWriteTask = queue.QueueAsync(second, secondWriteCts.Token).AsTask();
+
+        await Task.Delay(100);
+        Assert.False(secondWriteTask.IsCompleted);
+
+        var enumerator = queue.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("/first", enumerator.Current.Path);
+
+        Assert.True(await secondWriteTask);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("/second", enumerator.Current.Path);
+
+        await enumerator.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task QueueAsync_ReturnsFalseWhenWaitingWriterIsCancelled()
+    {
+        var queue = CreateQueue(capacity: 1);
+
+        Assert.True(await queue.QueueAsync(CreateRequest("198.51.100.1", "/first"), CancellationToken.None));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        var queued = await queue.QueueAsync(CreateRequest("198.51.100.2", "/second"), cts.Token);
+
+        Assert.False(queued);
+
+        var enumerator = queue.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("/first", enumerator.Current.Path);
+        await enumerator.DisposeAsync();
+    }
+
+    private static SuspiciousRequestQueue CreateQueue(int capacity)
+    {
+        return new SuspiciousRequestQueue(Options.Create(new DefenseEngineOptions
+        {
+            Queue = new QueueOptions
+            {
+                Capacity = capacity
+            }
+        }));
+    }
+
+    private static SuspiciousRequest CreateRequest(string ipAddress, string path)
+    {
+        return new SuspiciousRequest(
+            ipAddress,
+            "GET",
+            path,
+            string.Empty,
+            "test-agent",
+            ["signal"],
+            DateTimeOffset.UtcNow);
+    }
+}

--- a/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
+++ b/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
@@ -76,7 +76,7 @@ The appsettings.json file provides configuration values used by the ASP.NET Core
 
 #### **DefenseEngine:Queue**
 
-* **Capacity**: Maximum number of suspicious requests buffered for background analysis.
+* **Capacity**: Maximum number of suspicious requests buffered for background analysis. When the queue is full, writers wait for capacity instead of dropping older suspicious requests.
 
 #### **DefenseEngine:Tarpit**
 

--- a/RedisBlocklistMiddlewareApp/Services/SuspiciousRequestQueue.cs
+++ b/RedisBlocklistMiddlewareApp/Services/SuspiciousRequestQueue.cs
@@ -16,7 +16,7 @@ public sealed class SuspiciousRequestQueue : ISuspiciousRequestQueue
         {
             SingleReader = true,
             SingleWriter = false,
-            FullMode = BoundedChannelFullMode.DropOldest
+            FullMode = BoundedChannelFullMode.Wait
         });
     }
 
@@ -24,12 +24,15 @@ public sealed class SuspiciousRequestQueue : ISuspiciousRequestQueue
         SuspiciousRequest request,
         CancellationToken cancellationToken)
     {
-        if (!await _channel.Writer.WaitToWriteAsync(cancellationToken))
+        try
+        {
+            await _channel.Writer.WriteAsync(request, cancellationToken);
+            return true;
+        }
+        catch (OperationCanceledException)
         {
             return false;
         }
-
-        return _channel.Writer.TryWrite(request);
     }
 
     public IAsyncEnumerable<SuspiciousRequest> ReadAllAsync(CancellationToken cancellationToken)

--- a/docs/release_blockers.md
+++ b/docs/release_blockers.md
@@ -16,8 +16,8 @@ This document turns release readiness into a tracked execution queue. Each block
 | --- | --- | --- | --- |
 | 1 | Done | Protect operational endpoints and event data with authentication/authorization | The current stack exposes defense telemetry and recent decisions publicly. |
 | 2 | Done | Make proxy/client IP handling production-safe by default | Misconfigured forwarding can block reverse proxies or misattribute attacks. |
-| 3 | In Progress | Replace in-memory event storage with durable audit/event persistence | A security product needs restart-safe auditability and investigation history. |
-| 4 | Todo | Replace lossy queue behavior with durable or backpressure-aware intake | Dropping suspicious events under load undermines the product during attacks. |
+| 3 | Done | Replace in-memory event storage with durable audit/event persistence | A security product needs restart-safe auditability and investigation history. |
+| 4 | In Progress | Replace lossy queue behavior with durable or backpressure-aware intake | Dropping suspicious events under load undermines the product during attacks. |
 | 5 | Todo | Add automated tests for edge filtering, tarpit routing, auth, and persistence | A successful build alone is not release confidence. |
 | 6 | Todo | Add production configuration validation and startup fail-fast checks | Default localhost Redis and empty trusted-proxy config are not market-safe defaults. |
 | 7 | Todo | Add operational observability and admin controls | Release needs authenticated admin access, metrics, and actionable diagnostics. |
@@ -63,4 +63,16 @@ Defense decisions currently disappear when the process restarts because the even
 - Defense decisions are persisted durably.
 - `/defense/events` reads from durable storage.
 - Persistence is created automatically and documented.
+- The behavior is covered by automated tests.
+
+## Blocker 4
+
+### Problem
+
+The suspicious-request queue currently discards older entries when the queue reaches capacity. That makes the system least reliable when it is under attack pressure, which is exactly when it most needs to preserve evidence.
+
+### Definition of Done
+
+- Suspicious-request intake no longer silently drops older items by default.
+- Queue pressure behavior is explicit and documented.
 - The behavior is covered by automated tests.


### PR DESCRIPTION
## Summary
- switch the suspicious-request queue from DropOldest to explicit backpressure
- add queue tests for full-capacity waiting and cancellation behavior
- update configuration docs and the release blocker checklist

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

Closes #18