### PR TITLE
Define commercial v1 scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Scraping Defense (.NET Foundation)
+# AI Scraping Defense (.NET)
 
 This repository is being repositioned toward the original goal: a pure-.NET implementation of the `ai-scraping-defense` stack rather than an IIS-to-Linux control-plane adapter.
 
@@ -13,11 +13,19 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - Authenticated operator metrics and blocklist management endpoints under `/defense/*`.
 - An authenticated `/analyze` webhook endpoint with durable SQLite-backed intake for confirmed malicious events.
 
-## Current Scope
+## Commercial v1 Scope
 
-Today the repository is still a hybrid of legacy Python-era assets and the new .NET defense app. The .NET app is the active direction. It intentionally mirrors the same functional roles as the upstream Python project, but starts as a modular ASP.NET Core service instead of a multi-container Python stack.
+The first commercial release is a single deployable ASP.NET Core service that provides the core `ai-scraping-defense` workflow in .NET:
 
-See [docs/architecture.md](docs/architecture.md) for the current architecture and [docs/dotnet_parity_roadmap.md](docs/dotnet_parity_roadmap.md) for the parity plan against the upstream repository.
+- inspect inbound requests at the edge
+- tarpit suspicious traffic
+- persist defense decisions and operator-visible events
+- accept authenticated webhook intake for confirmed malicious traffic
+- block and unblock IPs through authenticated operator endpoints
+
+This is intentionally a modular monolith for v1. It preserves the upstream functional roles, but keeps them in one deployable until the .NET contracts and production behavior settle.
+
+See [docs/architecture.md](docs/architecture.md) for the current architecture, [docs/commercial_scope.md](docs/commercial_scope.md) for the v1 definition, and [docs/dotnet_parity_roadmap.md](docs/dotnet_parity_roadmap.md) for the post-v1 parity queue.
 
 ## Implemented Endpoints
 
@@ -41,12 +49,12 @@ Webhook intake endpoint:
   - `details.ip` is required and must be a valid IP address
   - accepted events are written durably before background processing
 
-## Near-Term Roadmap
+## Supported Data Stores
 
-- Split the current modular monolith into clear .NET service boundaries that line up with the upstream roles: edge gateway, AI intake, escalation engine, tarpit API, and admin surface.
-- Replace the current synthetic tarpit page generator with a PostgreSQL-backed Markov or equivalent .NET content engine.
-- Add persistent operational telemetry and blocklist management endpoints.
-- Port community blocklist sync, peer sync, and model-based escalation into .NET services.
+- `Redis`: required for hot operational state such as blocklists and short-window frequency counters.
+- `SQLite`: supported for local development, demos, and single-node/lightweight production installs as the durable audit and webhook intake store.
+- `PostgreSQL`: planned as the primary production relational backend for richer tarpit content, sync features, and larger-scale persistence.
+- `SQL Server`: deferred. It is not a commercial v1 target unless customer demand justifies the extra provider and test surface.
 
 ## Configuration
 
@@ -71,4 +79,4 @@ In `Production`, startup now fails fast if Redis still points at a loopback endp
 
 ## Status
 
-This remains work in progress. The solution now builds with `dotnet`, but release readiness still depends on completing the blocker queue in [docs/release_blockers.md](docs/release_blockers.md).
+The project now has an explicit commercial-v1 target, but release readiness still depends on closing the remaining items in [docs/release_blockers.md](docs/release_blockers.md) and the post-v1 parity queue in [docs/dotnet_parity_roadmap.md](docs/dotnet_parity_roadmap.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
-# System Architecture (.NET Foundation)
+# System Architecture (.NET)
 
-This repository is moving toward a pure-.NET version of the upstream `ai-scraping-defense` platform. The current implementation is a foundation release: one ASP.NET Core application that already exposes the same core roles as the upstream stack, but keeps them in-process while the .NET service boundaries settle.
+This repository is moving toward a pure-.NET version of the upstream `ai-scraping-defense` platform. Commercial v1 is intentionally a single ASP.NET Core application that already exposes the same core roles as the upstream stack, but keeps them in-process while the .NET service boundaries settle.
 
 ## Current Components
 
@@ -86,4 +86,4 @@ This app is intentionally shaped so it can be split into separate .NET services 
 - Admin API/UI
 - Blocklist sync workers
 
-The mapping and order of that work is documented in [docs/dotnet_parity_roadmap.md](dotnet_parity_roadmap.md).
+The commercial-v1 scope is documented in [docs/commercial_scope.md](commercial_scope.md). The post-v1 split and parity work is documented in [docs/dotnet_parity_roadmap.md](dotnet_parity_roadmap.md).

--- a/docs/commercial_scope.md
+++ b/docs/commercial_scope.md
@@ -1,0 +1,62 @@
+# Commercial Scope
+
+This document defines the first commercial release of the .NET stack. Its purpose is to stop treating the repository as an open-ended foundation and to make release readiness measurable.
+
+## v1 Product Definition
+
+Commercial v1 is a single deployable ASP.NET Core service with authenticated operator endpoints and durable local persistence.
+
+Included in v1:
+
+- Redis-backed IP blocklist enforcement
+- request inspection for suspicious paths, malformed headers, query abuse, and known bad user agents
+- rewrite of suspicious traffic into the tarpit surface
+- asynchronous defense analysis with Redis-backed request frequency tracking
+- authenticated operator endpoints for events, metrics, and manual blocklist actions
+- authenticated `/analyze` intake for externally confirmed malicious events
+- durable SQLite-backed audit and webhook inbox persistence
+- automated unit and integration-style tests covering the core pipeline
+
+Explicitly deferred from v1:
+
+- multi-project service split into dedicated `EdgeGateway`, `EscalationEngine`, and `TarpitApi` processes
+- peer sync and trust policy
+- community blocklist sync
+- richer reputation providers and optional LLM-backed scoring
+- PostgreSQL-backed Markov tarpit content generation
+- operator dashboard UI
+- SQL Server support
+
+## Supported Deployment Model
+
+Commercial v1 supports these deployment modes:
+
+- direct edge deployment where the app receives client IPs directly
+- trusted-proxy deployment where explicit reverse proxy IPs are configured
+- single-node durable deployment using Redis plus SQLite
+
+Commercial v1 does not yet claim:
+
+- multi-node relational consistency
+- cross-instance signal sync
+- operator UI parity with the upstream project
+
+## Database Strategy
+
+The storage model for commercial v1 is intentionally narrow:
+
+- `Redis` is the required operational store for hot state.
+- `SQLite` is the supported durable store for audit history and webhook intake in v1.
+- `PostgreSQL` is the planned next production relational backend after v1.
+- `SQL Server` is deferred until there is customer demand.
+
+This keeps the provider surface small while still allowing a clean path to larger-scale persistence later.
+
+## Release Criteria
+
+Commercial v1 is release-ready when:
+
+- the blocker queue in [release_blockers.md](release_blockers.md) is closed
+- the shipped feature set matches the included v1 definition above
+- all deferred items are documented as post-v1 work rather than implied release commitments
+- `dotnet build` and `dotnet test` pass on the main solution

--- a/docs/dotnet_parity_roadmap.md
+++ b/docs/dotnet_parity_roadmap.md
@@ -2,34 +2,25 @@
 
 This document maps the upstream `ai-scraping-defense` roles to the .NET implementation in this repository.
 
+Commercial v1 is defined in [commercial_scope.md](commercial_scope.md). This roadmap now tracks post-v1 parity work instead of acting as an implied release checklist.
+
 ## Upstream Role Mapping
 
 | Upstream role | Current .NET status | Next target |
 | --- | --- | --- |
 | Nginx/Lua edge filter | Implemented as ASP.NET Core middleware | Split into a dedicated edge gateway project |
 | AI Service webhook | Implemented as authenticated `/analyze` plus durable SQLite-backed intake | Add richer alerting/reporting and separate service boundary |
-| Escalation Engine | Partially represented by `DefenseAnalysisService` | Add richer heuristics, persistent telemetry, model scoring, optional LLM adapters |
+| Escalation Engine | Implemented at a baseline level in `DefenseAnalysisService` | Add richer heuristics, reputation providers, model scoring, optional LLM adapters |
 | Tarpit API | Implemented as deterministic synthetic page endpoint | Add richer tarpit modes, streaming, and Markov/PostgreSQL-backed content |
-| Admin UI | Not implemented in .NET | Add admin API first, then UI |
+| Admin UI | Not implemented in .NET | Add operator dashboard on top of the authenticated admin API |
 | Community blocklist sync | Not implemented in .NET | Add background worker and contracts |
 | Peer sync | Not implemented in .NET | Add background worker and peer trust model |
-| Metrics/observability | Limited to recent in-memory event feed | Add structured metrics, health, traces, and persistent audit events |
+| Metrics/observability | Implemented at operator-API level | Add structured metrics, traces, and richer telemetry export |
 
-## What Was Completed In This Step
-
-- Removed the Linux control-plane adapter branch from `main`.
-- Re-established the repo around the original pure-.NET objective.
-- Reworked the ASP.NET Core app into a .NET-native foundation with:
-  - Redis blocklist service
-  - suspicious-request queue
-  - background escalation worker
-  - frequency tracking
-  - tarpit endpoint
-  - recent decision feed
-
-## Recommended Next Implementation Steps
+## Post-v1 Parity Queue
 
 1. Split the current app into `EdgeGateway`, `EscalationEngine`, and `TarpitApi` projects under the solution while keeping shared contracts in a common library.
-2. Add a durable decision/event store so the current `/defense/events` feed survives restarts.
+2. Add richer escalation scoring, reputation providers, and optional LLM adapters.
 3. Port the upstream tarpit content generation strategy into a .NET service backed by PostgreSQL.
-4. Add model-adapter and reputation-provider interfaces so richer analysis can be plugged in without reworking the pipeline again.
+4. Add community blocklist sync and peer sync.
+5. Build an operator dashboard UI on top of the authenticated admin API.

--- a/docs/release_blockers.md
+++ b/docs/release_blockers.md
@@ -21,7 +21,7 @@ This document turns release readiness into a tracked execution queue. Each block
 | 5 | Done | Add automated tests for edge filtering, tarpit routing, auth, and persistence | A successful build alone is not release confidence. |
 | 6 | Done | Add production configuration validation and startup fail-fast checks | Default localhost Redis and empty trusted-proxy config are not market-safe defaults. |
 | 7 | In Progress | Add operational observability and admin controls | Release needs authenticated admin access, metrics, and actionable diagnostics. |
-| 8 | Todo | Close parity gaps required for the first commercial scope | The repo still declares itself a foundation/WIP rather than a releasable product. |
+| 8 | Done | Close parity gaps required for the first commercial scope | Commercial v1 scope, supported storage, and deferred features are now explicitly defined. |
 
 ## Blocker 1
 
@@ -114,3 +114,16 @@ The service still lacks a minimally complete authenticated operator API for obse
 - Authenticated manual blocklist inspection and update endpoints are exposed.
 - The behavior is documented.
 - The behavior is covered by automated tests.
+
+## Blocker 8
+
+### Problem
+
+The repository previously described itself as a `.NET foundation` and listed parity work as an undifferentiated backlog. That makes release-readiness ambiguous because the product boundary is unclear.
+
+### Definition of Done
+
+- Commercial v1 scope is explicitly documented.
+- Supported storage backends for v1 are explicitly documented.
+- Deferred features are explicitly documented as post-v1 work.
+- The README and parity docs align with the commercial-v1 definition.


### PR DESCRIPTION
## Summary
- define the commercial v1 product boundary for the .NET stack
- document the supported Redis/SQLite/PostgreSQL storage strategy and defer SQL Server
- align the README, architecture, roadmap, and release-blocker docs with that scope

## Testing
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

Closes #36