### PR TITLE
Add operator dashboard UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - A deterministic tarpit endpoint that returns synthetic HTML and recursive links.
 - A lightweight authenticated event feed at `/defense/events` for recent decisions.
 - Authenticated operator metrics and blocklist management endpoints under `/defense/*`.
+- A protected operator dashboard at `/defense/dashboard` backed by the same management API.
 - An authenticated `/analyze` webhook endpoint with durable SQLite-backed intake for confirmed malicious events.
 - Optional community blocklist feed sync with authenticated status surfaced under `/defense/community-blocklist/status`.
 - Optional peer sync with explicit `ObserveOnly` and `BlockList` trust modes plus authenticated signal export at `/peer-sync/signals`.
@@ -36,11 +37,15 @@ See [docs/architecture.md](docs/architecture.md) for the current architecture, [
 - `GET /health`
 - `GET /anti-scrape-tarpit/{path}`
 
-`GET /defense/events` is only exposed when `DefenseEngine:Management:ApiKey` is configured.
-`GET /defense/metrics` and the blocklist management endpoints follow the same API-key protection via the configured `DefenseEngine:Management:ApiKeyHeaderName` header.
+`GET /defense/dashboard` and the dashboard session endpoints are only exposed when `DefenseEngine:Management:ApiKey` is configured.
+`GET /defense/events`, `GET /defense/metrics`, and the blocklist management endpoints follow the same management authentication. They accept the configured `DefenseEngine:Management:ApiKeyHeaderName` header or a dashboard session cookie created at `/defense/dashboard/session`.
 `POST /analyze` is only exposed when `DefenseEngine:Intake:ApiKey` is configured and expects the configured `DefenseEngine:Intake:ApiKeyHeaderName` header.
 
 Management endpoints:
+- `GET /defense/dashboard`
+- `GET /defense/dashboard/session`
+- `POST /defense/dashboard/session`
+- `DELETE /defense/dashboard/session`
 - `GET /defense/events?count=50`
 - `GET /defense/metrics`
 - `GET /defense/community-blocklist/status`
@@ -94,6 +99,7 @@ Key areas:
 - `DefenseEngine:Heuristics`
 - `DefenseEngine:Networking`
 - `DefenseEngine:Management`
+  - `DashboardSessionHours` controls the browser dashboard session lifetime after successful sign-in.
 - `DefenseEngine:Intake`
 - `DefenseEngine:Audit`
 - `DefenseEngine:Escalation`

--- a/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -41,6 +42,29 @@ public sealed class ManagementEndpointTests
         var filter = CreateFilter();
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Headers["X-API-Key"] = "test-management-key";
+        var context = new TestEndpointFilterInvocationContext(httpContext);
+
+        var result = await filter.InvokeAsync(context, _ => ValueTask.FromResult<object?>(Results.Ok()));
+
+        await AssertStatusCodeAsync(result, StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public async Task ApiKeyFilter_AllowsRequest_WhenDashboardSessionCookieMatches()
+    {
+        var services = CreateServiceProvider();
+        var authenticationService = services.GetRequiredService<ManagementAuthenticationService>();
+        var filter = services.GetRequiredService<ApiKeyEndpointFilter>();
+        var responseContext = new DefaultHttpContext();
+        authenticationService.AppendSessionCookie(responseContext.Response, authenticationService.CreateSessionValue());
+        var setCookie = responseContext.Response.Headers.SetCookie.ToString();
+        var sessionValue = ExtractCookieValue(setCookie, ManagementAuthenticationService.SessionCookieName);
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services
+        };
+        httpContext.Request.Headers.Cookie = $"{ManagementAuthenticationService.SessionCookieName}={sessionValue}";
         var context = new TestEndpointFilterInvocationContext(httpContext);
 
         var result = await filter.InvokeAsync(context, _ => ValueTask.FromResult<object?>(Results.Ok()));
@@ -106,6 +130,7 @@ public sealed class ManagementEndpointTests
 
         var endpoints = Program.GetAdvertisedEndpoints(options);
 
+        Assert.Equal("/defense/dashboard", endpoints["dashboard"]);
         Assert.Equal("/defense/events", endpoints["events"]);
         Assert.Equal("/defense/metrics", endpoints["metrics"]);
     }
@@ -249,11 +274,26 @@ public sealed class ManagementEndpointTests
         Program.MapManagementEndpoints(app, options);
         var endpoints = GetRouteEndpoints(app);
 
+        Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/dashboard");
+        Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/dashboard/session");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/events");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/metrics");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/blocklist");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/community-blocklist/status");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/peer-sync/status");
+    }
+
+    [Fact]
+    public void OperatorDashboardPageService_RendersManagementApiSurface()
+    {
+        var pageService = new OperatorDashboardPageService();
+
+        var html = pageService.Render();
+
+        Assert.Contains("/defense/dashboard/session", html);
+        Assert.Contains("/defense/events", html);
+        Assert.Contains("/defense/metrics", html);
+        Assert.Contains("/defense/blocklist", html);
     }
 
     [Fact]
@@ -316,16 +356,7 @@ public sealed class ManagementEndpointTests
 
     private static ApiKeyEndpointFilter CreateFilter()
     {
-        var options = Options.Create(new DefenseEngineOptions
-        {
-            Management = new ManagementOptions
-            {
-                ApiKeyHeaderName = "X-API-Key",
-                ApiKey = "test-management-key"
-            }
-        });
-
-        return new ApiKeyEndpointFilter(options);
+        return CreateServiceProvider().GetRequiredService<ApiKeyEndpointFilter>();
     }
 
     private static IntakeApiKeyEndpointFilter CreateIntakeFilter()
@@ -359,16 +390,42 @@ public sealed class ManagementEndpointTests
     private static WebApplication CreateApp()
     {
         var builder = WebApplication.CreateBuilder();
+        builder.Services.AddDataProtection();
+        builder.Services.AddSingleton<ManagementAuthenticationService>();
         builder.Services.AddSingleton<ApiKeyEndpointFilter>();
         builder.Services.AddSingleton<IntakeApiKeyEndpointFilter>();
         builder.Services.AddSingleton<PeerApiKeyEndpointFilter>();
+        builder.Services.AddSingleton<IOperatorDashboardPageService, OperatorDashboardPageService>();
         builder.Services.AddSingleton<IDefenseEventStore, TestDefenseEventStore>();
         builder.Services.AddSingleton<IBlocklistService, TestBlocklistService>();
         builder.Services.AddSingleton<IWebhookEventInbox, TestWebhookEventInbox>();
         builder.Services.AddSingleton<IPeerSyncStatusStore, TestPeerSyncStatusStore>();
         builder.Services.AddSingleton<ICommunityBlocklistSyncStatusStore, TestCommunityBlocklistSyncStatusStore>();
-        builder.Services.AddSingleton(Options.Create(new DefenseEngineOptions()));
+        builder.Services.AddSingleton(Options.Create(CreateOptions()));
         return builder.Build();
+    }
+
+    private static ServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddDataProtection();
+        services.AddSingleton(Options.Create(CreateOptions()));
+        services.AddSingleton<ManagementAuthenticationService>();
+        services.AddSingleton<ApiKeyEndpointFilter>();
+        return services.BuildServiceProvider();
+    }
+
+    private static DefenseEngineOptions CreateOptions()
+    {
+        return new DefenseEngineOptions
+        {
+            Management = new ManagementOptions
+            {
+                ApiKeyHeaderName = "X-API-Key",
+                ApiKey = "test-management-key",
+                DashboardSessionHours = 8
+            }
+        };
     }
 
     private static IReadOnlyList<RouteEndpoint> GetRouteEndpoints(WebApplication app)
@@ -391,6 +448,15 @@ public sealed class ManagementEndpointTests
         await typedResult.ExecuteAsync(httpContext);
 
         Assert.Equal(expectedStatusCode, httpContext.Response.StatusCode);
+    }
+
+    private static string ExtractCookieValue(string setCookieHeader, string cookieName)
+    {
+        var cookieSegment = setCookieHeader
+            .Split(';', StringSplitOptions.RemoveEmptyEntries)
+            .First(segment => segment.StartsWith(cookieName + "=", StringComparison.Ordinal));
+
+        return cookieSegment[(cookieName.Length + 1)..];
     }
 
     private sealed class TestEndpointFilterInvocationContext : EndpointFilterInvocationContext

--- a/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
+++ b/RedisBlocklistMiddlewareApp/Configuration/DefenseEngineOptions.cs
@@ -114,6 +114,8 @@ public sealed class ManagementOptions
     public string ApiKeyHeaderName { get; set; } = "X-API-Key";
 
     public string ApiKey { get; set; } = string.Empty;
+
+    public int DashboardSessionHours { get; set; } = 8;
 }
 
 public sealed class IntakeOptions

--- a/RedisBlocklistMiddlewareApp/Models/OperatorDashboardModels.cs
+++ b/RedisBlocklistMiddlewareApp/Models/OperatorDashboardModels.cs
@@ -1,0 +1,3 @@
+namespace RedisBlocklistMiddlewareApp.Models;
+
+public sealed record DashboardSessionLoginRequest(string ApiKey);

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -12,6 +12,7 @@ var builder = WebApplication.CreateBuilder(args);
 var redisConnectionString = builder.Configuration.GetConnectionString("RedisConnection");
 
 builder.Services.AddHttpClient();
+builder.Services.AddDataProtection();
 builder.Services.AddSingleton<IValidateOptions<DefenseEngineOptions>, DefenseEngineOptionsValidator>();
 builder.Services.AddSingleton<ProductionConfigurationValidator>();
 builder.Services
@@ -61,6 +62,7 @@ builder.Services
             : options.Management.ApiKeyHeaderName.Trim();
 
         options.Management.ApiKey = options.Management.ApiKey.Trim();
+        options.Management.DashboardSessionHours = Math.Max(1, options.Management.DashboardSessionHours);
 
         options.Intake.ApiKeyHeaderName = string.IsNullOrWhiteSpace(options.Intake.ApiKeyHeaderName)
             ? "X-Webhook-Key"
@@ -188,9 +190,11 @@ builder.Services.AddSingleton<CommunityBlocklistSyncRunner>();
 builder.Services.AddSingleton<IPeerSignalFeedClient, HttpPeerSignalFeedClient>();
 builder.Services.AddSingleton<IPeerSyncStatusStore, PeerSyncStatusStore>();
 builder.Services.AddSingleton<PeerSyncRunner>();
+builder.Services.AddSingleton<ManagementAuthenticationService>();
 builder.Services.AddSingleton<ApiKeyEndpointFilter>();
 builder.Services.AddSingleton<IntakeApiKeyEndpointFilter>();
 builder.Services.AddSingleton<PeerApiKeyEndpointFilter>();
+builder.Services.AddSingleton<IOperatorDashboardPageService, OperatorDashboardPageService>();
 builder.Services.AddSingleton<IWebhookEventInbox, SqliteWebhookEventInbox>();
 builder.Services.AddHostedService<StartupValidationService>();
 builder.Services.AddHostedService<DefenseAnalysisService>();
@@ -286,6 +290,7 @@ public partial class Program
 
         if (ShouldExposeManagementEndpoints(runtimeOptions))
         {
+            endpoints["dashboard"] = "/defense/dashboard";
             endpoints["events"] = "/defense/events";
             endpoints["metrics"] = "/defense/metrics";
         }
@@ -311,6 +316,47 @@ public partial class Program
         {
             return;
         }
+
+        app.MapGet("/defense/dashboard", (
+            IOperatorDashboardPageService pageService) =>
+        {
+            return Results.Content(pageService.Render(), "text/html");
+        });
+
+        app.MapGet("/defense/dashboard/session", (
+            ManagementAuthenticationService authenticationService,
+            HttpContext httpContext) =>
+        {
+            return Results.Ok(new
+            {
+                authenticated = authenticationService.IsAuthenticated(httpContext)
+            });
+        });
+
+        app.MapPost("/defense/dashboard/session", (
+            DashboardSessionLoginRequest request,
+            ManagementAuthenticationService authenticationService,
+            HttpContext httpContext) =>
+        {
+            if (!authenticationService.IsApiKeyValid(request.ApiKey))
+            {
+                return Results.Unauthorized();
+            }
+
+            authenticationService.AppendSessionCookie(
+                httpContext.Response,
+                authenticationService.CreateSessionValue());
+
+            return Results.NoContent();
+        });
+
+        app.MapDelete("/defense/dashboard/session", (
+            ManagementAuthenticationService authenticationService,
+            HttpContext httpContext) =>
+        {
+            authenticationService.ClearSessionCookie(httpContext.Response);
+            return Results.NoContent();
+        });
 
         var management = app.MapGroup("/defense")
             .AddEndpointFilter<ApiKeyEndpointFilter>();

--- a/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
+++ b/RedisBlocklistMiddlewareApp/README for appsettings.json (Redis Middleware App).md
@@ -68,7 +68,8 @@ The appsettings.json file provides configuration values used by the ASP.NET Core
 #### **DefenseEngine:Management**
 
 * **ApiKeyHeaderName**: Header name required for authenticated management endpoints.
-* **ApiKey**: Shared secret required to access `/defense/events`. If blank, the endpoint is not exposed.
+* **ApiKey**: Shared secret required to access the management API and `/defense/dashboard`. If blank, the dashboard and management endpoints are not exposed.
+* **DashboardSessionHours**: Lifetime of the browser session cookie created by the operator dashboard after a successful sign-in.
 
 #### **DefenseEngine:Intake**
 

--- a/RedisBlocklistMiddlewareApp/Services/ApiKeyEndpointFilter.cs
+++ b/RedisBlocklistMiddlewareApp/Services/ApiKeyEndpointFilter.cs
@@ -1,47 +1,23 @@
-using System.Security.Cryptography;
-using System.Text;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
-using RedisBlocklistMiddlewareApp.Configuration;
-
 namespace RedisBlocklistMiddlewareApp.Services;
 
 public sealed class ApiKeyEndpointFilter : IEndpointFilter
 {
-    private readonly string _headerName;
-    private readonly byte[] _expectedApiKeyBytes;
+    private readonly ManagementAuthenticationService _authenticationService;
 
-    public ApiKeyEndpointFilter(IOptions<DefenseEngineOptions> options)
+    public ApiKeyEndpointFilter(ManagementAuthenticationService authenticationService)
     {
-        _headerName = options.Value.Management.ApiKeyHeaderName;
-        _expectedApiKeyBytes = Encoding.UTF8.GetBytes(options.Value.Management.ApiKey);
+        _authenticationService = authenticationService;
     }
 
     public ValueTask<object?> InvokeAsync(
         EndpointFilterInvocationContext context,
         EndpointFilterDelegate next)
     {
-        if (!context.HttpContext.Request.Headers.TryGetValue(_headerName, out var suppliedApiKey))
-        {
-            return ValueTask.FromResult<object?>(Results.Unauthorized());
-        }
-
-        var suppliedApiKeyBytes = Encoding.UTF8.GetBytes(suppliedApiKey.ToString());
-        if (!FixedTimeEquals(_expectedApiKeyBytes, suppliedApiKeyBytes))
+        if (!_authenticationService.IsAuthenticated(context.HttpContext))
         {
             return ValueTask.FromResult<object?>(Results.Unauthorized());
         }
 
         return next(context);
-    }
-
-    private static bool FixedTimeEquals(byte[] expected, byte[] supplied)
-    {
-        if (expected.Length != supplied.Length)
-        {
-            return false;
-        }
-
-        return CryptographicOperations.FixedTimeEquals(expected, supplied);
     }
 }

--- a/RedisBlocklistMiddlewareApp/Services/ManagementAuthenticationService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/ManagementAuthenticationService.cs
@@ -1,0 +1,122 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class ManagementAuthenticationService
+{
+    public const string SessionCookieName = "defense_dashboard_session";
+
+    private readonly string _headerName;
+    private readonly byte[] _expectedApiKeyBytes;
+    private readonly IDataProtector _dataProtector;
+    private readonly TimeSpan _sessionLifetime;
+
+    public ManagementAuthenticationService(
+        IOptions<DefenseEngineOptions> options,
+        IDataProtectionProvider dataProtectionProvider)
+    {
+        _headerName = options.Value.Management.ApiKeyHeaderName;
+        _expectedApiKeyBytes = Encoding.UTF8.GetBytes(options.Value.Management.ApiKey);
+        _dataProtector = dataProtectionProvider.CreateProtector("management-dashboard-session");
+        _sessionLifetime = TimeSpan.FromHours(options.Value.Management.DashboardSessionHours);
+    }
+
+    public bool IsAuthenticated(HttpContext httpContext)
+    {
+        return HasValidApiKeyHeader(httpContext) || HasValidSessionCookie(httpContext);
+    }
+
+    public bool IsApiKeyValid(string? suppliedApiKey)
+    {
+        if (string.IsNullOrEmpty(suppliedApiKey))
+        {
+            return false;
+        }
+
+        return FixedTimeEquals(_expectedApiKeyBytes, Encoding.UTF8.GetBytes(suppliedApiKey));
+    }
+
+    public string CreateSessionValue()
+    {
+        var expiresAtUtc = DateTimeOffset.UtcNow.Add(_sessionLifetime);
+        return _dataProtector.Protect(expiresAtUtc.ToUnixTimeSeconds().ToString());
+    }
+
+    public void AppendSessionCookie(HttpResponse response, string sessionValue)
+    {
+        response.Cookies.Append(
+            SessionCookieName,
+            sessionValue,
+            new CookieOptions
+            {
+                HttpOnly = true,
+                IsEssential = true,
+                Path = "/defense",
+                SameSite = SameSiteMode.Strict,
+                Secure = response.HttpContext.Request.IsHttps,
+                MaxAge = _sessionLifetime
+            });
+    }
+
+    public void ClearSessionCookie(HttpResponse response)
+    {
+        response.Cookies.Delete(
+            SessionCookieName,
+            new CookieOptions
+            {
+                Path = "/defense",
+                SameSite = SameSiteMode.Strict,
+                Secure = response.HttpContext.Request.IsHttps
+            });
+    }
+
+    public bool HasValidApiKeyHeader(HttpContext httpContext)
+    {
+        if (!httpContext.Request.Headers.TryGetValue(_headerName, out var suppliedApiKey))
+        {
+            return false;
+        }
+
+        return IsApiKeyValid(suppliedApiKey.ToString());
+    }
+
+    public bool HasValidSessionCookie(HttpContext httpContext)
+    {
+        if (!httpContext.Request.Cookies.TryGetValue(SessionCookieName, out var sessionValue) ||
+            string.IsNullOrWhiteSpace(sessionValue))
+        {
+            return false;
+        }
+
+        try
+        {
+            var payload = _dataProtector.Unprotect(sessionValue);
+            if (!long.TryParse(payload, out var expiresAtUnixSeconds))
+            {
+                return false;
+            }
+
+            var expiresAtUtc = DateTimeOffset.FromUnixTimeSeconds(expiresAtUnixSeconds);
+            return expiresAtUtc > DateTimeOffset.UtcNow;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool FixedTimeEquals(byte[] expected, byte[] supplied)
+    {
+        if (expected.Length != supplied.Length)
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(expected, supplied);
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/OperatorDashboardPageService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/OperatorDashboardPageService.cs
@@ -1,0 +1,786 @@
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface IOperatorDashboardPageService
+{
+    string Render();
+}
+
+public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
+{
+    public string Render()
+    {
+        return """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Defense Operator Console</title>
+  <style>
+    :root {
+      --paper: #f4efe4;
+      --paper-deep: #e8dcc4;
+      --ink: #1d2218;
+      --muted: #5f6658;
+      --line: rgba(29, 34, 24, 0.14);
+      --accent: #8d2a1e;
+      --accent-soft: rgba(141, 42, 30, 0.12);
+      --ok: #355e3b;
+      --warn: #8c5c12;
+      --panel: rgba(255, 252, 245, 0.88);
+      --shadow: 0 24px 60px rgba(33, 26, 17, 0.16);
+      --radius: 24px;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at top left, rgba(141, 42, 30, 0.16), transparent 32%),
+        radial-gradient(circle at top right, rgba(53, 94, 59, 0.14), transparent 28%),
+        linear-gradient(180deg, #f8f4eb 0%, #ece0c9 100%);
+      font-family: "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .shell {
+      width: min(1240px, calc(100vw - 32px));
+      margin: 24px auto 48px;
+      display: grid;
+      gap: 18px;
+    }
+
+    .hero,
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(18px);
+    }
+
+    .hero {
+      padding: 28px;
+      display: grid;
+      gap: 18px;
+    }
+
+    .hero-grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: 1.7fr 1fr;
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      color: var(--accent);
+      font-size: 0.82rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      width: fit-content;
+    }
+
+    h1, h2, h3 {
+      margin: 0;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    h1 { font-size: clamp(2.3rem, 4vw, 4.2rem); line-height: 0.94; max-width: 10ch; }
+    h2 { font-size: 1.35rem; }
+    h3 { font-size: 1rem; }
+
+    p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.55;
+    }
+
+    .status-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.72);
+      border: 1px solid var(--line);
+      font-size: 0.92rem;
+    }
+
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--warn);
+      box-shadow: 0 0 0 6px rgba(140, 92, 18, 0.12);
+    }
+
+    .dot.live {
+      background: var(--ok);
+      box-shadow: 0 0 0 6px rgba(53, 94, 59, 0.12);
+    }
+
+    .panel-grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: 1.25fr 0.95fr;
+    }
+
+    .panel {
+      padding: 22px;
+    }
+
+    .metric-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .metric-card {
+      padding: 18px;
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.82);
+      border: 1px solid var(--line);
+      min-height: 124px;
+      display: grid;
+      gap: 10px;
+      align-content: start;
+    }
+
+    .metric-label {
+      color: var(--muted);
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .metric-value {
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: clamp(2rem, 3vw, 2.8rem);
+      line-height: 1;
+    }
+
+    .toolbar,
+    .action-row,
+    .status-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .status-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .status-card,
+    .login-panel {
+      padding: 18px;
+      border-radius: 18px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.82);
+      display: grid;
+      gap: 10px;
+    }
+
+    .login-panel {
+      align-content: start;
+      min-height: 100%;
+    }
+
+    .table-wrap {
+      overflow-x: auto;
+      border-radius: 18px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.78);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 760px;
+    }
+
+    th, td {
+      padding: 14px 16px;
+      text-align: left;
+      border-bottom: 1px solid var(--line);
+      font-size: 0.94rem;
+      vertical-align: top;
+    }
+
+    th {
+      color: var(--muted);
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.72);
+      margin: 0 6px 6px 0;
+      font-size: 0.78rem;
+    }
+
+    .chip.blocked { color: var(--accent); border-color: rgba(141, 42, 30, 0.24); background: rgba(141, 42, 30, 0.08); }
+    .chip.observed { color: var(--ok); border-color: rgba(53, 94, 59, 0.24); background: rgba(53, 94, 59, 0.08); }
+
+    form {
+      display: grid;
+      gap: 12px;
+    }
+
+    label {
+      display: grid;
+      gap: 8px;
+      font-size: 0.84rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    input, button {
+      font: inherit;
+    }
+
+    input {
+      width: 100%;
+      padding: 14px 16px;
+      border-radius: 14px;
+      border: 1px solid rgba(29, 34, 24, 0.16);
+      background: rgba(255, 255, 255, 0.86);
+      color: var(--ink);
+    }
+
+    input:focus {
+      outline: 2px solid rgba(141, 42, 30, 0.18);
+      border-color: rgba(141, 42, 30, 0.38);
+    }
+
+    button {
+      border: 0;
+      border-radius: 999px;
+      padding: 12px 16px;
+      cursor: pointer;
+      transition: transform 150ms ease, opacity 150ms ease, background 150ms ease;
+    }
+
+    button:hover { transform: translateY(-1px); }
+    button:disabled { opacity: 0.55; cursor: wait; transform: none; }
+
+    .primary {
+      background: var(--accent);
+      color: white;
+    }
+
+    .secondary {
+      background: rgba(29, 34, 24, 0.07);
+      color: var(--ink);
+    }
+
+    .ghost {
+      background: transparent;
+      color: var(--muted);
+      border: 1px solid var(--line);
+    }
+
+    .inline-note,
+    .empty,
+    .mono {
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .mono {
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      word-break: break-word;
+    }
+
+    .banner {
+      display: none;
+      padding: 14px 16px;
+      border-radius: 16px;
+      border: 1px solid rgba(141, 42, 30, 0.24);
+      background: rgba(141, 42, 30, 0.08);
+      color: var(--accent);
+    }
+
+    .banner.visible {
+      display: block;
+    }
+
+    .hidden {
+      display: none !important;
+    }
+
+    @media (max-width: 960px) {
+      .hero-grid,
+      .panel-grid,
+      .metric-grid,
+      .status-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <section class="hero">
+      <div class="eyebrow">Operator Console</div>
+      <div class="hero-grid">
+        <div>
+          <h1>Scraping defense command board.</h1>
+          <p>Recent decisions, edge metrics, peer and community sync health, and manual blocklist controls all live here. Every action still flows through the authenticated management API.</p>
+        </div>
+        <aside class="login-panel">
+          <div class="status-bar">
+            <h2>Session</h2>
+            <button id="logoutButton" class="ghost hidden" type="button">Log out</button>
+          </div>
+          <p id="sessionCopy">Sign in with the management API key to unlock the dashboard and issue blocklist actions from the browser.</p>
+          <form id="loginForm">
+            <label>
+              Management API key
+              <input id="apiKeyInput" type="password" autocomplete="current-password" placeholder="Paste API key">
+            </label>
+            <div class="action-row">
+              <button class="primary" id="loginButton" type="submit">Open dashboard</button>
+              <button class="secondary" id="refreshButton" type="button">Refresh now</button>
+            </div>
+          </form>
+          <p class="inline-note">The browser session uses a server-issued cookie after the initial sign-in. The dashboard then reads the same `/defense/*` management endpoints as any other operator client.</p>
+        </aside>
+      </div>
+      <div class="status-bar">
+        <div class="status-pill"><span id="liveDot" class="dot"></span><strong id="liveLabel">Locked</strong></div>
+        <div class="status-pill">Last sync <span id="lastRefresh" class="mono">never</span></div>
+      </div>
+      <div id="errorBanner" class="banner" role="alert"></div>
+    </section>
+
+    <section class="panel">
+      <div class="status-bar">
+        <h2>Edge metrics</h2>
+        <p class="inline-note">Derived from the persisted defense event store.</p>
+      </div>
+      <div class="metric-grid">
+        <article class="metric-card">
+          <div class="metric-label">Total decisions</div>
+          <div id="metricTotal" class="metric-value">0</div>
+          <p>All recorded decisions in the durable audit store.</p>
+        </article>
+        <article class="metric-card">
+          <div class="metric-label">Blocked</div>
+          <div id="metricBlocked" class="metric-value">0</div>
+          <p>Requests escalated into active enforcement.</p>
+        </article>
+        <article class="metric-card">
+          <div class="metric-label">Observed</div>
+          <div id="metricObserved" class="metric-value">0</div>
+          <p>Requests retained for analysis without an immediate block.</p>
+        </article>
+        <article class="metric-card">
+          <div class="metric-label">Latest decision</div>
+          <div id="metricLatest" class="metric-value" style="font-size:1.4rem;">none</div>
+          <p>Most recent decision timestamp, formatted in local operator time.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel-grid">
+      <section class="panel">
+        <div class="status-bar">
+          <h2>Recent decisions</h2>
+          <div class="toolbar">
+            <button id="loadMoreButton" class="secondary" type="button">Load 100</button>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Action</th>
+                <th>IP</th>
+                <th>Path</th>
+                <th>Score</th>
+                <th>Signals</th>
+                <th>Observed</th>
+              </tr>
+            </thead>
+            <tbody id="eventsTableBody">
+              <tr><td colspan="6" class="empty">Sign in to load recent defense decisions.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <aside class="panel">
+        <div class="status-bar">
+          <h2>Control actions</h2>
+          <span class="inline-note">Lookup, block, and unblock IPs.</span>
+        </div>
+        <form id="blocklistForm">
+          <label>
+            IP address
+            <input id="ipInput" type="text" inputmode="text" placeholder="203.0.113.10">
+          </label>
+          <label>
+            Reason
+            <input id="reasonInput" type="text" placeholder="manual_block">
+          </label>
+          <div class="action-row">
+            <button class="primary" id="lookupButton" type="button">Check status</button>
+            <button class="secondary" id="blockButton" type="button">Block IP</button>
+            <button class="ghost" id="unblockButton" type="button">Unblock IP</button>
+          </div>
+        </form>
+        <div id="blocklistResult" class="status-card">
+          <h3>Blocklist result</h3>
+          <p class="mono">No lookup performed yet.</p>
+        </div>
+        <div class="status-grid">
+          <section class="status-card">
+            <h3>Community feeds</h3>
+            <p id="communityStatusCopy">Waiting for session.</p>
+          </section>
+          <section class="status-card">
+            <h3>Peer sync</h3>
+            <p id="peerStatusCopy">Waiting for session.</p>
+          </section>
+        </div>
+      </aside>
+    </section>
+  </main>
+
+  <script>
+    const state = {
+      authenticated: false,
+      eventCount: 50
+    };
+
+    const loginForm = document.getElementById("loginForm");
+    const logoutButton = document.getElementById("logoutButton");
+    const refreshButton = document.getElementById("refreshButton");
+    const loadMoreButton = document.getElementById("loadMoreButton");
+    const apiKeyInput = document.getElementById("apiKeyInput");
+    const liveDot = document.getElementById("liveDot");
+    const liveLabel = document.getElementById("liveLabel");
+    const lastRefresh = document.getElementById("lastRefresh");
+    const sessionCopy = document.getElementById("sessionCopy");
+    const errorBanner = document.getElementById("errorBanner");
+    const eventsTableBody = document.getElementById("eventsTableBody");
+    const blocklistResult = document.getElementById("blocklistResult");
+    const ipInput = document.getElementById("ipInput");
+    const reasonInput = document.getElementById("reasonInput");
+
+    document.getElementById("lookupButton").addEventListener("click", () => runBlocklistAction("lookup"));
+    document.getElementById("blockButton").addEventListener("click", () => runBlocklistAction("block"));
+    document.getElementById("unblockButton").addEventListener("click", () => runBlocklistAction("unblock"));
+    refreshButton.addEventListener("click", () => refreshDashboard());
+    loadMoreButton.addEventListener("click", () => {
+      state.eventCount = 100;
+      refreshEvents();
+    });
+    logoutButton.addEventListener("click", logout);
+
+    loginForm.addEventListener("submit", async event => {
+      event.preventDefault();
+      clearError();
+      setBusy(true);
+
+      try {
+        const response = await fetch("/defense/dashboard/session", {
+          method: "POST",
+          credentials: "same-origin",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ apiKey: apiKeyInput.value })
+        });
+
+        if (!response.ok) {
+          throw new Error(response.status === 401 ? "The supplied management API key was rejected." : "The dashboard session could not be created.");
+        }
+
+        apiKeyInput.value = "";
+        state.authenticated = true;
+        await refreshDashboard();
+      } catch (error) {
+        showError(error.message);
+      } finally {
+        setBusy(false);
+      }
+    });
+
+    async function refreshDashboard() {
+      clearError();
+
+      try {
+        const authenticated = await checkSession();
+        updateSessionUi(authenticated);
+
+        if (!authenticated) {
+          renderLockedState();
+          return;
+        }
+
+        await Promise.all([
+          refreshMetrics(),
+          refreshEvents(),
+          refreshStatuses()
+        ]);
+
+        lastRefresh.textContent = formatDate(new Date().toISOString());
+      } catch (error) {
+        showError(error.message || "The dashboard refresh failed.");
+      }
+    }
+
+    async function checkSession() {
+      try {
+        const response = await fetch("/defense/dashboard/session", {
+          credentials: "same-origin"
+        });
+
+        if (!response.ok) {
+          return false;
+        }
+
+        const payload = await response.json();
+        state.authenticated = Boolean(payload.authenticated);
+        return state.authenticated;
+      } catch {
+        state.authenticated = false;
+        return false;
+      }
+    }
+
+    async function refreshMetrics() {
+      const metrics = await fetchJson("/defense/metrics");
+      document.getElementById("metricTotal").textContent = number(metrics.totalDecisions);
+      document.getElementById("metricBlocked").textContent = number(metrics.blockedCount);
+      document.getElementById("metricObserved").textContent = number(metrics.observedCount);
+      document.getElementById("metricLatest").textContent = metrics.latestDecisionAtUtc ? formatDate(metrics.latestDecisionAtUtc) : "none";
+    }
+
+    async function refreshEvents() {
+      const events = await fetchJson("/defense/events?count=" + encodeURIComponent(state.eventCount));
+
+      if (!events.length) {
+        eventsTableBody.innerHTML = '<tr><td colspan="6" class="empty">No defense decisions are stored yet.</td></tr>';
+        return;
+      }
+
+      eventsTableBody.innerHTML = events.map(event => {
+        const actionClass = event.action === "blocked" ? "blocked" : "observed";
+        const signalHtml = (event.signals || []).map(signal => '<span class="chip">' + escapeHtml(signal) + '</span>').join("");
+
+        return `
+          <tr>
+            <td><span class="chip ${actionClass}">${escapeHtml(event.action)}</span></td>
+            <td class="mono">${escapeHtml(event.ipAddress)}</td>
+            <td class="mono">${escapeHtml(event.path)}</td>
+            <td>${number(event.score)}</td>
+            <td>${signalHtml || '<span class="empty">none</span>'}</td>
+            <td>${formatDate(event.observedAtUtc)}</td>
+          </tr>`;
+      }).join("");
+    }
+
+    async function refreshStatuses() {
+      const [community, peer] = await Promise.all([
+        fetchJson("/defense/community-blocklist/status"),
+        fetchJson("/defense/peer-sync/status")
+      ]);
+
+      document.getElementById("communityStatusCopy").textContent = summarizeStatus(community.enabled, community.importedCount, community.rejectedCount, community.lastSuccessAtUtc, community.lastError);
+      document.getElementById("peerStatusCopy").textContent = summarizePeerStatus(peer);
+    }
+
+    async function runBlocklistAction(action) {
+      clearError();
+
+      if (!state.authenticated) {
+        showError("Open a dashboard session before issuing blocklist actions.");
+        return;
+      }
+
+      const ip = ipInput.value.trim();
+      const reason = reasonInput.value.trim() || "manual_block";
+
+      if (!ip) {
+        showError("Enter an IP address first.");
+        return;
+      }
+
+      const baseUrl = "/defense/blocklist?ip=" + encodeURIComponent(ip);
+
+      try {
+        let response;
+
+        if (action === "lookup") {
+          response = await fetch(baseUrl, { credentials: "same-origin" });
+        } else if (action === "block") {
+          response = await fetch(baseUrl + "&reason=" + encodeURIComponent(reason), {
+            method: "POST",
+            credentials: "same-origin"
+          });
+        } else {
+          response = await fetch(baseUrl, {
+            method: "DELETE",
+            credentials: "same-origin"
+          });
+        }
+
+        const payload = await parseJson(response);
+        if (!response.ok) {
+          throw new Error(payload.error || "The blocklist action failed.");
+        }
+
+        blocklistResult.innerHTML = `
+          <h3>Blocklist result</h3>
+          <p class="mono">IP ${escapeHtml(payload.ip || ip)} is ${payload.blocked ? "blocked" : "not blocked"}.</p>`;
+
+        await refreshDashboard();
+      } catch (error) {
+        showError(error.message);
+      }
+    }
+
+    async function logout() {
+      await fetch("/defense/dashboard/session", {
+        method: "DELETE",
+        credentials: "same-origin"
+      });
+
+      state.authenticated = false;
+      updateSessionUi(false);
+      renderLockedState();
+      clearError();
+    }
+
+    async function fetchJson(url) {
+      const response = await fetch(url, {
+        credentials: "same-origin"
+      });
+
+      const payload = await parseJson(response);
+      if (!response.ok) {
+        throw new Error(payload.error || "Request failed.");
+      }
+
+      return payload;
+    }
+
+    async function parseJson(response) {
+      const contentType = response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        return {};
+      }
+
+      return response.json();
+    }
+
+    function updateSessionUi(authenticated) {
+      liveDot.classList.toggle("live", authenticated);
+      liveLabel.textContent = authenticated ? "Live" : "Locked";
+      logoutButton.classList.toggle("hidden", !authenticated);
+      sessionCopy.textContent = authenticated
+        ? "The console is using the authenticated management API through a same-origin session cookie."
+        : "Sign in with the management API key to unlock the dashboard and issue blocklist actions from the browser.";
+    }
+
+    function renderLockedState() {
+      document.getElementById("metricTotal").textContent = "0";
+      document.getElementById("metricBlocked").textContent = "0";
+      document.getElementById("metricObserved").textContent = "0";
+      document.getElementById("metricLatest").textContent = "none";
+      eventsTableBody.innerHTML = '<tr><td colspan="6" class="empty">Sign in to load recent defense decisions.</td></tr>';
+      document.getElementById("communityStatusCopy").textContent = "Waiting for session.";
+      document.getElementById("peerStatusCopy").textContent = "Waiting for session.";
+      blocklistResult.innerHTML = '<h3>Blocklist result</h3><p class="mono">No lookup performed yet.</p>';
+    }
+
+    function setBusy(isBusy) {
+      document.getElementById("loginButton").disabled = isBusy;
+      refreshButton.disabled = isBusy;
+    }
+
+    function showError(message) {
+      errorBanner.textContent = message;
+      errorBanner.classList.add("visible");
+    }
+
+    function clearError() {
+      errorBanner.textContent = "";
+      errorBanner.classList.remove("visible");
+    }
+
+    function summarizeStatus(enabled, imported, rejected, lastSuccessAtUtc, lastError) {
+      if (!enabled) {
+        return "Feature disabled.";
+      }
+
+      return `${number(imported)} imported, ${number(rejected)} rejected, last success ${lastSuccessAtUtc ? formatDate(lastSuccessAtUtc) : "never"}${lastError ? ", error: " + lastError : ""}`;
+    }
+
+    function summarizePeerStatus(peer) {
+      if (!peer.enabled) {
+        return "Feature disabled.";
+      }
+
+      return `${number(peer.importedCount)} imported, ${number(peer.blockedCount)} blocked, ${number(peer.observedCount)} observed, ${number(peer.rejectedCount)} rejected, last success ${peer.lastSuccessAtUtc ? formatDate(peer.lastSuccessAtUtc) : "never"}${peer.lastError ? ", error: " + peer.lastError : ""}`;
+    }
+
+    function number(value) {
+      return new Intl.NumberFormat().format(Number(value || 0));
+    }
+
+    function formatDate(value) {
+      return new Intl.DateTimeFormat(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short"
+      }).format(new Date(value));
+    }
+
+    function escapeHtml(value) {
+      return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+    }
+
+    refreshDashboard();
+    setInterval(() => {
+      refreshDashboard();
+    }, 30000);
+  </script>
+</body>
+</html>
+""";
+    }
+}

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -66,7 +66,8 @@
     },
     "Management": {
       "ApiKeyHeaderName": "X-API-Key",
-      "ApiKey": ""
+      "ApiKey": "",
+      "DashboardSessionHours": 8
     },
     "Intake": {
       "ApiKeyHeaderName": "X-Webhook-Key",


### PR DESCRIPTION
## Summary
- add a browser-based operator dashboard at /defense/dashboard for metrics, recent events, and manual blocklist workflows
- add cookie-backed dashboard sessions so the UI still uses the authenticated management API surface
- extend management tests and docs for the new dashboard/session flow

## Testing
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

Closes #35