### PR TITLE
Add pluggable escalation providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - Heuristic request inspection for known bad user agents, malformed headers, and suspicious paths.
 - A bounded suspicious-request queue with a background analysis worker.
 - Redis-backed request-frequency tracking for simple escalation decisions.
+- Pluggable escalation via configured CIDR reputation ranges, optional HTTP reputation checks, and an optional OpenAI-compatible classifier hook.
 - A deterministic tarpit endpoint that returns synthetic HTML and recursive links.
 - A lightweight authenticated event feed at `/defense/events` for recent decisions.
 - Authenticated operator metrics and blocklist management endpoints under `/defense/*`.
@@ -56,6 +57,18 @@ Webhook intake endpoint:
 - `PostgreSQL`: planned as the primary production relational backend for richer tarpit content, sync features, and larger-scale persistence.
 - `SQL Server`: deferred. It is not a commercial v1 target unless customer demand justifies the extra provider and test surface.
 
+## Escalation Extensions
+
+Queued suspicious-request analysis now persists a score breakdown with named contributions from:
+
+- base edge heuristics
+- short-window request frequency
+- configured CIDR reputation ranges
+- optional HTTP reputation providers
+- an optional OpenAI-compatible classifier endpoint
+
+The default configuration keeps the external reputation/model hooks disabled. They are exposed under `DefenseEngine:Escalation` so production deployments can opt in without changing the rest of the request pipeline.
+
 ## Configuration
 
 The .NET defense foundation is configured in [RedisBlocklistMiddlewareApp/appsettings.json](RedisBlocklistMiddlewareApp/appsettings.json) under the `DefenseEngine` section.
@@ -68,6 +81,7 @@ Key areas:
 - `DefenseEngine:Management`
 - `DefenseEngine:Intake`
 - `DefenseEngine:Audit`
+- `DefenseEngine:Escalation`
 - `DefenseEngine:Queue`
 - `DefenseEngine:Tarpit`
 

--- a/RedisBlocklistMiddlewareApp.Tests/DefenseEventStoreTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/DefenseEventStoreTests.cs
@@ -74,6 +74,22 @@ public sealed class DefenseEventStoreTests
         Assert.NotNull(metrics.LatestDecisionAtUtc);
     }
 
+    [Fact]
+    public void Store_RoundTripsDecisionBreakdown()
+    {
+        using var harness = SqliteStoreHarness.Create();
+        var store = harness.CreateStore();
+        store.Add(CreateDecision("198.51.100.50", "/breakdown"));
+
+        var recent = store.GetRecent(1);
+
+        Assert.Single(recent);
+        var breakdown = recent[0].Breakdown;
+        Assert.NotNull(breakdown);
+        Assert.Equal(10, breakdown!.TotalScore);
+        Assert.Contains(breakdown.Contributions, contribution => contribution.Source == "test");
+    }
+
     private static DefenseDecision CreateDecision(string ipAddress, string path, string action = "observed")
     {
         var observedAt = DateTimeOffset.UtcNow;
@@ -86,7 +102,19 @@ public sealed class DefenseEventStoreTests
             ["signal"],
             "summary",
             observedAt,
-            observedAt);
+            observedAt,
+            new DefenseScoreBreakdown(
+                5,
+                5,
+                10,
+                false,
+                [
+                    new DefenseScoreContribution(
+                        "test",
+                        10,
+                        ["signal"],
+                        "Test contribution.")
+                ]));
     }
 
     private sealed class SqliteStoreHarness : IDisposable

--- a/RedisBlocklistMiddlewareApp.Tests/ThreatAssessmentServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ThreatAssessmentServiceTests.cs
@@ -1,0 +1,185 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class ThreatAssessmentServiceTests
+{
+    [Fact]
+    public async Task AssessAsync_AggregatesProviderAndModelContributions()
+    {
+        var service = CreateService(
+            frequency: 3,
+            reputationProviders:
+            [
+                new TestReputationProvider(new ReputationAssessment(
+                    "configured_ranges",
+                    20,
+                    false,
+                    ["reputation_range:test_range"],
+                    "Matched configured test range."))
+            ],
+            modelAdapters:
+            [
+                new TestModelAdapter(new ModelAssessment(
+                    "openai_compatible_model",
+                    -5,
+                    false,
+                    "BENIGN_CRAWLER",
+                    ["model_verdict:benign_crawler"],
+                    "Model considered the request a benign crawler."))
+            ]);
+
+        var result = await service.AssessAsync(new SuspiciousRequest(
+            "198.51.100.10",
+            "GET",
+            "/products",
+            string.Empty,
+            "crawler",
+            ["missing_accept_language"],
+            DateTimeOffset.UtcNow), CancellationToken.None);
+
+        Assert.False(result.ShouldBlock);
+        Assert.Equal(45, result.Score);
+        Assert.Equal(3, result.Frequency);
+        Assert.Equal(15, result.Breakdown.BaseSignalScore);
+        Assert.Equal(15, result.Breakdown.FrequencyScore);
+        Assert.Contains(result.Breakdown.Contributions, contribution => contribution.Source == "configured_ranges");
+        Assert.Contains(result.Breakdown.Contributions, contribution => contribution.Source == "openai_compatible_model");
+        Assert.Contains("reputation_range:test_range", result.Signals);
+        Assert.Contains("model_verdict:benign_crawler", result.Signals);
+    }
+
+    [Fact]
+    public async Task AssessAsync_BlocksWhenExplicitMaliciousVerdictIsReturned()
+    {
+        var service = CreateService(
+            frequency: 1,
+            reputationProviders: [],
+            modelAdapters:
+            [
+                new TestModelAdapter(new ModelAssessment(
+                    "openai_compatible_model",
+                    5,
+                    true,
+                    "MALICIOUS_BOT",
+                    ["model_verdict:malicious_bot"],
+                    "Model classified the request as malicious."))
+            ],
+            configure: options =>
+            {
+                options.Heuristics.BlockScoreThreshold = 200;
+                options.Heuristics.FrequencyBlockThreshold = 50;
+            });
+
+        var result = await service.AssessAsync(new SuspiciousRequest(
+            "198.51.100.20",
+            "GET",
+            "/probe",
+            string.Empty,
+            "crawler",
+            ["generic_accept_any"],
+            DateTimeOffset.UtcNow), CancellationToken.None);
+
+        Assert.True(result.ShouldBlock);
+        Assert.Equal("threat_intelligence_verdict", result.BlockReason);
+        Assert.True(result.Breakdown.ExplicitMaliciousVerdict);
+        Assert.Contains("model_verdict:malicious_bot", result.Signals);
+    }
+
+    [Fact]
+    public async Task AssessAsync_BlocksWhenFrequencyThresholdIsReached()
+    {
+        var service = CreateService(
+            frequency: 8,
+            reputationProviders: [],
+            modelAdapters: [],
+            configure: options =>
+            {
+                options.Heuristics.BlockScoreThreshold = 500;
+                options.Heuristics.FrequencyBlockThreshold = 8;
+            });
+
+        var result = await service.AssessAsync(new SuspiciousRequest(
+            "198.51.100.30",
+            "GET",
+            "/probe",
+            string.Empty,
+            "crawler",
+            ["long_query_string"],
+            DateTimeOffset.UtcNow), CancellationToken.None);
+
+        Assert.True(result.ShouldBlock);
+        Assert.Equal("frequency_threshold", result.BlockReason);
+        Assert.Equal(35, result.Score);
+    }
+
+    private static ThreatAssessmentService CreateService(
+        long frequency,
+        IEnumerable<IThreatReputationProvider> reputationProviders,
+        IEnumerable<IThreatModelAdapter> modelAdapters,
+        Action<DefenseEngineOptions>? configure = null)
+    {
+        var options = new DefenseEngineOptions();
+        configure?.Invoke(options);
+
+        return new ThreatAssessmentService(
+            new TestRequestFrequencyTracker(frequency),
+            reputationProviders,
+            modelAdapters,
+            Options.Create(options),
+            NullLogger<ThreatAssessmentService>.Instance);
+    }
+
+    private sealed class TestRequestFrequencyTracker : IRequestFrequencyTracker
+    {
+        private readonly long _frequency;
+
+        public TestRequestFrequencyTracker(long frequency)
+        {
+            _frequency = frequency;
+        }
+
+        public Task<long> IncrementAsync(string ipAddress, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_frequency);
+        }
+    }
+
+    private sealed class TestReputationProvider : IThreatReputationProvider
+    {
+        private readonly ReputationAssessment? _assessment;
+
+        public TestReputationProvider(ReputationAssessment? assessment)
+        {
+            _assessment = assessment;
+        }
+
+        public string Name => "test_reputation";
+
+        public Task<ReputationAssessment?> AssessAsync(ThreatAssessmentContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_assessment);
+        }
+    }
+
+    private sealed class TestModelAdapter : IThreatModelAdapter
+    {
+        private readonly ModelAssessment? _assessment;
+
+        public TestModelAdapter(ModelAssessment? assessment)
+        {
+            _assessment = assessment;
+        }
+
+        public string Name => "test_model";
+
+        public Task<ModelAssessment?> AssessAsync(ThreatAssessmentContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_assessment);
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/ThreatIntelligenceProviderTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ThreatIntelligenceProviderTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class ThreatIntelligenceProviderTests
+{
+    [Fact]
+    public async Task ConfiguredRangeProvider_ReturnsAssessmentForMatchingCidr()
+    {
+        var options = Options.Create(new DefenseEngineOptions
+        {
+            Escalation = new EscalationOptions
+            {
+                ConfiguredRanges = new ConfiguredRangeReputationOptions
+                {
+                    Enabled = true,
+                    Entries =
+                    [
+                        new ReputationRangeEntry
+                        {
+                            Name = "test-range",
+                            Cidr = "198.51.100.0/24",
+                            ScoreAdjustment = 25
+                        }
+                    ]
+                }
+            }
+        });
+        var provider = new ConfiguredRangeReputationProvider(options);
+
+        var assessment = await provider.AssessAsync(CreateContext("198.51.100.44"), CancellationToken.None);
+
+        Assert.NotNull(assessment);
+        Assert.Equal(25, assessment!.ScoreAdjustment);
+        Assert.True(assessment.IsMalicious);
+        Assert.Contains("reputation_range:test-range", assessment.Signals);
+    }
+
+    [Fact]
+    public async Task HttpReputationProvider_ParsesMaliciousResponse()
+    {
+        var provider = new HttpReputationProvider(
+            new FakeHttpClientFactory(
+                CreateResponse("""
+                {
+                  "is_malicious": true,
+                  "score_adjustment": 30,
+                  "signals": ["reputation:http_feed"],
+                  "summary": "Known scraper address."
+                }
+                """)),
+            Options.Create(new DefenseEngineOptions
+            {
+                Escalation = new EscalationOptions
+                {
+                    HttpReputation = new HttpReputationProviderOptions
+                    {
+                        Enabled = true,
+                        Endpoint = "https://reputation.example.test/check"
+                    }
+                }
+            }),
+            NullLogger<HttpReputationProvider>.Instance);
+
+        var assessment = await provider.AssessAsync(CreateContext("198.51.100.45"), CancellationToken.None);
+
+        Assert.NotNull(assessment);
+        Assert.True(assessment!.IsMalicious);
+        Assert.Equal(30, assessment.ScoreAdjustment);
+        Assert.Contains("reputation:http_feed", assessment.Signals);
+    }
+
+    [Fact]
+    public async Task OpenAiCompatibleModelAdapter_ParsesJsonClassificationResponse()
+    {
+        var adapter = new OpenAiCompatibleModelAdapter(
+            new FakeHttpClientFactory(
+                CreateResponse("""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "{\"classification\":\"MALICIOUS_BOT\",\"summary\":\"Pattern matches scraper automation.\"}"
+                      }
+                    }
+                  ]
+                }
+                """)),
+            Options.Create(new DefenseEngineOptions
+            {
+                Escalation = new EscalationOptions
+                {
+                    OpenAiCompatibleModel = new OpenAiCompatibleModelAdapterOptions
+                    {
+                        Enabled = true,
+                        Endpoint = "https://llm.example.test/v1/chat/completions",
+                        Model = "test-model"
+                    }
+                }
+            }),
+            NullLogger<OpenAiCompatibleModelAdapter>.Instance);
+
+        var assessment = await adapter.AssessAsync(CreateContext("198.51.100.46"), CancellationToken.None);
+
+        Assert.NotNull(assessment);
+        Assert.Equal("MALICIOUS_BOT", assessment!.Classification);
+        Assert.True(assessment.IsBot);
+        Assert.Equal(40, assessment.ScoreAdjustment);
+        Assert.Contains("model_verdict:malicious_bot", assessment.Signals);
+    }
+
+    private static ThreatAssessmentContext CreateContext(string ipAddress)
+    {
+        return new ThreatAssessmentContext(
+            ipAddress,
+            "GET",
+            "/probe",
+            string.Empty,
+            "test-agent",
+            ["missing_accept_language"],
+            2,
+            15,
+            10);
+    }
+
+    private static HttpResponseMessage CreateResponse(string json)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    private sealed class FakeHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public FakeHttpClientFactory(HttpResponseMessage response)
+        {
+            _handler = new StaticResponseHandler(response);
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(_handler, disposeHandler: false);
+        }
+    }
+
+    private sealed class StaticResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public StaticResponseHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
@@ -16,6 +16,8 @@ public sealed class DefenseEngineOptions
 
     public AuditOptions Audit { get; set; } = new();
 
+    public EscalationOptions Escalation { get; set; } = new();
+
     public QueueOptions Queue { get; set; } = new();
 
     public TarpitOptions Tarpit { get; set; } = new();
@@ -127,6 +129,72 @@ public sealed class AuditOptions
     public string DatabasePath { get; set; } = "data/defense-events.db";
 
     public int MaxRecentEvents { get; set; } = 500;
+}
+
+public sealed class EscalationOptions
+{
+    public ConfiguredRangeReputationOptions ConfiguredRanges { get; set; } = new();
+
+    public HttpReputationProviderOptions HttpReputation { get; set; } = new();
+
+    public OpenAiCompatibleModelAdapterOptions OpenAiCompatibleModel { get; set; } = new();
+}
+
+public sealed class ConfiguredRangeReputationOptions
+{
+    public bool Enabled { get; set; }
+
+    public ReputationRangeEntry[] Entries { get; set; } = [];
+}
+
+public sealed class ReputationRangeEntry
+{
+    public string Name { get; set; } = string.Empty;
+
+    public string Cidr { get; set; } = string.Empty;
+
+    public int ScoreAdjustment { get; set; } = 0;
+
+    public string[] Signals { get; set; } = [];
+}
+
+public sealed class HttpReputationProviderOptions
+{
+    public bool Enabled { get; set; }
+
+    public string Endpoint { get; set; } = string.Empty;
+
+    public string ApiKeyHeaderName { get; set; } = "X-Api-Key";
+
+    public string ApiKey { get; set; } = string.Empty;
+
+    public int TimeoutSeconds { get; set; } = 10;
+
+    public int MaliciousScoreAdjustment { get; set; } = 35;
+}
+
+public sealed class OpenAiCompatibleModelAdapterOptions
+{
+    public bool Enabled { get; set; }
+
+    public string Endpoint { get; set; } = string.Empty;
+
+    public string ApiKey { get; set; } = string.Empty;
+
+    public string Model { get; set; } = string.Empty;
+
+    public string SystemPrompt { get; set; } =
+        "You are classifying incoming web requests for scraping-defense enforcement. " +
+        "Return JSON with classification and summary. Classification must be one of " +
+        "MALICIOUS_BOT, BENIGN_CRAWLER, HUMAN, or INCONCLUSIVE.";
+
+    public int TimeoutSeconds { get; set; } = 20;
+
+    public int MaliciousScoreAdjustment { get; set; } = 40;
+
+    public int BenignCrawlerScoreAdjustment { get; set; } = -5;
+
+    public int HumanScoreAdjustment { get; set; } = -15;
 }
 
 public sealed class TarpitOptions

--- a/RedisBlocklistMiddlewareApp/Models/DefenseModels.cs
+++ b/RedisBlocklistMiddlewareApp/Models/DefenseModels.cs
@@ -20,7 +20,21 @@ public sealed record DefenseDecision(
     IReadOnlyList<string> Signals,
     string Summary,
     DateTimeOffset ObservedAtUtc,
-    DateTimeOffset DecidedAtUtc);
+    DateTimeOffset DecidedAtUtc,
+    DefenseScoreBreakdown? Breakdown = null);
+
+public sealed record DefenseScoreBreakdown(
+    int BaseSignalScore,
+    int FrequencyScore,
+    int TotalScore,
+    bool ExplicitMaliciousVerdict,
+    IReadOnlyList<DefenseScoreContribution> Contributions);
+
+public sealed record DefenseScoreContribution(
+    string Source,
+    int ScoreDelta,
+    IReadOnlyList<string> Signals,
+    string Summary);
 
 public sealed record DefenseEventMetrics(
     long TotalDecisions,

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -11,6 +11,7 @@ using System.Net;
 var builder = WebApplication.CreateBuilder(args);
 var redisConnectionString = builder.Configuration.GetConnectionString("RedisConnection");
 
+builder.Services.AddHttpClient();
 builder.Services.AddSingleton<IValidateOptions<DefenseEngineOptions>, DefenseEngineOptionsValidator>();
 builder.Services.AddSingleton<ProductionConfigurationValidator>();
 builder.Services
@@ -60,6 +61,38 @@ builder.Services
 
         options.Audit.MaxRecentEvents = Math.Max(1, options.Audit.MaxRecentEvents);
 
+        options.Escalation.ConfiguredRanges.Entries = options.Escalation.ConfiguredRanges.Entries
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Cidr))
+            .Select(entry => new ReputationRangeEntry
+            {
+                Name = string.IsNullOrWhiteSpace(entry.Name) ? entry.Cidr.Trim() : entry.Name.Trim(),
+                Cidr = entry.Cidr.Trim(),
+                ScoreAdjustment = entry.ScoreAdjustment,
+                Signals = entry.Signals
+                    .Where(signal => !string.IsNullOrWhiteSpace(signal))
+                    .Select(signal => signal.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray()
+            })
+            .ToArray();
+
+        options.Escalation.HttpReputation.Endpoint = options.Escalation.HttpReputation.Endpoint.Trim();
+        options.Escalation.HttpReputation.ApiKeyHeaderName =
+            string.IsNullOrWhiteSpace(options.Escalation.HttpReputation.ApiKeyHeaderName)
+                ? "X-Api-Key"
+                : options.Escalation.HttpReputation.ApiKeyHeaderName.Trim();
+        options.Escalation.HttpReputation.ApiKey = options.Escalation.HttpReputation.ApiKey.Trim();
+        options.Escalation.HttpReputation.TimeoutSeconds = Math.Max(1, options.Escalation.HttpReputation.TimeoutSeconds);
+
+        options.Escalation.OpenAiCompatibleModel.Endpoint = options.Escalation.OpenAiCompatibleModel.Endpoint.Trim();
+        options.Escalation.OpenAiCompatibleModel.ApiKey = options.Escalation.OpenAiCompatibleModel.ApiKey.Trim();
+        options.Escalation.OpenAiCompatibleModel.Model = options.Escalation.OpenAiCompatibleModel.Model.Trim();
+        options.Escalation.OpenAiCompatibleModel.SystemPrompt =
+            string.IsNullOrWhiteSpace(options.Escalation.OpenAiCompatibleModel.SystemPrompt)
+                ? "You are classifying incoming web requests for scraping-defense enforcement. Return JSON with classification and summary."
+                : options.Escalation.OpenAiCompatibleModel.SystemPrompt.Trim();
+        options.Escalation.OpenAiCompatibleModel.TimeoutSeconds = Math.Max(1, options.Escalation.OpenAiCompatibleModel.TimeoutSeconds);
+
         if (!options.Redis.BlocklistKeyPrefix.EndsWith(':'))
         {
             options.Redis.BlocklistKeyPrefix += ":";
@@ -81,6 +114,10 @@ builder.Services.AddSingleton<ISuspiciousRequestQueue, SuspiciousRequestQueue>()
 builder.Services.AddSingleton<IRequestSignalEvaluator, RequestSignalEvaluator>();
 builder.Services.AddSingleton<ITarpitPageService, TarpitPageService>();
 builder.Services.AddSingleton<IClientIpResolver, ClientIpResolver>();
+builder.Services.AddSingleton<IThreatReputationProvider, ConfiguredRangeReputationProvider>();
+builder.Services.AddSingleton<IThreatReputationProvider, HttpReputationProvider>();
+builder.Services.AddSingleton<IThreatModelAdapter, OpenAiCompatibleModelAdapter>();
+builder.Services.AddSingleton<IThreatAssessmentService, ThreatAssessmentService>();
 builder.Services.AddSingleton<ApiKeyEndpointFilter>();
 builder.Services.AddSingleton<IntakeApiKeyEndpointFilter>();
 builder.Services.AddSingleton<IWebhookEventInbox, SqliteWebhookEventInbox>();
@@ -103,7 +140,7 @@ app.UseMiddleware<RedisBlocklistMiddleware>();
 app.MapGet("/", () => Results.Ok(new
 {
     service = "ai-scraping-defense-dotnet",
-    mode = "foundation",
+    mode = "commercial_v1",
     endpoints = advertisedEndpoints
 }));
 

--- a/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
+++ b/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
@@ -80,6 +80,33 @@ The appsettings.json file provides configuration values used by the ASP.NET Core
 * **DatabasePath**: Path to the SQLite database file used for durable defense-event storage. Relative paths are resolved from the application content root.
 * **MaxRecentEvents**: Maximum number of persisted events returned from the recent-events feed.
 
+#### **DefenseEngine:Escalation**
+
+* **ConfiguredRanges**: Optional CIDR-based reputation entries that contribute named score adjustments during queued analysis.
+  * **Enabled**: Turns configured-range reputation matching on or off.
+  * **Entries**: Array of CIDR entries.
+    * **Name**: Friendly label recorded in the score breakdown.
+    * **Cidr**: IPv4 or IPv6 CIDR to match.
+    * **ScoreAdjustment**: Positive or negative score contribution applied when the CIDR matches.
+    * **Signals**: Optional custom signals recorded on matching decisions.
+* **HttpReputation**: Optional HTTP-based reputation lookup used during queued analysis.
+  * **Enabled**: Turns the provider on or off.
+  * **Endpoint**: URL that accepts a POST body containing `ip`, `path`, `signals`, and `frequency`.
+  * **ApiKeyHeaderName**: Optional header name for the shared secret sent to the provider.
+  * **ApiKey**: Optional shared secret sent to the provider.
+  * **TimeoutSeconds**: Request timeout for the provider call.
+  * **MaliciousScoreAdjustment**: Fallback score adjustment when the provider returns `is_malicious=true` without an explicit `score_adjustment`.
+* **OpenAiCompatibleModel**: Optional classifier hook for local or remote chat-completions endpoints that follow the OpenAI-compatible shape.
+  * **Enabled**: Turns the classifier on or off.
+  * **Endpoint**: Full chat-completions URL.
+  * **ApiKey**: Optional bearer token sent as `Authorization: Bearer`.
+  * **Model**: Model identifier submitted to the endpoint.
+  * **SystemPrompt**: Prompt used to request a strict JSON classification response.
+  * **TimeoutSeconds**: Request timeout for the classifier call.
+  * **MaliciousScoreAdjustment**: Score delta applied when the model classifies `MALICIOUS_BOT`.
+  * **BenignCrawlerScoreAdjustment**: Score delta applied when the model classifies `BENIGN_CRAWLER`.
+  * **HumanScoreAdjustment**: Score delta applied when the model classifies `HUMAN`.
+
 #### **DefenseEngine:Queue**
 
 * **Capacity**: Maximum number of suspicious requests buffered for background analysis. When the queue is full, writers wait for capacity instead of dropping older suspicious requests.

--- a/RedisBlocklistMiddlewareApp/RedisBlocklistMiddleware.cs
+++ b/RedisBlocklistMiddlewareApp/RedisBlocklistMiddleware.cs
@@ -79,7 +79,19 @@ public sealed class RedisBlocklistMiddleware
                 evaluation.Signals,
                 "Blocked immediately by edge heuristics.",
                 DateTimeOffset.UtcNow,
-                DateTimeOffset.UtcNow));
+                DateTimeOffset.UtcNow,
+                new DefenseScoreBreakdown(
+                    100,
+                    0,
+                    100,
+                    true,
+                    [
+                        new DefenseScoreContribution(
+                            "edge_heuristics",
+                            100,
+                            evaluation.Signals,
+                            "Edge heuristics produced an immediate block verdict.")
+                    ])));
 
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             await context.Response.WriteAsync("Access denied.");

--- a/RedisBlocklistMiddlewareApp/Services/CidrMatcher.cs
+++ b/RedisBlocklistMiddlewareApp/Services/CidrMatcher.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+internal static class CidrMatcher
+{
+    public static bool Contains(string cidr, string ipAddress)
+    {
+        if (!TryParseCidr(cidr, out var networkAddress, out var prefixLength))
+        {
+            return false;
+        }
+
+        if (!IPAddress.TryParse(ipAddress, out var candidate))
+        {
+            return false;
+        }
+
+        if (candidate.AddressFamily != networkAddress.AddressFamily)
+        {
+            return false;
+        }
+
+        var networkBytes = networkAddress.GetAddressBytes();
+        var candidateBytes = candidate.GetAddressBytes();
+        var fullBytes = prefixLength / 8;
+        var remainingBits = prefixLength % 8;
+
+        for (var index = 0; index < fullBytes; index++)
+        {
+            if (networkBytes[index] != candidateBytes[index])
+            {
+                return false;
+            }
+        }
+
+        if (remainingBits == 0)
+        {
+            return true;
+        }
+
+        var mask = (byte)(0xFF << (8 - remainingBits));
+        return (networkBytes[fullBytes] & mask) == (candidateBytes[fullBytes] & mask);
+    }
+
+    private static bool TryParseCidr(
+        string cidr,
+        out IPAddress networkAddress,
+        out int prefixLength)
+    {
+        networkAddress = IPAddress.None;
+        prefixLength = 0;
+
+        var parts = cidr.Split('/', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 2 || !int.TryParse(parts[1], out prefixLength))
+        {
+            return false;
+        }
+
+        if (!IPAddress.TryParse(parts[0], out var parsedAddress))
+        {
+            return false;
+        }
+
+        networkAddress = parsedAddress;
+
+        var maxPrefixLength = networkAddress.AddressFamily switch
+        {
+            AddressFamily.InterNetwork => 32,
+            AddressFamily.InterNetworkV6 => 128,
+            _ => 0
+        };
+
+        return prefixLength >= 0 && prefixLength <= maxPrefixLength;
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/ConfiguredRangeReputationProvider.cs
+++ b/RedisBlocklistMiddlewareApp/Services/ConfiguredRangeReputationProvider.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class ConfiguredRangeReputationProvider : IThreatReputationProvider
+{
+    private readonly ConfiguredRangeReputationOptions _options;
+
+    public ConfiguredRangeReputationProvider(IOptions<DefenseEngineOptions> options)
+    {
+        _options = options.Value.Escalation.ConfiguredRanges;
+    }
+
+    public string Name => "configured_ranges";
+
+    public Task<ReputationAssessment?> AssessAsync(
+        ThreatAssessmentContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || _options.Entries.Length == 0)
+        {
+            return Task.FromResult<ReputationAssessment?>(null);
+        }
+
+        var matchingEntries = _options.Entries
+            .Where(entry =>
+                !string.IsNullOrWhiteSpace(entry.Cidr) &&
+                CidrMatcher.Contains(entry.Cidr, context.IpAddress))
+            .ToArray();
+
+        if (matchingEntries.Length == 0)
+        {
+            return Task.FromResult<ReputationAssessment?>(null);
+        }
+
+        var signals = matchingEntries
+            .SelectMany(entry =>
+            {
+                if (entry.Signals.Length > 0)
+                {
+                    return entry.Signals;
+                }
+
+                var signalName = string.IsNullOrWhiteSpace(entry.Name)
+                    ? entry.Cidr
+                    : entry.Name.Trim().Replace(" ", "_", StringComparison.Ordinal);
+                return new[] { $"reputation_range:{signalName}" };
+            })
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var scoreAdjustment = matchingEntries.Sum(entry => entry.ScoreAdjustment);
+        var summary = "Matched configured reputation range(s): " +
+            string.Join(", ", matchingEntries.Select(entry => string.IsNullOrWhiteSpace(entry.Name) ? entry.Cidr : entry.Name.Trim()));
+
+        return Task.FromResult<ReputationAssessment?>(new ReputationAssessment(
+            Name,
+            scoreAdjustment,
+            scoreAdjustment > 0,
+            signals,
+            summary));
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/DefenseAnalysisService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/DefenseAnalysisService.cs
@@ -9,25 +9,22 @@ namespace RedisBlocklistMiddlewareApp.Services;
 public sealed class DefenseAnalysisService : BackgroundService
 {
     private readonly ISuspiciousRequestQueue _queue;
-    private readonly IRequestFrequencyTracker _frequencyTracker;
+    private readonly IThreatAssessmentService _threatAssessmentService;
     private readonly IBlocklistService _blocklistService;
     private readonly IDefenseEventStore _eventStore;
-    private readonly HeuristicOptions _options;
     private readonly ILogger<DefenseAnalysisService> _logger;
 
     public DefenseAnalysisService(
         ISuspiciousRequestQueue queue,
-        IRequestFrequencyTracker frequencyTracker,
+        IThreatAssessmentService threatAssessmentService,
         IBlocklistService blocklistService,
         IDefenseEventStore eventStore,
-        IOptions<DefenseEngineOptions> options,
         ILogger<DefenseAnalysisService> logger)
     {
         _queue = queue;
-        _frequencyTracker = frequencyTracker;
+        _threatAssessmentService = threatAssessmentService;
         _blocklistService = blocklistService;
         _eventStore = eventStore;
-        _options = options.Value.Heuristics;
         _logger = logger;
     }
 
@@ -37,51 +34,43 @@ public sealed class DefenseAnalysisService : BackgroundService
         {
             try
             {
-                var frequency = await _frequencyTracker.IncrementAsync(
-                    request.IpAddress,
-                    stoppingToken);
-                var score = ScoreSignals(request.Signals, frequency);
-                var shouldBlock =
-                    score >= _options.BlockScoreThreshold ||
-                    frequency >= _options.FrequencyBlockThreshold;
-                var action = shouldBlock ? "blocked" : "observed";
-                var summary = shouldBlock
-                    ? "Queued analysis crossed the automated block threshold."
-                    : "Queued analysis recorded the request for continued observation.";
+                var assessment = await _threatAssessmentService.AssessAsync(request, stoppingToken);
+                var action = assessment.ShouldBlock ? "blocked" : "observed";
 
-                if (shouldBlock)
+                if (assessment.ShouldBlock)
                 {
                     await _blocklistService.BlockAsync(
                         request.IpAddress,
-                        "queued_analysis_threshold",
-                        request.Signals,
+                        assessment.BlockReason,
+                        assessment.Signals,
                         stoppingToken);
 
                     _logger.LogWarning(
                         "Blocked IP {IpAddress} after queued analysis with score {Score} and frequency {Frequency}.",
                         request.IpAddress,
-                        score,
-                        frequency);
+                        assessment.Score,
+                        assessment.Frequency);
                 }
                 else
                 {
                     _logger.LogInformation(
                         "Observed suspicious request from {IpAddress} with score {Score} and frequency {Frequency}.",
                         request.IpAddress,
-                        score,
-                        frequency);
+                        assessment.Score,
+                        assessment.Frequency);
                 }
 
                 _eventStore.Add(new DefenseDecision(
                     request.IpAddress,
                     action,
-                    score,
-                    frequency,
+                    assessment.Score,
+                    assessment.Frequency,
                     request.Path,
-                    request.Signals,
-                    summary,
+                    assessment.Signals,
+                    assessment.Summary,
                     request.ObservedAtUtc,
-                    DateTimeOffset.UtcNow));
+                    DateTimeOffset.UtcNow,
+                    assessment.Breakdown));
             }
             catch (Exception ex)
             {
@@ -91,41 +80,5 @@ public sealed class DefenseAnalysisService : BackgroundService
                     request.IpAddress);
             }
         }
-    }
-
-    private static int ScoreSignals(IReadOnlyList<string> signals, long frequency)
-    {
-        var score = 0;
-
-        foreach (var signal in signals)
-        {
-            if (signal.StartsWith("known_bad_user_agent:", StringComparison.Ordinal))
-            {
-                score += 100;
-            }
-            else if (signal.StartsWith("suspicious_path:", StringComparison.Ordinal))
-            {
-                score += 30;
-            }
-            else if (string.Equals(signal, "empty_user_agent", StringComparison.Ordinal))
-            {
-                score += 25;
-            }
-            else if (string.Equals(signal, "missing_accept_language", StringComparison.Ordinal))
-            {
-                score += 15;
-            }
-            else if (string.Equals(signal, "generic_accept_any", StringComparison.Ordinal))
-            {
-                score += 15;
-            }
-            else if (string.Equals(signal, "long_query_string", StringComparison.Ordinal))
-            {
-                score += 10;
-            }
-        }
-
-        score += (int)Math.Min(25, frequency * 5);
-        return score;
     }
 }

--- a/RedisBlocklistMiddlewareApp/Services/HttpReputationProvider.cs
+++ b/RedisBlocklistMiddlewareApp/Services/HttpReputationProvider.cs
@@ -1,0 +1,122 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class HttpReputationProvider : IThreatReputationProvider
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly HttpReputationProviderOptions _options;
+    private readonly ILogger<HttpReputationProvider> _logger;
+
+    public HttpReputationProvider(
+        IHttpClientFactory httpClientFactory,
+        IOptions<DefenseEngineOptions> options,
+        ILogger<HttpReputationProvider> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _options = options.Value.Escalation.HttpReputation;
+        _logger = logger;
+    }
+
+    public string Name => "http_reputation";
+
+    public async Task<ReputationAssessment?> AssessAsync(
+        ThreatAssessmentContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || string.IsNullOrWhiteSpace(_options.Endpoint))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, _options.Endpoint)
+            {
+                Content = JsonContent.Create(new
+                {
+                    ip = context.IpAddress,
+                    path = context.Path,
+                    signals = context.Signals,
+                    frequency = context.Frequency
+                })
+            };
+
+            if (!string.IsNullOrWhiteSpace(_options.ApiKey))
+            {
+                request.Headers.TryAddWithoutValidation(
+                    _options.ApiKeyHeaderName,
+                    _options.ApiKey);
+            }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, _options.TimeoutSeconds)));
+
+            var client = _httpClientFactory.CreateClient(Name);
+            using var response = await client.SendAsync(request, timeoutCts.Token);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "HTTP reputation provider returned status code {StatusCode}.",
+                    (int)response.StatusCode);
+                return null;
+            }
+
+            await using var responseStream = await response.Content.ReadAsStreamAsync(timeoutCts.Token);
+            using var document = await JsonDocument.ParseAsync(responseStream, cancellationToken: timeoutCts.Token);
+            var root = document.RootElement;
+
+            var isMalicious = root.TryGetProperty("is_malicious", out var maliciousElement) &&
+                maliciousElement.ValueKind is JsonValueKind.True or JsonValueKind.False &&
+                maliciousElement.GetBoolean();
+            var scoreAdjustment = root.TryGetProperty("score_adjustment", out var scoreElement) &&
+                scoreElement.TryGetInt32(out var explicitScore)
+                ? explicitScore
+                : (isMalicious ? _options.MaliciousScoreAdjustment : 0);
+            var summary = root.TryGetProperty("summary", out var summaryElement) &&
+                summaryElement.ValueKind == JsonValueKind.String
+                ? summaryElement.GetString() ?? string.Empty
+                : string.Empty;
+            var signals = root.TryGetProperty("signals", out var signalsElement) &&
+                signalsElement.ValueKind == JsonValueKind.Array
+                ? signalsElement.EnumerateArray()
+                    .Where(element => element.ValueKind == JsonValueKind.String)
+                    .Select(element => element.GetString()!)
+                    .Where(signal => !string.IsNullOrWhiteSpace(signal))
+                    .ToArray()
+                : [];
+
+            if (string.IsNullOrWhiteSpace(summary))
+            {
+                summary = isMalicious
+                    ? "HTTP reputation provider flagged the IP as malicious."
+                    : "HTTP reputation provider returned a neutral reputation verdict.";
+            }
+
+            if (signals.Length == 0 && isMalicious)
+            {
+                signals = ["reputation:http_malicious_ip"];
+            }
+
+            return new ReputationAssessment(
+                Name,
+                scoreAdjustment,
+                isMalicious,
+                signals,
+                summary);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning("HTTP reputation provider timed out.");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "HTTP reputation provider failed.");
+            return null;
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/IThreatAssessmentService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IThreatAssessmentService.cs
@@ -1,0 +1,43 @@
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface IThreatAssessmentService
+{
+    Task<ThreatAssessmentResult> AssessAsync(SuspiciousRequest request, CancellationToken cancellationToken);
+}
+
+public sealed record ThreatAssessmentContext(
+    string IpAddress,
+    string Method,
+    string Path,
+    string QueryString,
+    string UserAgent,
+    IReadOnlyList<string> Signals,
+    long Frequency,
+    int BaseSignalScore,
+    int FrequencyScore);
+
+public sealed record ReputationAssessment(
+    string Source,
+    int ScoreAdjustment,
+    bool IsMalicious,
+    IReadOnlyList<string> Signals,
+    string Summary);
+
+public sealed record ModelAssessment(
+    string Source,
+    int ScoreAdjustment,
+    bool? IsBot,
+    string Classification,
+    IReadOnlyList<string> Signals,
+    string Summary);
+
+public sealed record ThreatAssessmentResult(
+    bool ShouldBlock,
+    string BlockReason,
+    string Summary,
+    int Score,
+    long Frequency,
+    IReadOnlyList<string> Signals,
+    DefenseScoreBreakdown Breakdown);

--- a/RedisBlocklistMiddlewareApp/Services/IThreatModelAdapter.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IThreatModelAdapter.cs
@@ -1,0 +1,10 @@
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface IThreatModelAdapter
+{
+    string Name { get; }
+
+    Task<ModelAssessment?> AssessAsync(
+        ThreatAssessmentContext context,
+        CancellationToken cancellationToken);
+}

--- a/RedisBlocklistMiddlewareApp/Services/IThreatReputationProvider.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IThreatReputationProvider.cs
@@ -1,0 +1,10 @@
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface IThreatReputationProvider
+{
+    string Name { get; }
+
+    Task<ReputationAssessment?> AssessAsync(
+        ThreatAssessmentContext context,
+        CancellationToken cancellationToken);
+}

--- a/RedisBlocklistMiddlewareApp/Services/OpenAiCompatibleModelAdapter.cs
+++ b/RedisBlocklistMiddlewareApp/Services/OpenAiCompatibleModelAdapter.cs
@@ -1,0 +1,238 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class OpenAiCompatibleModelAdapter : IThreatModelAdapter
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly OpenAiCompatibleModelAdapterOptions _options;
+    private readonly ILogger<OpenAiCompatibleModelAdapter> _logger;
+
+    public OpenAiCompatibleModelAdapter(
+        IHttpClientFactory httpClientFactory,
+        IOptions<DefenseEngineOptions> options,
+        ILogger<OpenAiCompatibleModelAdapter> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _options = options.Value.Escalation.OpenAiCompatibleModel;
+        _logger = logger;
+    }
+
+    public string Name => "openai_compatible_model";
+
+    public async Task<ModelAssessment?> AssessAsync(
+        ThreatAssessmentContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled ||
+            string.IsNullOrWhiteSpace(_options.Endpoint) ||
+            string.IsNullOrWhiteSpace(_options.Model))
+        {
+            return null;
+        }
+
+        try
+        {
+            var serializedContext = JsonSerializer.Serialize(new
+            {
+                ip = context.IpAddress,
+                method = context.Method,
+                path = context.Path,
+                query_string = context.QueryString,
+                user_agent = context.UserAgent,
+                signals = context.Signals,
+                frequency = context.Frequency,
+                base_signal_score = context.BaseSignalScore,
+                frequency_score = context.FrequencyScore
+            });
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, _options.Endpoint)
+            {
+                Content = JsonContent.Create(new
+                {
+                    model = _options.Model,
+                    temperature = 0.1,
+                    response_format = new { type = "json_object" },
+                    messages = new object[]
+                    {
+                        new
+                        {
+                            role = "system",
+                            content = _options.SystemPrompt
+                        },
+                        new
+                        {
+                            role = "user",
+                            content =
+                                "Classify this request and return JSON with classification and summary only: " +
+                                serializedContext
+                        }
+                    }
+                })
+            };
+
+            if (!string.IsNullOrWhiteSpace(_options.ApiKey))
+            {
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(
+                    "Bearer",
+                    _options.ApiKey);
+            }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, _options.TimeoutSeconds)));
+
+            var client = _httpClientFactory.CreateClient(Name);
+            using var response = await client.SendAsync(request, timeoutCts.Token);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "OpenAI-compatible model adapter returned status code {StatusCode}.",
+                    (int)response.StatusCode);
+                return null;
+            }
+
+            await using var responseStream = await response.Content.ReadAsStreamAsync(timeoutCts.Token);
+            using var envelope = await JsonDocument.ParseAsync(responseStream, cancellationToken: timeoutCts.Token);
+
+            if (!TryGetMessageContent(envelope.RootElement, out var content))
+            {
+                _logger.LogWarning("OpenAI-compatible model adapter returned an unexpected response shape.");
+                return null;
+            }
+
+            var classification = ExtractClassification(content);
+            var summary = ExtractSummary(content) ??
+                "OpenAI-compatible model adapter returned a classification verdict.";
+
+            return classification switch
+            {
+                "MALICIOUS_BOT" => new ModelAssessment(
+                    Name,
+                    _options.MaliciousScoreAdjustment,
+                    true,
+                    classification,
+                    ["model_verdict:malicious_bot"],
+                    summary),
+                "BENIGN_CRAWLER" => new ModelAssessment(
+                    Name,
+                    _options.BenignCrawlerScoreAdjustment,
+                    false,
+                    classification,
+                    ["model_verdict:benign_crawler"],
+                    summary),
+                "HUMAN" => new ModelAssessment(
+                    Name,
+                    _options.HumanScoreAdjustment,
+                    false,
+                    classification,
+                    ["model_verdict:human"],
+                    summary),
+                _ => new ModelAssessment(
+                    Name,
+                    0,
+                    null,
+                    "INCONCLUSIVE",
+                    [],
+                    summary)
+            };
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning("OpenAI-compatible model adapter timed out.");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "OpenAI-compatible model adapter failed.");
+            return null;
+        }
+    }
+
+    private static bool TryGetMessageContent(JsonElement root, out string content)
+    {
+        content = string.Empty;
+
+        if (!root.TryGetProperty("choices", out var choicesElement) ||
+            choicesElement.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        var firstChoice = choicesElement.EnumerateArray().FirstOrDefault();
+        if (firstChoice.ValueKind == JsonValueKind.Undefined ||
+            !firstChoice.TryGetProperty("message", out var messageElement) ||
+            !messageElement.TryGetProperty("content", out var contentElement) ||
+            contentElement.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        content = contentElement.GetString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(content);
+    }
+
+    private static string ExtractClassification(string content)
+    {
+        if (TryParseJsonContent(content, out var root) &&
+            root.TryGetProperty("classification", out var classificationElement) &&
+            classificationElement.ValueKind == JsonValueKind.String)
+        {
+            return NormalizeClassification(classificationElement.GetString());
+        }
+
+        return NormalizeClassification(content);
+    }
+
+    private static string? ExtractSummary(string content)
+    {
+        if (TryParseJsonContent(content, out var root) &&
+            root.TryGetProperty("summary", out var summaryElement) &&
+            summaryElement.ValueKind == JsonValueKind.String)
+        {
+            return summaryElement.GetString();
+        }
+
+        return null;
+    }
+
+    private static bool TryParseJsonContent(string content, out JsonElement root)
+    {
+        root = default;
+
+        try
+        {
+            using var document = JsonDocument.Parse(content);
+            root = document.RootElement.Clone();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string NormalizeClassification(string? raw)
+    {
+        var normalized = raw?.Trim().ToUpperInvariant() ?? string.Empty;
+
+        if (normalized.Contains("MALICIOUS_BOT", StringComparison.Ordinal))
+        {
+            return "MALICIOUS_BOT";
+        }
+
+        if (normalized.Contains("BENIGN_CRAWLER", StringComparison.Ordinal))
+        {
+            return "BENIGN_CRAWLER";
+        }
+
+        if (normalized.Contains("HUMAN", StringComparison.Ordinal))
+        {
+            return "HUMAN";
+        }
+
+        return "INCONCLUSIVE";
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/SqliteDefenseEventStore.cs
+++ b/RedisBlocklistMiddlewareApp/Services/SqliteDefenseEventStore.cs
@@ -52,6 +52,7 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
                     frequency,
                     path,
                     signals_json,
+                    breakdown_json,
                     summary,
                     observed_at_utc,
                     decided_at_utc
@@ -64,6 +65,7 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
                     $frequency,
                     $path,
                     $signalsJson,
+                    $breakdownJson,
                     $summary,
                     $observedAtUtc,
                     $decidedAtUtc
@@ -76,6 +78,9 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
             command.Parameters.AddWithValue("$frequency", decision.Frequency);
             command.Parameters.AddWithValue("$path", decision.Path);
             command.Parameters.AddWithValue("$signalsJson", JsonSerializer.Serialize(decision.Signals));
+            command.Parameters.AddWithValue(
+                "$breakdownJson",
+                decision.Breakdown is null ? DBNull.Value : JsonSerializer.Serialize(decision.Breakdown));
             command.Parameters.AddWithValue("$summary", decision.Summary);
             command.Parameters.AddWithValue("$observedAtUtc", decision.ObservedAtUtc.UtcDateTime.ToString("O"));
             command.Parameters.AddWithValue("$decidedAtUtc", decision.DecidedAtUtc.UtcDateTime.ToString("O"));
@@ -120,6 +125,7 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
                     frequency,
                     path,
                     signals_json,
+                    breakdown_json,
                     summary,
                     observed_at_utc,
                     decided_at_utc
@@ -139,9 +145,12 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
                     reader.GetInt64(3),
                     reader.GetString(4),
                     JsonSerializer.Deserialize<string[]>(reader.GetString(5)) ?? [],
-                    reader.GetString(6),
-                    DateTimeOffset.Parse(reader.GetString(7)),
-                    DateTimeOffset.Parse(reader.GetString(8))));
+                    reader.GetString(7),
+                    DateTimeOffset.Parse(reader.GetString(8)),
+                    DateTimeOffset.Parse(reader.GetString(9)),
+                    reader.IsDBNull(6)
+                        ? null
+                        : JsonSerializer.Deserialize<DefenseScoreBreakdown>(reader.GetString(6))));
             }
         }
 
@@ -197,6 +206,7 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
                     frequency INTEGER NOT NULL,
                     path TEXT NOT NULL,
                     signals_json TEXT NOT NULL,
+                    breakdown_json TEXT NULL,
                     summary TEXT NOT NULL,
                     observed_at_utc TEXT NOT NULL,
                     decided_at_utc TEXT NOT NULL
@@ -215,6 +225,8 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
                 );
                 """;
             command.ExecuteNonQuery();
+
+            EnsureBreakdownColumn(connection);
 
             using var seedCommand = connection.CreateCommand();
             seedCommand.CommandText =
@@ -259,5 +271,37 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
         var connection = new SqliteConnection(_connectionString);
         connection.Open();
         return connection;
+    }
+
+    private static void EnsureBreakdownColumn(SqliteConnection connection)
+    {
+        using var tableInfo = connection.CreateCommand();
+        tableInfo.CommandText = "PRAGMA table_info(defense_events);";
+
+        var hasBreakdownColumn = false;
+        using (var reader = tableInfo.ExecuteReader())
+        {
+            while (reader.Read())
+            {
+                if (string.Equals(reader.GetString(1), "breakdown_json", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasBreakdownColumn = true;
+                    break;
+                }
+            }
+        }
+
+        if (hasBreakdownColumn)
+        {
+            return;
+        }
+
+        using var alterCommand = connection.CreateCommand();
+        alterCommand.CommandText =
+            """
+            ALTER TABLE defense_events
+            ADD COLUMN breakdown_json TEXT NULL;
+            """;
+        alterCommand.ExecuteNonQuery();
     }
 }

--- a/RedisBlocklistMiddlewareApp/Services/ThreatAssessmentService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/ThreatAssessmentService.cs
@@ -1,0 +1,213 @@
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class ThreatAssessmentService : IThreatAssessmentService
+{
+    private readonly IRequestFrequencyTracker _frequencyTracker;
+    private readonly IReadOnlyList<IThreatReputationProvider> _reputationProviders;
+    private readonly IReadOnlyList<IThreatModelAdapter> _modelAdapters;
+    private readonly HeuristicOptions _heuristics;
+    private readonly ILogger<ThreatAssessmentService> _logger;
+
+    public ThreatAssessmentService(
+        IRequestFrequencyTracker frequencyTracker,
+        IEnumerable<IThreatReputationProvider> reputationProviders,
+        IEnumerable<IThreatModelAdapter> modelAdapters,
+        IOptions<DefenseEngineOptions> options,
+        ILogger<ThreatAssessmentService> logger)
+    {
+        _frequencyTracker = frequencyTracker;
+        _reputationProviders = reputationProviders.ToArray();
+        _modelAdapters = modelAdapters.ToArray();
+        _heuristics = options.Value.Heuristics;
+        _logger = logger;
+    }
+
+    public async Task<ThreatAssessmentResult> AssessAsync(
+        SuspiciousRequest request,
+        CancellationToken cancellationToken)
+    {
+        var frequency = await _frequencyTracker.IncrementAsync(request.IpAddress, cancellationToken);
+        var baseSignalScore = ScoreSignals(request.Signals);
+        var frequencyScore = (int)Math.Min(25, frequency * 5);
+        var context = new ThreatAssessmentContext(
+            request.IpAddress,
+            request.Method,
+            request.Path,
+            request.QueryString,
+            request.UserAgent,
+            request.Signals,
+            frequency,
+            baseSignalScore,
+            frequencyScore);
+
+        var combinedSignals = new List<string>(request.Signals);
+        var contributions = new List<DefenseScoreContribution>();
+        if (baseSignalScore > 0)
+        {
+            contributions.Add(new DefenseScoreContribution(
+                "edge_signals",
+                baseSignalScore,
+                request.Signals,
+                "Base edge heuristics contributed to the escalation score."));
+        }
+
+        if (frequencyScore > 0)
+        {
+            contributions.Add(new DefenseScoreContribution(
+                "frequency",
+                frequencyScore,
+                ["frequency_window"],
+                "Short-window suspicious request frequency increased the escalation score."));
+        }
+
+        var explicitMaliciousVerdict = false;
+        var totalScore = baseSignalScore + frequencyScore;
+
+        foreach (var provider in _reputationProviders)
+        {
+            var assessment = await provider.AssessAsync(context, cancellationToken);
+            if (assessment is null)
+            {
+                continue;
+            }
+
+            totalScore += assessment.ScoreAdjustment;
+            explicitMaliciousVerdict |= assessment.IsMalicious;
+            AppendContribution(contributions, combinedSignals, assessment.Source, assessment.ScoreAdjustment, assessment.Signals, assessment.Summary);
+        }
+
+        foreach (var adapter in _modelAdapters)
+        {
+            var assessment = await adapter.AssessAsync(context, cancellationToken);
+            if (assessment is null)
+            {
+                continue;
+            }
+
+            totalScore += assessment.ScoreAdjustment;
+            explicitMaliciousVerdict |= assessment.IsBot == true;
+            AppendContribution(contributions, combinedSignals, assessment.Source, assessment.ScoreAdjustment, assessment.Signals, assessment.Summary);
+        }
+
+        totalScore = Math.Max(0, totalScore);
+        var shouldBlock =
+            explicitMaliciousVerdict ||
+            totalScore >= _heuristics.BlockScoreThreshold ||
+            frequency >= _heuristics.FrequencyBlockThreshold;
+        var blockReason = explicitMaliciousVerdict
+            ? "threat_intelligence_verdict"
+            : frequency >= _heuristics.FrequencyBlockThreshold
+                ? "frequency_threshold"
+                : "queued_analysis_threshold";
+        var summary = BuildSummary(shouldBlock, totalScore, frequency, explicitMaliciousVerdict, contributions);
+
+        _logger.LogInformation(
+            "Threat assessment completed for {IpAddress} with score {Score}, frequency {Frequency}, explicit malicious verdict {ExplicitVerdict}, block {ShouldBlock}.",
+            request.IpAddress,
+            totalScore,
+            frequency,
+            explicitMaliciousVerdict,
+            shouldBlock);
+
+        return new ThreatAssessmentResult(
+            shouldBlock,
+            blockReason,
+            summary,
+            totalScore,
+            frequency,
+            combinedSignals.Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
+            new DefenseScoreBreakdown(
+                baseSignalScore,
+                frequencyScore,
+                totalScore,
+                explicitMaliciousVerdict,
+                contributions));
+    }
+
+    private static int ScoreSignals(IReadOnlyList<string> signals)
+    {
+        var score = 0;
+
+        foreach (var signal in signals)
+        {
+            if (signal.StartsWith("known_bad_user_agent:", StringComparison.Ordinal))
+            {
+                score += 100;
+            }
+            else if (signal.StartsWith("suspicious_path:", StringComparison.Ordinal))
+            {
+                score += 30;
+            }
+            else if (string.Equals(signal, "empty_user_agent", StringComparison.Ordinal))
+            {
+                score += 25;
+            }
+            else if (string.Equals(signal, "missing_accept_language", StringComparison.Ordinal))
+            {
+                score += 15;
+            }
+            else if (string.Equals(signal, "generic_accept_any", StringComparison.Ordinal))
+            {
+                score += 15;
+            }
+            else if (string.Equals(signal, "long_query_string", StringComparison.Ordinal))
+            {
+                score += 10;
+            }
+        }
+
+        return score;
+    }
+
+    private static void AppendContribution(
+        ICollection<DefenseScoreContribution> contributions,
+        ICollection<string> combinedSignals,
+        string source,
+        int scoreDelta,
+        IReadOnlyList<string> signals,
+        string summary)
+    {
+        if (scoreDelta == 0 && signals.Count == 0 && string.IsNullOrWhiteSpace(summary))
+        {
+            return;
+        }
+
+        contributions.Add(new DefenseScoreContribution(
+            source,
+            scoreDelta,
+            signals,
+            summary));
+
+        foreach (var signal in signals)
+        {
+            combinedSignals.Add(signal);
+        }
+    }
+
+    private static string BuildSummary(
+        bool shouldBlock,
+        int totalScore,
+        long frequency,
+        bool explicitMaliciousVerdict,
+        IReadOnlyList<DefenseScoreContribution> contributions)
+    {
+        var dominantSources = contributions
+            .OrderByDescending(contribution => Math.Abs(contribution.ScoreDelta))
+            .Take(3)
+            .Select(contribution => contribution.Source)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var action = shouldBlock ? "blocked" : "observed";
+        var verdictText = explicitMaliciousVerdict ? " explicit malicious verdict;" : string.Empty;
+        var sourceText = dominantSources.Length == 0
+            ? " no named contributors."
+            : " top contributors: " + string.Join(", ", dominantSources) + ".";
+
+        return $"Queued analysis {action} the request with total score {totalScore}, frequency {frequency},{verdictText}{sourceText}";
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs
@@ -52,7 +52,19 @@ public sealed class WebhookIntakeProcessingService : BackgroundService
                     signals,
                     $"Blocked from webhook intake: {reason}",
                     item.Event.TimestampUtc,
-                    DateTimeOffset.UtcNow));
+                    DateTimeOffset.UtcNow,
+                    new DefenseScoreBreakdown(
+                        100,
+                        0,
+                        100,
+                        true,
+                        [
+                            new DefenseScoreContribution(
+                                "webhook_intake",
+                                100,
+                                signals,
+                                $"Webhook intake supplied a blocking verdict: {reason}")
+                        ])));
 
                 await _inbox.CompleteAsync(item.Id, stoppingToken);
             }

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -76,6 +76,31 @@
       "DatabasePath": "data/defense-events.db",
       "MaxRecentEvents": 500
     },
+    "Escalation": {
+      "ConfiguredRanges": {
+        "Enabled": false,
+        "Entries": []
+      },
+      "HttpReputation": {
+        "Enabled": false,
+        "Endpoint": "",
+        "ApiKeyHeaderName": "X-Api-Key",
+        "ApiKey": "",
+        "TimeoutSeconds": 10,
+        "MaliciousScoreAdjustment": 35
+      },
+      "OpenAiCompatibleModel": {
+        "Enabled": false,
+        "Endpoint": "",
+        "ApiKey": "",
+        "Model": "",
+        "SystemPrompt": "You are classifying incoming web requests for scraping-defense enforcement. Return JSON with classification and summary. Classification must be one of MALICIOUS_BOT, BENIGN_CRAWLER, HUMAN, or INCONCLUSIVE.",
+        "TimeoutSeconds": 20,
+        "MaliciousScoreAdjustment": 40,
+        "BenignCrawlerScoreAdjustment": -5,
+        "HumanScoreAdjustment": -15
+      }
+    },
     "Queue": {
       "Capacity": 1024
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,8 +26,9 @@ The background worker in [RedisBlocklistMiddlewareApp/Services/DefenseAnalysisSe
 - Consume suspicious requests asynchronously.
 - Update per-IP frequency counters in Redis.
 - Compute a score from the collected request signals.
+- Apply optional configured-range reputation, HTTP reputation, and OpenAI-compatible model contributions.
 - Promote high-risk or high-frequency IPs into the Redis blocklist.
-- Store recent decisions in the persistent audit/event store.
+- Store recent decisions and their score breakdown in the persistent audit/event store.
 
 ### Webhook Intake
 

--- a/docs/dotnet_parity_roadmap.md
+++ b/docs/dotnet_parity_roadmap.md
@@ -10,7 +10,7 @@ Commercial v1 is defined in [commercial_scope.md](commercial_scope.md). This roa
 | --- | --- | --- |
 | Nginx/Lua edge filter | Implemented as ASP.NET Core middleware | Split into a dedicated edge gateway project |
 | AI Service webhook | Implemented as authenticated `/analyze` plus durable SQLite-backed intake | Add richer alerting/reporting and separate service boundary |
-| Escalation Engine | Implemented at a baseline level in `DefenseAnalysisService` | Add richer heuristics, reputation providers, model scoring, optional LLM adapters |
+| Escalation Engine | Implemented with baseline scoring, reputation-provider hooks, and an optional OpenAI-compatible model adapter | Add more provider types, richer telemetry, and separate service boundary |
 | Tarpit API | Implemented as deterministic synthetic page endpoint | Add richer tarpit modes, streaming, and Markov/PostgreSQL-backed content |
 | Admin UI | Not implemented in .NET | Add operator dashboard on top of the authenticated admin API |
 | Community blocklist sync | Not implemented in .NET | Add background worker and contracts |


### PR DESCRIPTION
## Summary
- introduce a second-stage threat assessment service with score breakdown persistence
- add pluggable configured-range and HTTP reputation providers plus an optional OpenAI-compatible classifier hook
- document the new escalation configuration and cover the pipeline with provider/adapter tests

## Testing
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

Closes #30