### PR TITLE
Add PostgreSQL-backed tarpit content

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - An authenticated `/analyze` webhook endpoint with durable SQLite-backed intake for confirmed malicious events.
 - Optional community blocklist feed sync with authenticated status surfaced under `/defense/community-blocklist/status`.
 - Optional peer sync with explicit `ObserveOnly` and `BlockList` trust modes plus authenticated signal export at `/peer-sync/signals`.
+- Optional PostgreSQL-backed Markov tarpit content with deterministic render variants.
 
 ## Commercial v1 Scope
 
@@ -64,7 +65,7 @@ Peer export endpoint:
 
 - `Redis`: required for hot operational state such as blocklists and short-window frequency counters.
 - `SQLite`: supported for local development, demos, and single-node/lightweight production installs as the durable audit and webhook intake store.
-- `PostgreSQL`: planned as the primary production relational backend for richer tarpit content, sync features, and larger-scale persistence.
+- `PostgreSQL`: supported for the Markov-backed tarpit corpus and remains the primary production relational direction for richer content and larger-scale persistence.
 - `SQL Server`: deferred. It is not a commercial v1 target unless customer demand justifies the extra provider and test surface.
 
 ## Escalation Extensions
@@ -78,6 +79,10 @@ Queued suspicious-request analysis now persists a score breakdown with named con
 - an optional OpenAI-compatible classifier endpoint
 
 The default configuration keeps the external reputation/model hooks disabled. They are exposed under `DefenseEngine:Escalation` so production deployments can opt in without changing the rest of the request pipeline.
+
+## PostgreSQL Tarpit
+
+The tarpit can now switch from fixed synthetic paragraphs to a PostgreSQL-backed Markov corpus under `DefenseEngine:Tarpit:PostgresMarkov`. When enabled, the app reads `markov_words` and `markov_sequences` tables and uses the durable corpus to generate deterministic crawl-wasting paragraphs. The base schema is in [init_markov.sql](/home/rich/dev/ai-scraping-defense-iis/db/init_markov.sql).
 
 ## Configuration
 

--- a/RedisBlocklistMiddlewareApp.Tests/TarpitPageServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/TarpitPageServiceTests.cs
@@ -43,10 +43,73 @@ public sealed class TarpitPageServiceTests
         Assert.Contains("href=\"/custom-tarpit/nested/path/", page);
     }
 
-    private static TarpitPageService CreateService(Action<DefenseEngineOptions>? configure = null)
+    [Fact]
+    public void GeneratePage_UsesArchiveVariantWhenConfigured()
+    {
+        var service = CreateService(options =>
+        {
+            options.Tarpit.Modes = [TarpitRenderModes.ArchiveIndex];
+            options.Tarpit.LinkCount = 1;
+            options.Tarpit.ParagraphCount = 1;
+        });
+
+        var page = service.GeneratePage("archive/index", "198.51.100.50");
+
+        Assert.Contains("Archive manifests", page);
+        Assert.Contains(".zip", page);
+    }
+
+    [Fact]
+    public void GeneratePage_UsesPostgresMarkovSnapshotWhenAvailable()
+    {
+        var service = CreateService(
+            options =>
+            {
+                options.Tarpit.ParagraphCount = 1;
+                options.Tarpit.Modes = [TarpitRenderModes.Standard];
+                options.Tarpit.MarkovWordsPerParagraph = 5;
+            },
+            new TestMarkovStore(new TarpitMarkovSnapshot(
+                new Dictionary<string, string[]>
+                {
+                    ["\u001f"] = ["quartzflux"],
+                    ["\u001fquartzflux"] = ["hyperlattice"],
+                    ["quartzflux\u001fhyperlattice"] = ["stabilizes"],
+                    ["hyperlattice\u001fstabilizes"] = ["archivecore"],
+                    ["stabilizes\u001farchivecore"] = ["telemetrymesh"]
+                },
+                ["quartzflux", "hyperlattice", "stabilizes", "archivecore", "telemetrymesh"])));
+
+        var page = service.GeneratePage("archive/index", "198.51.100.50");
+
+        Assert.Contains("quartzflux", page, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("hyperlattice", page, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("telemetrymesh", page, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static TarpitPageService CreateService(
+        Action<DefenseEngineOptions>? configure = null,
+        ITarpitMarkovStore? markovStore = null)
     {
         var options = new DefenseEngineOptions();
         configure?.Invoke(options);
-        return new TarpitPageService(Options.Create(options));
+        return new TarpitPageService(
+            Options.Create(options),
+            markovStore ?? new TestMarkovStore(null));
+    }
+
+    private sealed class TestMarkovStore : ITarpitMarkovStore
+    {
+        private readonly TarpitMarkovSnapshot? _snapshot;
+
+        public TestMarkovStore(TarpitMarkovSnapshot? snapshot)
+        {
+            _snapshot = snapshot;
+        }
+
+        public TarpitMarkovSnapshot? GetSnapshot()
+        {
+            return _snapshot;
+        }
     }
 }

--- a/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
@@ -275,4 +275,37 @@ public sealed class TarpitOptions
     public int ParagraphCount { get; set; } = 5;
 
     public int ResponseDelayMilliseconds { get; set; } = 200;
+
+    public string[] Modes { get; set; } =
+    [
+        TarpitRenderModes.Standard,
+        TarpitRenderModes.ArchiveIndex,
+        TarpitRenderModes.ApiCatalog
+    ];
+
+    public int MarkovWordsPerParagraph { get; set; } = 36;
+
+    public PostgresMarkovOptions PostgresMarkov { get; set; } = new();
+}
+
+public sealed class PostgresMarkovOptions
+{
+    public bool Enabled { get; set; }
+
+    public string ConnectionString { get; set; } = string.Empty;
+
+    public string WordsTableName { get; set; } = "markov_words";
+
+    public string SequencesTableName { get; set; } = "markov_sequences";
+
+    public int RefreshMinutes { get; set; } = 30;
+}
+
+public static class TarpitRenderModes
+{
+    public const string Standard = "Standard";
+
+    public const string ArchiveIndex = "ArchiveIndex";
+
+    public const string ApiCatalog = "ApiCatalog";
 }

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -32,6 +32,29 @@ builder.Services
         }
 
         options.Tarpit.PathPrefix = options.Tarpit.PathPrefix.TrimEnd('/');
+        options.Tarpit.Modes = options.Tarpit.Modes
+            .Where(mode => !string.IsNullOrWhiteSpace(mode))
+            .Select(mode => mode.Trim())
+            .Where(mode =>
+                string.Equals(mode, TarpitRenderModes.Standard, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(mode, TarpitRenderModes.ArchiveIndex, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(mode, TarpitRenderModes.ApiCatalog, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (options.Tarpit.Modes.Length == 0)
+        {
+            options.Tarpit.Modes = [TarpitRenderModes.Standard];
+        }
+
+        options.Tarpit.MarkovWordsPerParagraph = Math.Max(8, options.Tarpit.MarkovWordsPerParagraph);
+        options.Tarpit.PostgresMarkov.ConnectionString = options.Tarpit.PostgresMarkov.ConnectionString.Trim();
+        options.Tarpit.PostgresMarkov.WordsTableName = string.IsNullOrWhiteSpace(options.Tarpit.PostgresMarkov.WordsTableName)
+            ? "markov_words"
+            : options.Tarpit.PostgresMarkov.WordsTableName.Trim();
+        options.Tarpit.PostgresMarkov.SequencesTableName = string.IsNullOrWhiteSpace(options.Tarpit.PostgresMarkov.SequencesTableName)
+            ? "markov_sequences"
+            : options.Tarpit.PostgresMarkov.SequencesTableName.Trim();
+        options.Tarpit.PostgresMarkov.RefreshMinutes = Math.Max(1, options.Tarpit.PostgresMarkov.RefreshMinutes);
 
         options.Management.ApiKeyHeaderName = string.IsNullOrWhiteSpace(options.Management.ApiKeyHeaderName)
             ? "X-API-Key"
@@ -152,6 +175,7 @@ builder.Services.AddSingleton<IRequestFrequencyTracker, RedisRequestFrequencyTra
 builder.Services.AddSingleton<IDefenseEventStore, SqliteDefenseEventStore>();
 builder.Services.AddSingleton<ISuspiciousRequestQueue, SuspiciousRequestQueue>();
 builder.Services.AddSingleton<IRequestSignalEvaluator, RequestSignalEvaluator>();
+builder.Services.AddSingleton<ITarpitMarkovStore, PostgresTarpitMarkovStore>();
 builder.Services.AddSingleton<ITarpitPageService, TarpitPageService>();
 builder.Services.AddSingleton<IClientIpResolver, ClientIpResolver>();
 builder.Services.AddSingleton<IThreatReputationProvider, ConfiguredRangeReputationProvider>();

--- a/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
+++ b/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
@@ -150,6 +150,14 @@ Imported community entries are validated before they are applied. Invalid, loopb
 * **LinkCount**: Number of recursive links rendered in each tarpit page.
 * **ParagraphCount**: Number of generated paragraphs rendered in each tarpit page.
 * **ResponseDelayMilliseconds**: Artificial delay applied before returning tarpit content.
+* **Modes**: Deterministic tarpit render variants. Supported values are `Standard`, `ArchiveIndex`, and `ApiCatalog`.
+* **MarkovWordsPerParagraph**: Approximate word budget for each PostgreSQL-backed Markov paragraph.
+* **PostgresMarkov**: PostgreSQL-backed corpus options.
+  * **Enabled**: Turns PostgreSQL-backed tarpit content on or off.
+  * **ConnectionString**: PostgreSQL connection string used to load the Markov corpus.
+  * **WordsTableName**: Table name for token rows. Defaults to `markov_words`.
+  * **SequencesTableName**: Table name for Markov transitions. Defaults to `markov_sequences`.
+  * **RefreshMinutes**: Cache refresh interval for reloading the corpus.
 
 ## **Overrides**
 

--- a/RedisBlocklistMiddlewareApp/RedisBlocklistMiddlewareApp.csproj
+++ b/RedisBlocklistMiddlewareApp/RedisBlocklistMiddlewareApp.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.15" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.31" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>

--- a/RedisBlocklistMiddlewareApp/Services/ITarpitMarkovStore.cs
+++ b/RedisBlocklistMiddlewareApp/Services/ITarpitMarkovStore.cs
@@ -1,0 +1,10 @@
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface ITarpitMarkovStore
+{
+    TarpitMarkovSnapshot? GetSnapshot();
+}
+
+public sealed record TarpitMarkovSnapshot(
+    IReadOnlyDictionary<string, string[]> Transitions,
+    IReadOnlyList<string> AvailableWords);

--- a/RedisBlocklistMiddlewareApp/Services/PostgresTarpitMarkovStore.cs
+++ b/RedisBlocklistMiddlewareApp/Services/PostgresTarpitMarkovStore.cs
@@ -1,0 +1,149 @@
+using Microsoft.Extensions.Options;
+using Npgsql;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class PostgresTarpitMarkovStore : ITarpitMarkovStore
+{
+    private readonly PostgresMarkovOptions _options;
+    private readonly ILogger<PostgresTarpitMarkovStore> _logger;
+    private readonly object _gate = new();
+    private TarpitMarkovSnapshot? _snapshot;
+    private DateTimeOffset _loadedAtUtc;
+
+    public PostgresTarpitMarkovStore(
+        IOptions<DefenseEngineOptions> options,
+        ILogger<PostgresTarpitMarkovStore> logger)
+    {
+        _options = options.Value.Tarpit.PostgresMarkov;
+        _logger = logger;
+    }
+
+    public TarpitMarkovSnapshot? GetSnapshot()
+    {
+        if (!_options.Enabled || string.IsNullOrWhiteSpace(_options.ConnectionString))
+        {
+            return null;
+        }
+
+        lock (_gate)
+        {
+            if (_snapshot is not null &&
+                DateTimeOffset.UtcNow - _loadedAtUtc < TimeSpan.FromMinutes(Math.Max(1, _options.RefreshMinutes)))
+            {
+                return _snapshot;
+            }
+
+            _snapshot = TryLoadSnapshot();
+            _loadedAtUtc = DateTimeOffset.UtcNow;
+            return _snapshot;
+        }
+    }
+
+    private TarpitMarkovSnapshot? TryLoadSnapshot()
+    {
+        try
+        {
+            using var connection = new NpgsqlConnection(_options.ConnectionString);
+            connection.Open();
+
+            var words = LoadWords(connection);
+            if (words.Count == 0)
+            {
+                return null;
+            }
+
+            var transitions = LoadTransitions(connection, words);
+            if (transitions.Count == 0)
+            {
+                return null;
+            }
+
+            return new TarpitMarkovSnapshot(
+                transitions,
+                words.Values
+                    .Where(word => !string.IsNullOrWhiteSpace(word))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load PostgreSQL tarpit Markov snapshot.");
+            return null;
+        }
+    }
+
+    private Dictionary<int, string> LoadWords(NpgsqlConnection connection)
+    {
+        var words = new Dictionary<int, string>();
+        using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT id, word FROM {QuoteIdentifier(_options.WordsTableName)};";
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            words[reader.GetInt32(0)] = reader.GetString(1);
+        }
+
+        return words;
+    }
+
+    private Dictionary<string, string[]> LoadTransitions(
+        NpgsqlConnection connection,
+        IReadOnlyDictionary<int, string> words)
+    {
+        var transitionMap = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            $"""
+            SELECT p1, p2, next_id, freq
+            FROM {QuoteIdentifier(_options.SequencesTableName)}
+            ORDER BY p1, p2, next_id;
+            """;
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var p1 = reader.GetInt32(0);
+            var p2 = reader.GetInt32(1);
+            var nextId = reader.GetInt32(2);
+            var freq = Math.Max(1, reader.GetInt32(3));
+
+            if (!words.TryGetValue(p1, out var p1Word) ||
+                !words.TryGetValue(p2, out var p2Word) ||
+                !words.TryGetValue(nextId, out var nextWord))
+            {
+                continue;
+            }
+
+            var stateKey = BuildStateKey(p1Word, p2Word);
+            if (!transitionMap.TryGetValue(stateKey, out var nextWords))
+            {
+                nextWords = [];
+                transitionMap[stateKey] = nextWords;
+            }
+
+            for (var index = 0; index < freq; index++)
+            {
+                nextWords.Add(nextWord);
+            }
+        }
+
+        return transitionMap.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.ToArray(),
+            StringComparer.Ordinal);
+    }
+
+    private static string BuildStateKey(string previousOne, string previousTwo)
+    {
+        return $"{previousOne}\u001f{previousTwo}";
+    }
+
+    private static string QuoteIdentifier(string identifier)
+    {
+        return "\"" + identifier.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/TarpitPageService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/TarpitPageService.cs
@@ -43,10 +43,14 @@ public sealed class TarpitPageService : ITarpitPageService
     ];
 
     private readonly TarpitOptions _options;
+    private readonly ITarpitMarkovStore _markovStore;
 
-    public TarpitPageService(IOptions<DefenseEngineOptions> options)
+    public TarpitPageService(
+        IOptions<DefenseEngineOptions> options,
+        ITarpitMarkovStore markovStore)
     {
         _options = options.Value.Tarpit;
+        _markovStore = markovStore;
     }
 
     public string GeneratePage(string path, string clientIpAddress)
@@ -55,6 +59,7 @@ public sealed class TarpitPageService : ITarpitPageService
         var random = new Random(GetDeterministicSeed(normalizedPath, clientIpAddress));
         var encodedPathText = WebUtility.HtmlEncode("/" + normalizedPath);
         var encodedPathForUrl = EncodePathForUrl(normalizedPath);
+        var renderMode = PickRenderMode(random);
         var builder = new StringBuilder();
 
         builder.AppendLine("<!doctype html>");
@@ -75,9 +80,58 @@ public sealed class TarpitPageService : ITarpitPageService
         builder.AppendLine($"  <h1>{Pick(Topics, random)}</h1>");
         builder.AppendLine($"  <p>Session path: {encodedPathText}</p>");
 
+        RenderBody(builder, renderMode, encodedPathForUrl, random);
+        builder.AppendLine("</main>");
+        builder.AppendLine("</body>");
+        builder.AppendLine("</html>");
+
+        return builder.ToString();
+    }
+
+    private int GetDeterministicSeed(string path, string clientIpAddress)
+    {
+        var bytes = SHA256.HashData(
+            Encoding.UTF8.GetBytes($"{_options.Seed}|{path}|{clientIpAddress}"));
+        return BitConverter.ToInt32(bytes, 0);
+    }
+
+    private void RenderBody(
+        StringBuilder builder,
+        string renderMode,
+        string encodedPathForUrl,
+        Random random)
+    {
         for (var i = 0; i < Math.Max(1, _options.ParagraphCount); i++)
         {
             builder.AppendLine($"  <p>{BuildParagraph(random)}</p>");
+        }
+
+        if (string.Equals(renderMode, TarpitRenderModes.ArchiveIndex, StringComparison.Ordinal))
+        {
+            builder.AppendLine("  <h2>Archive manifests</h2>");
+            builder.AppendLine("  <ul>");
+            for (var i = 0; i < Math.Max(1, _options.LinkCount); i++)
+            {
+                var slug = BuildSlug(random);
+                builder.AppendLine(
+                    $"    <li><a href=\"{_options.PathPrefix}/{encodedPathForUrl}/archive/{Uri.EscapeDataString(slug)}.zip\">{WebUtility.HtmlEncode(slug)}.zip</a></li>");
+            }
+            builder.AppendLine("  </ul>");
+            return;
+        }
+
+        if (string.Equals(renderMode, TarpitRenderModes.ApiCatalog, StringComparison.Ordinal))
+        {
+            builder.AppendLine("  <h2>API mirrors</h2>");
+            builder.AppendLine("  <ul>");
+            for (var i = 0; i < Math.Max(1, _options.LinkCount); i++)
+            {
+                var slug = BuildSlug(random);
+                builder.AppendLine(
+                    $"    <li><a href=\"{_options.PathPrefix}/{encodedPathForUrl}/api/{Uri.EscapeDataString(slug)}.json\">/{WebUtility.HtmlEncode(slug)}/status</a></li>");
+            }
+            builder.AppendLine("  </ul>");
+            return;
         }
 
         builder.AppendLine("  <h2>Related indexes</h2>");
@@ -93,22 +147,18 @@ public sealed class TarpitPageService : ITarpitPageService
         }
 
         builder.AppendLine("  </ul>");
-        builder.AppendLine("</main>");
-        builder.AppendLine("</body>");
-        builder.AppendLine("</html>");
-
-        return builder.ToString();
     }
 
-    private int GetDeterministicSeed(string path, string clientIpAddress)
+    private string BuildParagraph(Random random)
     {
-        var bytes = SHA256.HashData(
-            Encoding.UTF8.GetBytes($"{_options.Seed}|{path}|{clientIpAddress}"));
-        return BitConverter.ToInt32(bytes, 0);
-    }
+        var snapshot = _markovStore.GetSnapshot();
+        if (snapshot is not null &&
+            snapshot.Transitions.Count > 0 &&
+            snapshot.AvailableWords.Count > 0)
+        {
+            return BuildMarkovParagraph(snapshot, random);
+        }
 
-    private static string BuildParagraph(Random random)
-    {
         var sentenceCount = random.Next(3, 6);
         var sentences = new List<string>(sentenceCount);
 
@@ -124,6 +174,72 @@ public sealed class TarpitPageService : ITarpitPageService
     private static string BuildSlug(Random random)
     {
         return $"{Pick(Nouns, random)}-{Pick(Nouns, random)}-{random.Next(1000, 9999)}";
+    }
+
+    private string BuildMarkovParagraph(TarpitMarkovSnapshot snapshot, Random random)
+    {
+        var words = new List<string>(Math.Max(8, _options.MarkovWordsPerParagraph));
+        var previousOne = string.Empty;
+        var previousTwo = string.Empty;
+
+        for (var index = 0; index < Math.Max(8, _options.MarkovWordsPerParagraph); index++)
+        {
+            var stateKey = BuildStateKey(previousOne, previousTwo);
+            if (!snapshot.Transitions.TryGetValue(stateKey, out var candidates) || candidates.Length == 0)
+            {
+                var fallback = snapshot.AvailableWords[random.Next(snapshot.AvailableWords.Count)];
+                if (string.IsNullOrWhiteSpace(fallback))
+                {
+                    continue;
+                }
+
+                words.Add(fallback);
+                previousOne = previousTwo;
+                previousTwo = fallback;
+                continue;
+            }
+
+            var nextWord = candidates[random.Next(candidates.Length)];
+            if (string.IsNullOrWhiteSpace(nextWord))
+            {
+                previousOne = string.Empty;
+                previousTwo = string.Empty;
+                continue;
+            }
+
+            words.Add(nextWord);
+            previousOne = previousTwo;
+            previousTwo = nextWord;
+        }
+
+        if (words.Count == 0)
+        {
+            return "Archive manifests normalize synthetic crawl indexes.";
+        }
+
+        var paragraph = string.Join(' ', words);
+        if (!paragraph.EndsWith(".", StringComparison.Ordinal) &&
+            !paragraph.EndsWith("!", StringComparison.Ordinal) &&
+            !paragraph.EndsWith("?", StringComparison.Ordinal))
+        {
+            paragraph += ".";
+        }
+
+        return Capitalize(paragraph);
+    }
+
+    private string PickRenderMode(Random random)
+    {
+        var modes = _options.Modes.Length == 0
+            ? new[] { TarpitRenderModes.Standard }
+            : _options.Modes;
+
+        return modes[random.Next(modes.Length)];
+    }
+
+    private static string BuildStateKey(string previousOne, string previousTwo)
+    {
+        return $"{previousOne}\u001f{previousTwo}";
     }
 
     private static string EncodePathForUrl(string path)

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -126,7 +126,20 @@
       "Seed": "ai-scraping-defense-dotnet",
       "LinkCount": 6,
       "ParagraphCount": 5,
-      "ResponseDelayMilliseconds": 200
+      "ResponseDelayMilliseconds": 200,
+      "Modes": [
+        "Standard",
+        "ArchiveIndex",
+        "ApiCatalog"
+      ],
+      "MarkovWordsPerParagraph": 36,
+      "PostgresMarkov": {
+        "Enabled": false,
+        "ConnectionString": "",
+        "WordsTableName": "markov_words",
+        "SequencesTableName": "markov_sequences",
+        "RefreshMinutes": 30
+      }
     }
   }
 }

--- a/db/init_markov.sql
+++ b/db/init_markov.sql
@@ -1,35 +1,27 @@
--- anti_scrape/db/init_markov.sql (Placeholder Schema)
--- Basic schema for PostgreSQL Markov chain storage
-
--- Table to store unique words/tokens
-CREATE TABLE IF NOT EXISTS markov_words (
+CREATE TABLE IF NOT EXISTS markov_words
+(
     id SERIAL PRIMARY KEY,
     word TEXT UNIQUE NOT NULL
 );
 
--- Create index for faster word lookup
-CREATE INDEX IF NOT EXISTS idx_markov_words_word ON markov_words (word);
+CREATE INDEX IF NOT EXISTS idx_markov_words_word
+    ON markov_words (word);
 
--- Insert the empty string as a special token (ID 1 if table is empty)
-INSERT INTO markov_words (word) VALUES ('') ON CONFLICT (word) DO NOTHING;
+INSERT INTO markov_words (word)
+VALUES ('')
+ON CONFLICT (word) DO NOTHING;
 
--- Table to store sequences (word1_id -> word2_id -> next_word_id) and frequency
-CREATE TABLE IF NOT EXISTS markov_sequences (
+CREATE TABLE IF NOT EXISTS markov_sequences
+(
     p1 INT NOT NULL REFERENCES markov_words(id),
     p2 INT NOT NULL REFERENCES markov_words(id),
     next_id INT NOT NULL REFERENCES markov_words(id),
-    freq INT DEFAULT 1 NOT NULL,
-    -- Constraint to ensure combination of p1, p2, next_id is unique
-    CONSTRAINT uq_sequence UNIQUE (p1, p2, next_id)
+    freq INT NOT NULL DEFAULT 1,
+    CONSTRAINT uq_markov_sequence UNIQUE (p1, p2, next_id)
 );
 
--- Index for fast lookup of next possible words based on previous two
-CREATE INDEX IF NOT EXISTS idx_markov_sequences_prev ON markov_sequences (p1, p2);
+CREATE INDEX IF NOT EXISTS idx_markov_sequences_prev
+    ON markov_sequences (p1, p2);
 
--- Optional: Index for frequency-based lookups if needed
-CREATE INDEX IF NOT EXISTS idx_markov_sequences_freq ON markov_sequences (p1, p2, freq DESC);
-
--- Example of how the training script would insert/update:
--- INSERT INTO markov_sequences (p1, p2, next_id, freq)
--- VALUES (%s, %s, %s, 1)
--- ON CONFLICT (p1, p2, next_id) DO UPDATE SET freq = markov_sequences.freq + 1;
+CREATE INDEX IF NOT EXISTS idx_markov_sequences_freq
+    ON markov_sequences (p1, p2, freq DESC);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,7 +83,9 @@ Requests rewritten to `/anti-scrape-tarpit/{path}` are served by the minimal API
 
 Current behavior:
 
-- Deterministic synthetic HTML based on request path and seed.
+- Deterministic HTML based on request path and seed.
+- Optional PostgreSQL-backed Markov paragraphs loaded through [RedisBlocklistMiddlewareApp/Services/PostgresTarpitMarkovStore.cs](../RedisBlocklistMiddlewareApp/Services/PostgresTarpitMarkovStore.cs).
+- Deterministic render variants for archive manifests and API catalogs.
 - Recursive synthetic links to keep crawlers occupied.
 - Configurable response delay to simulate low-value slow streaming.
 

--- a/docs/dotnet_parity_roadmap.md
+++ b/docs/dotnet_parity_roadmap.md
@@ -11,7 +11,7 @@ Commercial v1 is defined in [commercial_scope.md](commercial_scope.md). This roa
 | Nginx/Lua edge filter | Implemented as ASP.NET Core middleware | Split into a dedicated edge gateway project |
 | AI Service webhook | Implemented as authenticated `/analyze` plus durable SQLite-backed intake | Add richer alerting/reporting and separate service boundary |
 | Escalation Engine | Implemented with baseline scoring, reputation-provider hooks, and an optional OpenAI-compatible model adapter | Add more provider types, richer telemetry, and separate service boundary |
-| Tarpit API | Implemented as deterministic synthetic page endpoint | Add richer tarpit modes, streaming, and Markov/PostgreSQL-backed content |
+| Tarpit API | Implemented as deterministic page generation with PostgreSQL-backed Markov support and multiple render variants | Add streaming/archive rotation parity and deeper crawl-wasting content sources |
 | Admin UI | Not implemented in .NET | Add operator dashboard on top of the authenticated admin API |
 | Community blocklist sync | Implemented as a configurable feed sync worker with admin-visible status | Add richer source trust, reporting parity, and deduplication policies |
 | Peer sync | Implemented with authenticated signal export, timed import, and explicit trust modes | Add richer trust scoring, deduplication policy, and multi-node coordination |


### PR DESCRIPTION
## Summary
- add optional PostgreSQL-backed Markov tarpit content with cached corpus loading
- add deterministic tarpit render variants for standard pages, archive manifests, and API catalogs
- document the schema/configuration and cover the new tarpit behavior with tests

## Testing
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln --no-build

Closes #34