### PR TITLE
Fail fast on unsafe production Redis defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ For direct edge deployments, leave `DefenseEngine:Networking:ClientIpResolutionM
 
 Defense decisions are now persisted to SQLite via `DefenseEngine:Audit:DatabasePath`, which keeps recent event history available across restarts.
 
+In `Production`, startup now fails fast if Redis still points at a loopback endpoint like `localhost` unless you explicitly opt in with `DefenseEngine:Redis:AllowLoopbackConnectionStringInProduction`.
+
 ## Status
 
 This remains work in progress. The solution now builds with `dotnet`, but release readiness still depends on completing the blocker queue in [docs/release_blockers.md](docs/release_blockers.md).

--- a/RedisBlocklistMiddlewareApp.Tests/ProductionConfigurationValidatorTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ProductionConfigurationValidatorTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Hosting;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class ProductionConfigurationValidatorTests
+{
+    [Fact]
+    public void Validate_AllowsLoopbackRedisOutsideProduction()
+    {
+        var validator = new ProductionConfigurationValidator();
+        var errors = validator.Validate(
+            new TestHostEnvironment("Development"),
+            new DefenseEngineOptions
+            {
+                Redis = new RedisOptions
+                {
+                    ConnectionString = "localhost:6379"
+                }
+            });
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_RejectsLoopbackRedisInProduction()
+    {
+        var validator = new ProductionConfigurationValidator();
+        var errors = validator.Validate(
+            new TestHostEnvironment("Production"),
+            new DefenseEngineOptions
+            {
+                Redis = new RedisOptions
+                {
+                    ConnectionString = "localhost:6379"
+                }
+            });
+
+        Assert.Contains(errors, error => error.Contains("loopback Redis endpoint", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_AllowsRemoteRedisInProduction()
+    {
+        var validator = new ProductionConfigurationValidator();
+        var errors = validator.Validate(
+            new TestHostEnvironment("Production"),
+            new DefenseEngineOptions
+            {
+                Redis = new RedisOptions
+                {
+                    ConnectionString = "redis.internal.example:6379"
+                }
+            });
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_AllowsLoopbackRedisInProductionWhenExplicitlyConfigured()
+    {
+        var validator = new ProductionConfigurationValidator();
+        var errors = validator.Validate(
+            new TestHostEnvironment("Production"),
+            new DefenseEngineOptions
+            {
+                Redis = new RedisOptions
+                {
+                    ConnectionString = "127.0.0.1:6379",
+                    AllowLoopbackConnectionStringInProduction = true
+                }
+            });
+
+        Assert.Empty(errors);
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public TestHostEnvironment(string environmentName)
+        {
+            EnvironmentName = environmentName;
+        }
+
+        public string EnvironmentName { get; set; }
+
+        public string ApplicationName { get; set; } = "RedisBlocklistMiddlewareApp.Tests";
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
@@ -23,6 +23,8 @@ public sealed class RedisOptions
 {
     public string ConnectionString { get; set; } = "localhost:6379";
 
+    public bool AllowLoopbackConnectionStringInProduction { get; set; }
+
     public string BlocklistKeyPrefix { get; set; } = "blocklist:ip:";
 
     public string FrequencyKeyPrefix { get; set; } = "frequency:ip:";

--- a/RedisBlocklistMiddlewareApp/Configuration/ProductionConfigurationValidator.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/ProductionConfigurationValidator.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace RedisBlocklistMiddlewareApp.Configuration;
+
+public sealed class ProductionConfigurationValidator
+{
+    public IReadOnlyList<string> Validate(IHostEnvironment environment, DefenseEngineOptions options)
+    {
+        var errors = new List<string>();
+
+        if (!environment.IsProduction())
+        {
+            return errors;
+        }
+
+        if (!options.Redis.AllowLoopbackConnectionStringInProduction &&
+            UsesLoopbackRedisEndpoint(options.Redis.ConnectionString))
+        {
+            errors.Add(
+                "DefenseEngine:Redis:ConnectionString points at a loopback Redis endpoint. Set a non-loopback production Redis host or explicitly enable DefenseEngine:Redis:AllowLoopbackConnectionStringInProduction.");
+        }
+
+        return errors;
+    }
+
+    private static bool UsesLoopbackRedisEndpoint(string connectionString)
+    {
+        foreach (var segment in connectionString.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (segment.Contains('='))
+            {
+                continue;
+            }
+
+            var host = ExtractHost(segment);
+            if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(host, "127.0.0.1", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(host, "::1", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ExtractHost(string endpoint)
+    {
+        if (endpoint.StartsWith('['))
+        {
+            var endBracket = endpoint.IndexOf(']');
+            return endBracket > 1
+                ? endpoint[1..endBracket]
+                : endpoint;
+        }
+
+        var colonIndex = endpoint.IndexOf(':');
+        return colonIndex > 0
+            ? endpoint[..colonIndex]
+            : endpoint;
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Configuration/StartupValidationService.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/StartupValidationService.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace RedisBlocklistMiddlewareApp.Configuration;
+
+public sealed class StartupValidationService : IHostedService
+{
+    private readonly IHostEnvironment _environment;
+    private readonly DefenseEngineOptions _options;
+    private readonly ProductionConfigurationValidator _validator;
+
+    public StartupValidationService(
+        IHostEnvironment environment,
+        IOptions<DefenseEngineOptions> options,
+        ProductionConfigurationValidator validator)
+    {
+        _environment = environment;
+        _options = options.Value;
+        _validator = validator;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var errors = _validator.Validate(_environment, _options);
+        if (errors.Count > 0)
+        {
+            throw new OptionsValidationException(
+                DefenseEngineOptions.SectionName,
+                typeof(DefenseEngineOptions),
+                errors);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -9,6 +9,7 @@ var builder = WebApplication.CreateBuilder(args);
 var redisConnectionString = builder.Configuration.GetConnectionString("RedisConnection");
 
 builder.Services.AddSingleton<IValidateOptions<DefenseEngineOptions>, DefenseEngineOptionsValidator>();
+builder.Services.AddSingleton<ProductionConfigurationValidator>();
 builder.Services
     .AddOptions<DefenseEngineOptions>()
     .Bind(builder.Configuration.GetSection(DefenseEngineOptions.SectionName))
@@ -72,6 +73,7 @@ builder.Services.AddSingleton<IRequestSignalEvaluator, RequestSignalEvaluator>()
 builder.Services.AddSingleton<ITarpitPageService, TarpitPageService>();
 builder.Services.AddSingleton<IClientIpResolver, ClientIpResolver>();
 builder.Services.AddSingleton<ApiKeyEndpointFilter>();
+builder.Services.AddHostedService<StartupValidationService>();
 builder.Services.AddHostedService<DefenseAnalysisService>();
 
 var app = builder.Build();

--- a/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
+++ b/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
@@ -41,6 +41,7 @@ The appsettings.json file provides configuration values used by the ASP.NET Core
 #### **DefenseEngine:Redis**
 
 * **ConnectionString**: Redis connection string used by the blocklist and frequency services.
+* **AllowLoopbackConnectionStringInProduction**: Allows `localhost`/loopback Redis endpoints in `Production`. Leave this `false` for normal deployments so startup fails fast on local-only defaults.
 * **BlocklistKeyPrefix**: Prefix used for Redis keys that represent blocked IP addresses.
 * **FrequencyKeyPrefix**: Prefix used for Redis keys that track suspicious request frequency.
 * **BlocklistDatabase**: Redis database index used for the blocklist.

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -14,6 +14,7 @@
   "DefenseEngine": {
     "Redis": {
       "ConnectionString": "localhost:6379",
+      "AllowLoopbackConnectionStringInProduction": false,
       "BlocklistKeyPrefix": "blocklist:ip:",
       "FrequencyKeyPrefix": "frequency:ip:",
       "BlocklistDatabase": 2,

--- a/docs/release_blockers.md
+++ b/docs/release_blockers.md
@@ -18,8 +18,8 @@ This document turns release readiness into a tracked execution queue. Each block
 | 2 | Done | Make proxy/client IP handling production-safe by default | Misconfigured forwarding can block reverse proxies or misattribute attacks. |
 | 3 | Done | Replace in-memory event storage with durable audit/event persistence | A security product needs restart-safe auditability and investigation history. |
 | 4 | Done | Replace lossy queue behavior with durable or backpressure-aware intake | Dropping suspicious events under load undermines the product during attacks. |
-| 5 | In Progress | Add automated tests for edge filtering, tarpit routing, auth, and persistence | A successful build alone is not release confidence. |
-| 6 | Todo | Add production configuration validation and startup fail-fast checks | Default localhost Redis and empty trusted-proxy config are not market-safe defaults. |
+| 5 | Done | Add automated tests for edge filtering, tarpit routing, auth, and persistence | A successful build alone is not release confidence. |
+| 6 | In Progress | Add production configuration validation and startup fail-fast checks | Default localhost Redis and empty trusted-proxy config are not market-safe defaults. |
 | 7 | Todo | Add operational observability and admin controls | Release needs authenticated admin access, metrics, and actionable diagnostics. |
 | 8 | Todo | Close parity gaps required for the first commercial scope | The repo still declares itself a foundation/WIP rather than a releasable product. |
 
@@ -89,3 +89,15 @@ The project now has a meaningful test baseline, but release confidence still dep
 - Automated tests cover tarpit routing behavior.
 - Automated tests cover auth and persistence behavior.
 - The release checklist can mark the testing blocker done.
+
+## Blocker 6
+
+### Problem
+
+The application still allows clearly development-only defaults like loopback Redis endpoints to boot in production. A market-facing release should fail fast when those unsafe defaults are still present.
+
+### Definition of Done
+
+- Startup fails fast in production when unsafe defaults are still configured.
+- The validation is documented.
+- The behavior is covered by automated tests.


### PR DESCRIPTION
## Summary
- add a production startup validator for unsafe loopback Redis defaults
- allow an explicit override when loopback Redis is intentionally desired in production
- document the new fail-fast behavior and cover it with tests

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

Closes #24