### PR TITLE
Add durable AI webhook intake API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - A deterministic tarpit endpoint that returns synthetic HTML and recursive links.
 - A lightweight authenticated event feed at `/defense/events` for recent decisions.
 - Authenticated operator metrics and blocklist management endpoints under `/defense/*`.
+- An authenticated `/analyze` webhook endpoint with durable SQLite-backed intake for confirmed malicious events.
 
 ## Current Scope
 
@@ -25,6 +26,7 @@ See [docs/architecture.md](docs/architecture.md) for the current architecture an
 
 `GET /defense/events` is only exposed when `DefenseEngine:Management:ApiKey` is configured.
 `GET /defense/metrics` and the blocklist management endpoints follow the same API-key protection via the configured `DefenseEngine:Management:ApiKeyHeaderName` header.
+`POST /analyze` is only exposed when `DefenseEngine:Intake:ApiKey` is configured and expects the configured `DefenseEngine:Intake:ApiKeyHeaderName` header.
 
 Management endpoints:
 - `GET /defense/events?count=50`
@@ -32,6 +34,12 @@ Management endpoints:
 - `GET /defense/blocklist?ip=203.0.113.10`
 - `POST /defense/blocklist?ip=203.0.113.10&reason=manual_block`
 - `DELETE /defense/blocklist?ip=203.0.113.10`
+
+Webhook intake endpoint:
+- `POST /analyze`
+  - body shape mirrors the legacy AI service webhook: `event_type`, `reason`, `timestamp_utc`, `details`
+  - `details.ip` is required and must be a valid IP address
+  - accepted events are written durably before background processing
 
 ## Near-Term Roadmap
 
@@ -50,6 +58,7 @@ Key areas:
 - `DefenseEngine:Heuristics`
 - `DefenseEngine:Networking`
 - `DefenseEngine:Management`
+- `DefenseEngine:Intake`
 - `DefenseEngine:Audit`
 - `DefenseEngine:Queue`
 - `DefenseEngine:Tarpit`

--- a/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
@@ -48,6 +48,30 @@ public sealed class ManagementEndpointTests
     }
 
     [Fact]
+    public async Task IntakeApiKeyFilter_ReturnsUnauthorized_WhenHeaderIsMissing()
+    {
+        var filter = CreateIntakeFilter();
+        var context = new TestEndpointFilterInvocationContext(new DefaultHttpContext());
+
+        var result = await filter.InvokeAsync(context, _ => ValueTask.FromResult<object?>(Results.Ok()));
+
+        await AssertStatusCodeAsync(result, StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task IntakeApiKeyFilter_AllowsRequest_WhenHeaderMatches()
+    {
+        var filter = CreateIntakeFilter();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-Webhook-Key"] = "test-intake-key";
+        var context = new TestEndpointFilterInvocationContext(httpContext);
+
+        var result = await filter.InvokeAsync(context, _ => ValueTask.FromResult<object?>(Results.Ok()));
+
+        await AssertStatusCodeAsync(result, StatusCodes.Status200OK);
+    }
+
+    [Fact]
     public void GetAdvertisedEndpoints_HidesEvents_WhenManagementApiKeyIsMissing()
     {
         var endpoints = Program.GetAdvertisedEndpoints(new DefenseEngineOptions());
@@ -70,6 +94,22 @@ public sealed class ManagementEndpointTests
 
         Assert.Equal("/defense/events", endpoints["events"]);
         Assert.Equal("/defense/metrics", endpoints["metrics"]);
+    }
+
+    [Fact]
+    public void GetAdvertisedEndpoints_IncludesAnalyze_WhenIntakeApiKeyIsConfigured()
+    {
+        var options = new DefenseEngineOptions
+        {
+            Intake = new IntakeOptions
+            {
+                ApiKey = "test-intake-key"
+            }
+        };
+
+        var endpoints = Program.GetAdvertisedEndpoints(options);
+
+        Assert.Equal("/analyze", endpoints["analyze"]);
     }
 
     [Fact]
@@ -155,6 +195,35 @@ public sealed class ManagementEndpointTests
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/blocklist");
     }
 
+    [Fact]
+    public void MapIntakeEndpoints_RegistersAnalyze_WhenIntakeApiKeyIsConfigured()
+    {
+        var app = CreateApp();
+        var options = new DefenseEngineOptions
+        {
+            Intake = new IntakeOptions
+            {
+                ApiKey = "test-intake-key"
+            }
+        };
+
+        Program.MapIntakeEndpoints(app, options);
+        var endpoints = GetRouteEndpoints(app);
+
+        Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/analyze");
+    }
+
+    [Fact]
+    public void MapIntakeEndpoints_DoesNotRegisterAnalyze_WhenIntakeApiKeyIsMissing()
+    {
+        var app = CreateApp();
+
+        Program.MapIntakeEndpoints(app, new DefenseEngineOptions());
+        var endpoints = GetRouteEndpoints(app);
+
+        Assert.DoesNotContain(endpoints, endpoint => endpoint.RoutePattern.RawText == "/analyze");
+    }
+
     private static ApiKeyEndpointFilter CreateFilter()
     {
         var options = Options.Create(new DefenseEngineOptions
@@ -169,12 +238,28 @@ public sealed class ManagementEndpointTests
         return new ApiKeyEndpointFilter(options);
     }
 
+    private static IntakeApiKeyEndpointFilter CreateIntakeFilter()
+    {
+        var options = Options.Create(new DefenseEngineOptions
+        {
+            Intake = new IntakeOptions
+            {
+                ApiKeyHeaderName = "X-Webhook-Key",
+                ApiKey = "test-intake-key"
+            }
+        });
+
+        return new IntakeApiKeyEndpointFilter(options);
+    }
+
     private static WebApplication CreateApp()
     {
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddSingleton<ApiKeyEndpointFilter>();
+        builder.Services.AddSingleton<IntakeApiKeyEndpointFilter>();
         builder.Services.AddSingleton<IDefenseEventStore, TestDefenseEventStore>();
         builder.Services.AddSingleton<IBlocklistService, TestBlocklistService>();
+        builder.Services.AddSingleton<IWebhookEventInbox, TestWebhookEventInbox>();
         return builder.Build();
     }
 
@@ -253,6 +338,35 @@ public sealed class ManagementEndpointTests
         public Task UnblockAsync(string ipAddress, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestWebhookEventInbox : IWebhookEventInbox
+    {
+        public Task<long> EnqueueAsync(Models.IntakeWebhookEvent webhookEvent, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(1L);
+        }
+
+        public IAsyncEnumerable<Models.WebhookInboxItem> ReadAllAsync(CancellationToken cancellationToken)
+        {
+            return ReadEmptyAsync();
+        }
+
+        public Task CompleteAsync(long id, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task AbandonAsync(long id, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        private static async IAsyncEnumerable<Models.WebhookInboxItem> ReadEmptyAsync()
+        {
+            await Task.CompletedTask;
+            yield break;
         }
     }
 }

--- a/RedisBlocklistMiddlewareApp.Tests/WebhookEventInboxTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/WebhookEventInboxTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class WebhookEventInboxTests
+{
+    [Fact]
+    public async Task Inbox_PersistsQueuedEventsAcrossInstances()
+    {
+        using var harness = SqliteInboxHarness.Create();
+        var firstInbox = harness.CreateInbox();
+
+        await firstInbox.EnqueueAsync(CreateEvent("198.51.100.10"), CancellationToken.None);
+
+        var secondInbox = harness.CreateInbox();
+        await using var enumerator = secondInbox.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("198.51.100.10", enumerator.Current.Event.Details.IpAddress);
+        Assert.Equal("suspicious_activity_detected", enumerator.Current.Event.EventType);
+    }
+
+    [Fact]
+    public async Task Abandon_RequeuesClaimedWebhookEvent()
+    {
+        using var harness = SqliteInboxHarness.Create();
+        var inbox = harness.CreateInbox();
+        await inbox.EnqueueAsync(CreateEvent("198.51.100.11"), CancellationToken.None);
+
+        await using var firstEnumerator = inbox.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+        Assert.True(await firstEnumerator.MoveNextAsync());
+        var claimed = firstEnumerator.Current;
+        await firstEnumerator.DisposeAsync();
+
+        await inbox.AbandonAsync(claimed.Id, CancellationToken.None);
+
+        await using var secondEnumerator = inbox.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+        Assert.True(await secondEnumerator.MoveNextAsync());
+        Assert.Equal(claimed.Id, secondEnumerator.Current.Id);
+    }
+
+    private static IntakeWebhookEvent CreateEvent(string ipAddress)
+    {
+        return new IntakeWebhookEvent(
+            "suspicious_activity_detected",
+            "High Combined Score (0.95)",
+            DateTimeOffset.UtcNow,
+            new IntakeWebhookDetails(
+                ipAddress,
+                "GET",
+                "/test",
+                string.Empty,
+                "test-agent",
+                ["signal"]));
+    }
+
+    private sealed class SqliteInboxHarness : IDisposable
+    {
+        private readonly string _rootPath;
+
+        private SqliteInboxHarness(string rootPath)
+        {
+            _rootPath = rootPath;
+            Options = Microsoft.Extensions.Options.Options.Create(new DefenseEngineOptions
+            {
+                Audit = new AuditOptions
+                {
+                    DatabasePath = "intake.db"
+                }
+            });
+        }
+
+        public IOptions<DefenseEngineOptions> Options { get; }
+
+        public static SqliteInboxHarness Create()
+        {
+            var rootPath = Path.Combine(Path.GetTempPath(), "ai-scraping-defense-intake-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(rootPath);
+            return new SqliteInboxHarness(rootPath);
+        }
+
+        public SqliteWebhookEventInbox CreateInbox()
+        {
+            return new SqliteWebhookEventInbox(Options, new TestHostEnvironment(_rootPath));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_rootPath))
+            {
+                Directory.Delete(_rootPath, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public TestHostEnvironment(string contentRootPath)
+        {
+            ContentRootPath = contentRootPath;
+        }
+
+        public string EnvironmentName { get; set; } = "Development";
+
+        public string ApplicationName { get; set; } = "RedisBlocklistMiddlewareApp.Tests";
+
+        public string ContentRootPath { get; set; }
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/WebhookIntakeProcessingServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/WebhookIntakeProcessingServiceTests.cs
@@ -1,0 +1,141 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging.Abstractions;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class WebhookIntakeProcessingServiceTests
+{
+    [Fact]
+    public async Task ProcessingService_BlocklistsWebhookIp_AndRecordsDecision()
+    {
+        var inbox = new TestWebhookEventInbox();
+        var blocklist = new TestBlocklistService();
+        var eventStore = new TestDefenseEventStore();
+        var service = new WebhookIntakeProcessingService(
+            inbox,
+            blocklist,
+            eventStore,
+            NullLogger<WebhookIntakeProcessingService>.Instance);
+
+        await inbox.EnqueueAsync(new WebhookInboxItem(
+            7,
+            new IntakeWebhookEvent(
+                "suspicious_activity_detected",
+                "High Combined Score (0.95)",
+                DateTimeOffset.UtcNow,
+                new IntakeWebhookDetails(
+                    "198.51.100.20",
+                    "GET",
+                    "/upstream",
+                    string.Empty,
+                    "test-agent",
+                    ["upstream_signal"]))), CancellationToken.None);
+
+        await service.StartAsync(CancellationToken.None);
+        await inbox.WaitForCompletionAsync();
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Single(blocklist.BlockCalls);
+        Assert.Equal("198.51.100.20", blocklist.BlockCalls[0].IpAddress);
+        Assert.Single(eventStore.Decisions);
+        Assert.Equal("blocked", eventStore.Decisions[0].Action);
+        Assert.Equal("/upstream", eventStore.Decisions[0].Path);
+    }
+
+    private sealed class TestWebhookEventInbox : IWebhookEventInbox
+    {
+        private readonly Channel<WebhookInboxItem> _channel = Channel.CreateUnbounded<WebhookInboxItem>();
+        private readonly TaskCompletionSource _completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<long> EnqueueAsync(IntakeWebhookEvent webhookEvent, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task EnqueueAsync(WebhookInboxItem item, CancellationToken cancellationToken)
+        {
+            _channel.Writer.TryWrite(item);
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<WebhookInboxItem> ReadAllAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await foreach (var item in _channel.Reader.ReadAllAsync(cancellationToken))
+            {
+                yield return item;
+            }
+        }
+
+        public Task CompleteAsync(long id, CancellationToken cancellationToken)
+        {
+            _completed.TrySetResult();
+            _channel.Writer.TryComplete();
+            return Task.CompletedTask;
+        }
+
+        public Task AbandonAsync(long id, CancellationToken cancellationToken)
+        {
+            _completed.TrySetException(new InvalidOperationException("Webhook item was abandoned unexpectedly."));
+            _channel.Writer.TryComplete();
+            return Task.CompletedTask;
+        }
+
+        public Task WaitForCompletionAsync()
+        {
+            return _completed.Task;
+        }
+    }
+
+    private sealed class TestBlocklistService : IBlocklistService
+    {
+        public List<(string IpAddress, string Reason, IReadOnlyCollection<string> Signals)> BlockCalls { get; } = [];
+
+        public Task<bool> IsBlockedAsync(string ipAddress, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task BlockAsync(
+            string ipAddress,
+            string reason,
+            IReadOnlyCollection<string> signals,
+            CancellationToken cancellationToken)
+        {
+            BlockCalls.Add((ipAddress, reason, signals));
+            return Task.CompletedTask;
+        }
+
+        public Task UnblockAsync(string ipAddress, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestDefenseEventStore : IDefenseEventStore
+    {
+        public List<DefenseDecision> Decisions { get; } = [];
+
+        public void Add(DefenseDecision decision)
+        {
+            Decisions.Add(decision);
+        }
+
+        public IReadOnlyList<DefenseDecision> GetRecent(int count)
+        {
+            return Decisions.Take(count).ToArray();
+        }
+
+        public DefenseEventMetrics GetMetrics()
+        {
+            return new DefenseEventMetrics(
+                Decisions.Count,
+                Decisions.LongCount(decision => decision.Action == "blocked"),
+                Decisions.LongCount(decision => decision.Action == "observed"),
+                Decisions.OrderByDescending(decision => decision.DecidedAtUtc)
+                    .Select(decision => (DateTimeOffset?)decision.DecidedAtUtc)
+                    .FirstOrDefault());
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
@@ -12,6 +12,8 @@ public sealed class DefenseEngineOptions
 
     public ManagementOptions Management { get; set; } = new();
 
+    public IntakeOptions Intake { get; set; } = new();
+
     public AuditOptions Audit { get; set; } = new();
 
     public QueueOptions Queue { get; set; } = new();
@@ -104,6 +106,13 @@ public static class ClientIpResolutionModes
 public sealed class ManagementOptions
 {
     public string ApiKeyHeaderName { get; set; } = "X-API-Key";
+
+    public string ApiKey { get; set; } = string.Empty;
+}
+
+public sealed class IntakeOptions
+{
+    public string ApiKeyHeaderName { get; set; } = "X-Webhook-Key";
 
     public string ApiKey { get; set; } = string.Empty;
 }

--- a/RedisBlocklistMiddlewareApp/Models/DefenseModels.cs
+++ b/RedisBlocklistMiddlewareApp/Models/DefenseModels.cs
@@ -1,5 +1,7 @@
 namespace RedisBlocklistMiddlewareApp.Models;
 
+using System.Text.Json.Serialization;
+
 public sealed record SuspiciousRequest(
     string IpAddress,
     string Method,
@@ -30,3 +32,21 @@ public sealed record RequestSignalEvaluation(
     bool BlockImmediately,
     string BlockReason,
     IReadOnlyList<string> Signals);
+
+public sealed record IntakeWebhookEvent(
+    [property: JsonPropertyName("event_type")] string EventType,
+    [property: JsonPropertyName("reason")] string Reason,
+    [property: JsonPropertyName("timestamp_utc")] DateTimeOffset TimestampUtc,
+    [property: JsonPropertyName("details")] IntakeWebhookDetails Details);
+
+public sealed record IntakeWebhookDetails(
+    [property: JsonPropertyName("ip")] string IpAddress,
+    [property: JsonPropertyName("method")] string? Method,
+    [property: JsonPropertyName("path")] string? Path,
+    [property: JsonPropertyName("query_string")] string? QueryString,
+    [property: JsonPropertyName("user_agent")] string? UserAgent,
+    [property: JsonPropertyName("signals")] IReadOnlyList<string>? Signals);
+
+public sealed record WebhookInboxItem(
+    long Id,
+    IntakeWebhookEvent Event);

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using RedisBlocklistMiddlewareApp;
 using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
 using RedisBlocklistMiddlewareApp.Services;
 using System.Net;
 
@@ -36,6 +37,12 @@ builder.Services
             : options.Management.ApiKeyHeaderName.Trim();
 
         options.Management.ApiKey = options.Management.ApiKey.Trim();
+
+        options.Intake.ApiKeyHeaderName = string.IsNullOrWhiteSpace(options.Intake.ApiKeyHeaderName)
+            ? "X-Webhook-Key"
+            : options.Intake.ApiKeyHeaderName.Trim();
+
+        options.Intake.ApiKey = options.Intake.ApiKey.Trim();
 
         options.Networking.ClientIpResolutionMode = string.IsNullOrWhiteSpace(options.Networking.ClientIpResolutionMode)
             ? ClientIpResolutionModes.Direct
@@ -75,8 +82,11 @@ builder.Services.AddSingleton<IRequestSignalEvaluator, RequestSignalEvaluator>()
 builder.Services.AddSingleton<ITarpitPageService, TarpitPageService>();
 builder.Services.AddSingleton<IClientIpResolver, ClientIpResolver>();
 builder.Services.AddSingleton<ApiKeyEndpointFilter>();
+builder.Services.AddSingleton<IntakeApiKeyEndpointFilter>();
+builder.Services.AddSingleton<IWebhookEventInbox, SqliteWebhookEventInbox>();
 builder.Services.AddHostedService<StartupValidationService>();
 builder.Services.AddHostedService<DefenseAnalysisService>();
+builder.Services.AddHostedService<WebhookIntakeProcessingService>();
 
 var app = builder.Build();
 var runtimeOptions = app.Services.GetRequiredService<IOptions<DefenseEngineOptions>>().Value;
@@ -123,6 +133,7 @@ app.MapGet("/health", async (
 });
 
 Program.MapManagementEndpoints(app, runtimeOptions);
+Program.MapIntakeEndpoints(app, runtimeOptions);
 
 app.MapGet(tarpitRoutePattern, async (
     HttpContext context,
@@ -166,6 +177,11 @@ public partial class Program
         {
             endpoints["events"] = "/defense/events";
             endpoints["metrics"] = "/defense/metrics";
+        }
+
+        if (ShouldExposeIntakeEndpoints(runtimeOptions))
+        {
+            endpoints["analyze"] = "/analyze";
         }
 
         return endpoints;
@@ -278,9 +294,55 @@ public partial class Program
             StringComparison.OrdinalIgnoreCase);
     }
 
+    public static void MapIntakeEndpoints(
+        IEndpointRouteBuilder app,
+        DefenseEngineOptions runtimeOptions)
+    {
+        if (!ShouldExposeIntakeEndpoints(runtimeOptions))
+        {
+            return;
+        }
+
+        app.MapPost("/analyze", async (
+            IntakeWebhookEvent webhookEvent,
+            IWebhookEventInbox inbox,
+            CancellationToken cancellationToken) =>
+        {
+            if (!TryNormalizeIpAddress(webhookEvent.Details.IpAddress, out var normalizedIp))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "The webhook details.ip field must contain a valid IPv4 or IPv6 address."
+                });
+            }
+
+            var normalizedEvent = webhookEvent with
+            {
+                Details = webhookEvent.Details with
+                {
+                    IpAddress = normalizedIp
+                }
+            };
+
+            var itemId = await inbox.EnqueueAsync(normalizedEvent, cancellationToken);
+
+            return Results.Accepted($"/analyze/{itemId}", new
+            {
+                status = "queued",
+                itemId
+            });
+        })
+        .AddEndpointFilter<IntakeApiKeyEndpointFilter>();
+    }
+
     public static string GetTarpitRoutePattern(DefenseEngineOptions runtimeOptions)
     {
         return $"{runtimeOptions.Tarpit.PathPrefix}/{{**path}}";
+    }
+
+    public static bool ShouldExposeIntakeEndpoints(DefenseEngineOptions runtimeOptions)
+    {
+        return !string.IsNullOrWhiteSpace(runtimeOptions.Intake.ApiKey);
     }
 
     public static bool TryNormalizeIpAddress(string value, out string normalizedIp)

--- a/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
+++ b/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
@@ -70,6 +70,11 @@ The appsettings.json file provides configuration values used by the ASP.NET Core
 * **ApiKeyHeaderName**: Header name required for authenticated management endpoints.
 * **ApiKey**: Shared secret required to access `/defense/events`. If blank, the endpoint is not exposed.
 
+#### **DefenseEngine:Intake**
+
+* **ApiKeyHeaderName**: Header name required for the authenticated `/analyze` webhook endpoint.
+* **ApiKey**: Shared secret required to access `/analyze`. If blank, the endpoint is not exposed.
+
 #### **DefenseEngine:Audit**
 
 * **DatabasePath**: Path to the SQLite database file used for durable defense-event storage. Relative paths are resolved from the application content root.

--- a/RedisBlocklistMiddlewareApp/Services/IWebhookEventInbox.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IWebhookEventInbox.cs
@@ -1,0 +1,14 @@
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface IWebhookEventInbox
+{
+    Task<long> EnqueueAsync(IntakeWebhookEvent webhookEvent, CancellationToken cancellationToken);
+
+    IAsyncEnumerable<WebhookInboxItem> ReadAllAsync(CancellationToken cancellationToken);
+
+    Task CompleteAsync(long id, CancellationToken cancellationToken);
+
+    Task AbandonAsync(long id, CancellationToken cancellationToken);
+}

--- a/RedisBlocklistMiddlewareApp/Services/IntakeApiKeyEndpointFilter.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IntakeApiKeyEndpointFilter.cs
@@ -1,0 +1,47 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class IntakeApiKeyEndpointFilter : IEndpointFilter
+{
+    private readonly string _headerName;
+    private readonly byte[] _expectedApiKeyBytes;
+
+    public IntakeApiKeyEndpointFilter(IOptions<DefenseEngineOptions> options)
+    {
+        _headerName = options.Value.Intake.ApiKeyHeaderName;
+        _expectedApiKeyBytes = Encoding.UTF8.GetBytes(options.Value.Intake.ApiKey);
+    }
+
+    public ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        if (!context.HttpContext.Request.Headers.TryGetValue(_headerName, out var suppliedApiKey))
+        {
+            return ValueTask.FromResult<object?>(Results.Unauthorized());
+        }
+
+        var suppliedApiKeyBytes = Encoding.UTF8.GetBytes(suppliedApiKey.ToString());
+        if (!FixedTimeEquals(_expectedApiKeyBytes, suppliedApiKeyBytes))
+        {
+            return ValueTask.FromResult<object?>(Results.Unauthorized());
+        }
+
+        return next(context);
+    }
+
+    private static bool FixedTimeEquals(byte[] expected, byte[] supplied)
+    {
+        if (expected.Length != supplied.Length)
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(expected, supplied);
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/SqliteWebhookEventInbox.cs
+++ b/RedisBlocklistMiddlewareApp/Services/SqliteWebhookEventInbox.cs
@@ -1,0 +1,252 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading.Channels;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class SqliteWebhookEventInbox : IWebhookEventInbox
+{
+    private readonly string _connectionString;
+    private readonly Channel<bool> _signalChannel = Channel.CreateUnbounded<bool>(new UnboundedChannelOptions
+    {
+        SingleReader = true,
+        SingleWriter = false
+    });
+    private readonly object _gate = new();
+
+    public SqliteWebhookEventInbox(
+        IOptions<DefenseEngineOptions> options,
+        IHostEnvironment environment)
+    {
+        var databasePath = options.Value.Audit.DatabasePath;
+        var resolvedDatabasePath = Path.IsPathRooted(databasePath)
+            ? databasePath
+            : Path.Combine(environment.ContentRootPath, databasePath);
+
+        var directory = Path.GetDirectoryName(resolvedDatabasePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = resolvedDatabasePath
+        }.ToString();
+
+        EnsureSchema();
+        ResetLeases();
+    }
+
+    public Task<long> EnqueueAsync(IntakeWebhookEvent webhookEvent, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                INSERT INTO webhook_intake_events
+                (
+                    event_type,
+                    reason,
+                    timestamp_utc,
+                    payload_json,
+                    status,
+                    leased_at_utc
+                )
+                VALUES
+                (
+                    $eventType,
+                    $reason,
+                    $timestampUtc,
+                    $payloadJson,
+                    'pending',
+                    NULL
+                );
+
+                SELECT last_insert_rowid();
+                """;
+            command.Parameters.AddWithValue("$eventType", webhookEvent.EventType);
+            command.Parameters.AddWithValue("$reason", webhookEvent.Reason);
+            command.Parameters.AddWithValue("$timestampUtc", webhookEvent.TimestampUtc.UtcDateTime.ToString("O"));
+            command.Parameters.AddWithValue("$payloadJson", JsonSerializer.Serialize(webhookEvent));
+            var id = (long)command.ExecuteScalar()!;
+            _signalChannel.Writer.TryWrite(true);
+            return Task.FromResult(id);
+        }
+    }
+
+    public async IAsyncEnumerable<WebhookInboxItem> ReadAllAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var next = TryClaimNext();
+            if (next is not null)
+            {
+                yield return next;
+                continue;
+            }
+
+            await _signalChannel.Reader.ReadAsync(cancellationToken);
+        }
+    }
+
+    public Task CompleteAsync(long id, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                DELETE FROM webhook_intake_events
+                WHERE id = $id;
+                """;
+            command.Parameters.AddWithValue("$id", id);
+            command.ExecuteNonQuery();
+            return Task.CompletedTask;
+        }
+    }
+
+    public Task AbandonAsync(long id, CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                UPDATE webhook_intake_events
+                SET
+                    status = 'pending',
+                    leased_at_utc = NULL
+                WHERE id = $id;
+                """;
+            command.Parameters.AddWithValue("$id", id);
+            command.ExecuteNonQuery();
+            _signalChannel.Writer.TryWrite(true);
+            return Task.CompletedTask;
+        }
+    }
+
+    private WebhookInboxItem? TryClaimNext()
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var transaction = connection.BeginTransaction();
+
+            using var selectCommand = connection.CreateCommand();
+            selectCommand.Transaction = transaction;
+            selectCommand.CommandText =
+                """
+                SELECT id, payload_json
+                FROM webhook_intake_events
+                WHERE status = 'pending'
+                ORDER BY id
+                LIMIT 1;
+                """;
+
+            using var reader = selectCommand.ExecuteReader();
+            if (!reader.Read())
+            {
+                transaction.Commit();
+                return null;
+            }
+
+            var id = reader.GetInt64(0);
+            var payloadJson = reader.GetString(1);
+            reader.Close();
+
+            using var updateCommand = connection.CreateCommand();
+            updateCommand.Transaction = transaction;
+            updateCommand.CommandText =
+                """
+                UPDATE webhook_intake_events
+                SET
+                    status = 'processing',
+                    leased_at_utc = $leasedAtUtc
+                WHERE id = $id;
+                """;
+            updateCommand.Parameters.AddWithValue("$id", id);
+            updateCommand.Parameters.AddWithValue("$leasedAtUtc", DateTimeOffset.UtcNow.UtcDateTime.ToString("O"));
+            updateCommand.ExecuteNonQuery();
+
+            transaction.Commit();
+
+            var webhookEvent = JsonSerializer.Deserialize<IntakeWebhookEvent>(payloadJson)
+                ?? throw new InvalidOperationException($"Failed to deserialize webhook inbox payload {id}.");
+
+            return new WebhookInboxItem(id, webhookEvent);
+        }
+    }
+
+    private void EnsureSchema()
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                CREATE TABLE IF NOT EXISTS webhook_intake_events
+                (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_type TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    timestamp_utc TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    leased_at_utc TEXT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_webhook_intake_events_status_id
+                    ON webhook_intake_events (status, id);
+                """;
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private void ResetLeases()
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                UPDATE webhook_intake_events
+                SET
+                    status = 'pending',
+                    leased_at_utc = NULL
+                WHERE status = 'processing';
+                """;
+            command.ExecuteNonQuery();
+
+            using var countCommand = connection.CreateCommand();
+            countCommand.CommandText =
+                """
+                SELECT COUNT(*)
+                FROM webhook_intake_events
+                WHERE status = 'pending';
+                """;
+            var pendingCount = Convert.ToInt32(countCommand.ExecuteScalar());
+            for (var i = 0; i < pendingCount; i++)
+            {
+                _signalChannel.Writer.TryWrite(true);
+            }
+        }
+    }
+
+    private SqliteConnection OpenConnection()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+        return connection;
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class WebhookIntakeProcessingService : BackgroundService
+{
+    private readonly IWebhookEventInbox _inbox;
+    private readonly IBlocklistService _blocklistService;
+    private readonly IDefenseEventStore _eventStore;
+    private readonly ILogger<WebhookIntakeProcessingService> _logger;
+
+    public WebhookIntakeProcessingService(
+        IWebhookEventInbox inbox,
+        IBlocklistService blocklistService,
+        IDefenseEventStore eventStore,
+        ILogger<WebhookIntakeProcessingService> logger)
+    {
+        _inbox = inbox;
+        _blocklistService = blocklistService;
+        _eventStore = eventStore;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var item in _inbox.ReadAllAsync(stoppingToken))
+        {
+            try
+            {
+                var normalizedIp = item.Event.Details.IpAddress;
+                var reason = string.IsNullOrWhiteSpace(item.Event.Reason)
+                    ? "external_webhook"
+                    : item.Event.Reason.Trim();
+                var signals = item.Event.Details.Signals?.Count > 0
+                    ? item.Event.Details.Signals
+                    : [$"webhook_event:{item.Event.EventType}"];
+
+                await _blocklistService.BlockAsync(
+                    normalizedIp,
+                    reason,
+                    signals,
+                    stoppingToken);
+
+                _eventStore.Add(new DefenseDecision(
+                    normalizedIp,
+                    "blocked",
+                    100,
+                    1,
+                    item.Event.Details.Path ?? "/",
+                    signals,
+                    $"Blocked from webhook intake: {reason}",
+                    item.Event.TimestampUtc,
+                    DateTimeOffset.UtcNow));
+
+                await _inbox.CompleteAsync(item.Id, stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Webhook intake processing failed for item {ItemId}.", item.Id);
+                await _inbox.AbandonAsync(item.Id, stoppingToken);
+            }
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -68,6 +68,10 @@
       "ApiKeyHeaderName": "X-API-Key",
       "ApiKey": ""
     },
+    "Intake": {
+      "ApiKeyHeaderName": "X-Webhook-Key",
+      "ApiKey": ""
+    },
     "Audit": {
       "DatabasePath": "data/defense-events.db",
       "MaxRecentEvents": 500

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,18 @@ The background worker in [RedisBlocklistMiddlewareApp/Services/DefenseAnalysisSe
 - Update per-IP frequency counters in Redis.
 - Compute a score from the collected request signals.
 - Promote high-risk or high-frequency IPs into the Redis blocklist.
-- Store recent decisions in an in-memory event feed.
+- Store recent decisions in the persistent audit/event store.
+
+### Webhook Intake
+
+The upstream AI-service webhook role is now represented by `POST /analyze` in [RedisBlocklistMiddlewareApp/Program.cs](../RedisBlocklistMiddlewareApp/Program.cs). Accepted webhook events are written durably through [RedisBlocklistMiddlewareApp/Services/SqliteWebhookEventInbox.cs](../RedisBlocklistMiddlewareApp/Services/SqliteWebhookEventInbox.cs), and [RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs](../RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs) consumes them asynchronously.
+
+Current behavior:
+
+- Requires an intake API key when the endpoint is enabled.
+- Accepts webhook events in the legacy AI-service shape.
+- Persists accepted events before processing.
+- Promotes the flagged IP into the Redis blocklist and records a defense decision.
 
 ### Redis State
 

--- a/docs/dotnet_parity_roadmap.md
+++ b/docs/dotnet_parity_roadmap.md
@@ -7,7 +7,7 @@ This document maps the upstream `ai-scraping-defense` roles to the .NET implemen
 | Upstream role | Current .NET status | Next target |
 | --- | --- | --- |
 | Nginx/Lua edge filter | Implemented as ASP.NET Core middleware | Split into a dedicated edge gateway project |
-| AI Service webhook | Partially represented by queued suspicious-request intake | Add explicit webhook/API surface and durable intake storage |
+| AI Service webhook | Implemented as authenticated `/analyze` plus durable SQLite-backed intake | Add richer alerting/reporting and separate service boundary |
 | Escalation Engine | Partially represented by `DefenseAnalysisService` | Add richer heuristics, persistent telemetry, model scoring, optional LLM adapters |
 | Tarpit API | Implemented as deterministic synthetic page endpoint | Add richer tarpit modes, streaming, and Markov/PostgreSQL-backed content |
 | Admin UI | Not implemented in .NET | Add admin API first, then UI |


### PR DESCRIPTION
## Summary
- add an authenticated /analyze webhook endpoint that mirrors the legacy AI service shape
- persist accepted webhook events durably in SQLite before background processing
- add a webhook intake processor, tests, and docs/roadmap updates

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

Closes #31