### PR TITLE
Close remaining routing and bypass test gaps

### DIFF
--- a/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
@@ -72,6 +72,38 @@ public sealed class ManagementEndpointTests
     }
 
     [Fact]
+    public void GetAdvertisedEndpoints_UsesConfiguredTarpitPrefix()
+    {
+        var options = new DefenseEngineOptions
+        {
+            Tarpit = new TarpitOptions
+            {
+                PathPrefix = "/custom-tarpit"
+            }
+        };
+
+        var endpoints = Program.GetAdvertisedEndpoints(options);
+
+        Assert.Equal("/custom-tarpit/{path}", endpoints["tarpit"]);
+    }
+
+    [Fact]
+    public void GetTarpitRoutePattern_UsesCatchAllUnderConfiguredPrefix()
+    {
+        var options = new DefenseEngineOptions
+        {
+            Tarpit = new TarpitOptions
+            {
+                PathPrefix = "/custom-tarpit"
+            }
+        };
+
+        var pattern = Program.GetTarpitRoutePattern(options);
+
+        Assert.Equal("/custom-tarpit/{**path}", pattern);
+    }
+
+    [Fact]
     public void MapManagementEndpoints_DoesNotRegisterDefenseEvents_WhenManagementApiKeyIsMissing()
     {
         var app = CreateApp();

--- a/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
@@ -37,6 +37,54 @@ public sealed class RedisBlocklistMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_BypassesDefenseEndpoints()
+    {
+        var blocklist = new FakeBlocklistService { IsBlockedResult = true };
+        var queue = new FakeSuspiciousRequestQueue();
+        var eventStore = new FakeDefenseEventStore();
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            blocklist,
+            new FakeRequestSignalEvaluator(new RequestSignalEvaluation(false, string.Empty, [])),
+            queue,
+            eventStore,
+            new FakeClientIpResolver("198.51.100.11"));
+        var context = CreateContext("/defense/events");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextState.WasCalled);
+        Assert.Equal(0, blocklist.IsBlockedCallCount);
+        Assert.Empty(queue.Requests);
+        Assert.Empty(eventStore.Decisions);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_BypassesTarpitEndpoints()
+    {
+        var blocklist = new FakeBlocklistService { IsBlockedResult = true };
+        var queue = new FakeSuspiciousRequestQueue();
+        var eventStore = new FakeDefenseEventStore();
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            blocklist,
+            new FakeRequestSignalEvaluator(new RequestSignalEvaluation(false, string.Empty, [])),
+            queue,
+            eventStore,
+            new FakeClientIpResolver("198.51.100.12"));
+        var context = CreateContext("/anti-scrape-tarpit/nested/path");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextState.WasCalled);
+        Assert.Equal(0, blocklist.IsBlockedCallCount);
+        Assert.Empty(queue.Requests);
+        Assert.Empty(eventStore.Decisions);
+    }
+
+    [Fact]
     public async Task InvokeAsync_ReturnsForbidden_ForBlockedClientIp()
     {
         var blocklist = new FakeBlocklistService { IsBlockedResult = true };

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -76,7 +76,7 @@ builder.Services.AddHostedService<DefenseAnalysisService>();
 
 var app = builder.Build();
 var runtimeOptions = app.Services.GetRequiredService<IOptions<DefenseEngineOptions>>().Value;
-var tarpitRoutePattern = $"{runtimeOptions.Tarpit.PathPrefix}/{{**path}}";
+var tarpitRoutePattern = Program.GetTarpitRoutePattern(runtimeOptions);
 var advertisedEndpoints = Program.GetAdvertisedEndpoints(runtimeOptions);
 
 if (Program.ShouldUseForwardedHeaders(runtimeOptions))
@@ -195,5 +195,10 @@ public partial class Program
             runtimeOptions.Networking.ClientIpResolutionMode,
             ClientIpResolutionModes.TrustedProxy,
             StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string GetTarpitRoutePattern(DefenseEngineOptions runtimeOptions)
+    {
+        return $"{runtimeOptions.Tarpit.PathPrefix}/{{**path}}";
     }
 }

--- a/docs/release_blockers.md
+++ b/docs/release_blockers.md
@@ -17,8 +17,8 @@ This document turns release readiness into a tracked execution queue. Each block
 | 1 | Done | Protect operational endpoints and event data with authentication/authorization | The current stack exposes defense telemetry and recent decisions publicly. |
 | 2 | Done | Make proxy/client IP handling production-safe by default | Misconfigured forwarding can block reverse proxies or misattribute attacks. |
 | 3 | Done | Replace in-memory event storage with durable audit/event persistence | A security product needs restart-safe auditability and investigation history. |
-| 4 | In Progress | Replace lossy queue behavior with durable or backpressure-aware intake | Dropping suspicious events under load undermines the product during attacks. |
-| 5 | Todo | Add automated tests for edge filtering, tarpit routing, auth, and persistence | A successful build alone is not release confidence. |
+| 4 | Done | Replace lossy queue behavior with durable or backpressure-aware intake | Dropping suspicious events under load undermines the product during attacks. |
+| 5 | In Progress | Add automated tests for edge filtering, tarpit routing, auth, and persistence | A successful build alone is not release confidence. |
 | 6 | Todo | Add production configuration validation and startup fail-fast checks | Default localhost Redis and empty trusted-proxy config are not market-safe defaults. |
 | 7 | Todo | Add operational observability and admin controls | Release needs authenticated admin access, metrics, and actionable diagnostics. |
 | 8 | Todo | Close parity gaps required for the first commercial scope | The repo still declares itself a foundation/WIP rather than a releasable product. |
@@ -76,3 +76,16 @@ The suspicious-request queue currently discards older entries when the queue rea
 - Suspicious-request intake no longer silently drops older items by default.
 - Queue pressure behavior is explicit and documented.
 - The behavior is covered by automated tests.
+
+## Blocker 5
+
+### Problem
+
+The project now has a meaningful test baseline, but release confidence still depends on directly covering the routing and bypass decisions that determine whether suspicious traffic is inspected, tarpitted, or allowed through to operational endpoints.
+
+### Definition of Done
+
+- Automated tests cover edge filtering and bypass behavior.
+- Automated tests cover tarpit routing behavior.
+- Automated tests cover auth and persistence behavior.
+- The release checklist can mark the testing blocker done.


### PR DESCRIPTION
## Summary
- add direct tests for tarpit route pattern generation and advertised tarpit endpoints
- add middleware tests covering management and tarpit bypass paths
- update the release blocker checklist for the testing milestone

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

Closes #21