### PR TITLE
Release hardening, packaging, and end-to-end coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+**/bin
+**/obj
+.venv
+env
+venv
+logs
+archives
+secrets
+*.db
+*.sqlite3
+*.log
+docker-compose.override.yml
+

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -1,0 +1,31 @@
+name: dotnet-ci
+
+on:
+  push:
+    branches:
+      - main
+      - codex/**
+      - copilot/**
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.104
+
+      - name: Restore
+        run: dotnet restore anti-scraping-defense-iis.sln
+
+      - name: Build
+        run: dotnet build anti-scraping-defense-iis.sln --no-restore
+
+      - name: Test
+        run: dotnet test anti-scraping-defense-iis.sln --no-build
+

--- a/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
+++ b/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
@@ -25,6 +25,8 @@ public sealed class DefenseEngineOptions
     public QueueOptions Queue { get; set; } = new();
 
     public TarpitOptions Tarpit { get; set; } = new();
+
+    public ObservabilityOptions Observability { get; set; } = new();
 }
 
 public sealed class RedisOptions
@@ -288,6 +290,17 @@ public sealed class TarpitOptions
     public int MarkovWordsPerParagraph { get; set; } = 36;
 
     public PostgresMarkovOptions PostgresMarkov { get; set; } = new();
+}
+
+public sealed class ObservabilityOptions
+{
+    public string ServiceName { get; set; } = "ai-scraping-defense-dotnet";
+
+    public bool EnablePrometheusEndpoint { get; set; } = true;
+
+    public string PrometheusEndpointPath { get; set; } = "/metrics";
+
+    public string OtlpEndpoint { get; set; } = string.Empty;
 }
 
 public sealed class PostgresMarkovOptions

--- a/AiScrapingDefense.IntegrationTests/AiScrapingDefense.IntegrationTests.csproj
+++ b/AiScrapingDefense.IntegrationTests/AiScrapingDefense.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Npgsql" Version="10.0.2" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.Redis" Version="4.11.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RedisBlocklistMiddlewareApp\RedisBlocklistMiddlewareApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AiScrapingDefense.IntegrationTests/DefenseStackFixture.cs
+++ b/AiScrapingDefense.IntegrationTests/DefenseStackFixture.cs
@@ -1,0 +1,280 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp;
+using RedisBlocklistMiddlewareApp.Services;
+using StackExchange.Redis;
+using Testcontainers.PostgreSql;
+using Testcontainers.Redis;
+
+namespace AiScrapingDefense.IntegrationTests;
+
+public sealed class DefenseStackFixture : IAsyncLifetime
+{
+    private readonly RedisContainer _redisContainer = new RedisBuilder("redis:7.2-alpine")
+        .Build();
+
+    private readonly PostgreSqlContainer _postgresContainer = new PostgreSqlBuilder("postgres:16-alpine")
+        .WithDatabase("markov")
+        .WithUsername("postgres")
+        .WithPassword("postgres")
+        .Build();
+
+    public string ManagementApiKey => "integration-management-key";
+
+    public string IntakeApiKey => "integration-intake-key";
+
+    public async Task InitializeAsync()
+    {
+        await _redisContainer.StartAsync();
+        await _postgresContainer.StartAsync();
+        await InitializeMarkovSchemaAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _postgresContainer.DisposeAsync();
+        await _redisContainer.DisposeAsync();
+    }
+
+    public async Task<IntegrationTestHost> CreateHostAsync()
+    {
+        const int redisDatabaseBase = 0;
+        var auditDirectory = Path.Combine(Path.GetTempPath(), "ai-scraping-defense-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(auditDirectory);
+        var auditDatabasePath = Path.Combine(auditDirectory, "defense-events.db");
+
+        await using var redis = await ConnectionMultiplexer.ConnectAsync(_redisContainer.GetConnectionString());
+        await redis.GetDatabase(redisDatabaseBase).ExecuteAsync("FLUSHDB");
+        await redis.GetDatabase(redisDatabaseBase + 1).ExecuteAsync("FLUSHDB");
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:RedisConnection"] = _redisContainer.GetConnectionString(),
+            ["DefenseEngine:Redis:ConnectionString"] = _redisContainer.GetConnectionString(),
+            ["DefenseEngine:Redis:BlocklistDatabase"] = redisDatabaseBase.ToString(),
+            ["DefenseEngine:Redis:FrequencyDatabase"] = (redisDatabaseBase + 1).ToString(),
+            ["DefenseEngine:Redis:BlockDurationMinutes"] = "60",
+            ["DefenseEngine:Redis:FrequencyWindowSeconds"] = "60",
+            ["DefenseEngine:Heuristics:BlockScoreThreshold"] = "80",
+            ["DefenseEngine:Heuristics:FrequencyBlockThreshold"] = "2",
+            ["DefenseEngine:Management:ApiKey"] = ManagementApiKey,
+            ["DefenseEngine:Intake:ApiKey"] = IntakeApiKey,
+            ["DefenseEngine:Audit:DatabasePath"] = auditDatabasePath,
+            ["DefenseEngine:Tarpit:ResponseDelayMilliseconds"] = "0",
+            ["DefenseEngine:Tarpit:PostgresMarkov:Enabled"] = "true",
+            ["DefenseEngine:Tarpit:PostgresMarkov:ConnectionString"] = _postgresContainer.GetConnectionString(),
+            ["DefenseEngine:PeerSync:Enabled"] = "false",
+            ["DefenseEngine:CommunityBlocklist:Enabled"] = "false",
+            ["DefenseEngine:Observability:EnablePrometheusEndpoint"] = "false"
+        };
+
+        var factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Development");
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(settings);
+                });
+                builder.ConfigureServices(services =>
+                {
+                    services.RemoveAll<IClientIpResolver>();
+                    services.AddSingleton<IClientIpResolver, HeaderDrivenClientIpResolver>();
+                    services.PostConfigure<DefenseEngineOptions>(options =>
+                    {
+                        options.Redis.ConnectionString = _redisContainer.GetConnectionString();
+                        options.Redis.BlocklistDatabase = redisDatabaseBase;
+                        options.Redis.FrequencyDatabase = redisDatabaseBase + 1;
+                        options.Redis.BlockDurationMinutes = 60;
+                        options.Redis.FrequencyWindowSeconds = 60;
+                        options.Heuristics.BlockScoreThreshold = 80;
+                        options.Heuristics.FrequencyBlockThreshold = 2;
+                        options.Management.ApiKey = ManagementApiKey;
+                        options.Intake.ApiKey = IntakeApiKey;
+                        options.Audit.DatabasePath = auditDatabasePath;
+                        options.Tarpit.ResponseDelayMilliseconds = 0;
+                        options.Tarpit.PostgresMarkov.Enabled = true;
+                        options.Tarpit.PostgresMarkov.ConnectionString = _postgresContainer.GetConnectionString();
+                        options.PeerSync.Enabled = false;
+                        options.CommunityBlocklist.Enabled = false;
+                        options.Observability.EnablePrometheusEndpoint = false;
+                    });
+                });
+            });
+
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var runtimeOptions = factory.Services.GetRequiredService<IOptions<DefenseEngineOptions>>().Value;
+        if (runtimeOptions.Management.ApiKey != ManagementApiKey || runtimeOptions.Intake.ApiKey != IntakeApiKey)
+        {
+            throw new InvalidOperationException("Integration host did not apply the expected management/intake API key configuration.");
+        }
+
+        var routeEndpoints = factory.Services
+            .GetServices<EndpointDataSource>()
+            .SelectMany(dataSource => dataSource.Endpoints)
+            .OfType<RouteEndpoint>()
+            .ToArray();
+
+        var routePatterns = routeEndpoints
+            .Select(endpoint => endpoint.RoutePattern.RawText)
+            .Where(pattern => !string.IsNullOrWhiteSpace(pattern))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        static bool HasHttpMethod(IEnumerable<RouteEndpoint> endpoints, string routePattern, string method)
+        {
+            return endpoints
+                .Where(endpoint => string.Equals(endpoint.RoutePattern.RawText, routePattern, StringComparison.OrdinalIgnoreCase))
+                .Select(endpoint => endpoint.Metadata.GetMetadata<HttpMethodMetadata>())
+                .Where(metadata => metadata is not null)
+                .Any(metadata => metadata!.HttpMethods.Contains(method, StringComparer.OrdinalIgnoreCase));
+        }
+
+        if (!routePatterns.Contains("/defense/blocklist") ||
+            !routePatterns.Contains("/analyze") ||
+            !HasHttpMethod(routeEndpoints, "/defense/blocklist", "POST") ||
+            !HasHttpMethod(routeEndpoints, "/defense/blocklist", "GET") ||
+            !HasHttpMethod(routeEndpoints, "/defense/blocklist", "DELETE") ||
+            !HasHttpMethod(routeEndpoints, "/analyze", "POST"))
+        {
+            throw new InvalidOperationException("Integration host did not register the expected management and intake endpoints.");
+        }
+
+        using (var eventsProbe = new HttpRequestMessage(HttpMethod.Get, "/defense/events?count=1"))
+        {
+            eventsProbe.Headers.Add("X-API-Key", ManagementApiKey);
+            var response = await client.SendAsync(eventsProbe);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException(
+                    $"Management events probe failed with {(int)response.StatusCode} {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+            }
+        }
+
+        using (var blockStatusProbe = new HttpRequestMessage(HttpMethod.Get, "/defense/blocklist?ip=198.51.100.200"))
+        {
+            blockStatusProbe.Headers.Add("X-API-Key", ManagementApiKey);
+            var response = await client.SendAsync(blockStatusProbe);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException(
+                    $"Management blocklist probe failed with {(int)response.StatusCode} {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+            }
+        }
+
+        using (var intakeProbe = new HttpRequestMessage(HttpMethod.Post, "/analyze")
+        {
+            Content = JsonContent.Create(new
+            {
+                event_type = "probe",
+                reason = "integration_probe",
+                timestamp_utc = DateTimeOffset.UtcNow,
+                details = new
+                {
+                    ip = "not-an-ip",
+                    method = "GET",
+                    path = "/probe",
+                    query_string = "",
+                    user_agent = "integration-probe",
+                    signals = Array.Empty<string>()
+                }
+            })
+        })
+        {
+            intakeProbe.Headers.Add("X-Webhook-Key", IntakeApiKey);
+            var response = await client.SendAsync(intakeProbe);
+            if (response.StatusCode != HttpStatusCode.BadRequest)
+            {
+                throw new InvalidOperationException(
+                    $"Intake probe failed with {(int)response.StatusCode} {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+            }
+        }
+
+        return new IntegrationTestHost(factory, client, auditDatabasePath);
+    }
+
+    private async Task InitializeMarkovSchemaAsync()
+    {
+        var sql = await File.ReadAllTextAsync(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "db", "init_markov.sql"));
+
+        await using var connection = new NpgsqlConnection(_postgresContainer.GetConnectionString());
+        await connection.OpenAsync();
+        await using (var command = new NpgsqlCommand(sql, connection))
+        {
+            await command.ExecuteNonQueryAsync();
+        }
+
+        const string seedSql =
+            """
+            INSERT INTO markov_words (word)
+            VALUES ('clockwork'), ('lemur'), ('taxonomy'), ('drift')
+            ON CONFLICT (word) DO NOTHING;
+
+            WITH words AS (
+                SELECT id, word FROM markov_words
+            ),
+            empty_word AS (
+                SELECT id FROM words WHERE word = ''
+            ),
+            clockwork_word AS (
+                SELECT id FROM words WHERE word = 'clockwork'
+            ),
+            lemur_word AS (
+                SELECT id FROM words WHERE word = 'lemur'
+            ),
+            taxonomy_word AS (
+                SELECT id FROM words WHERE word = 'taxonomy'
+            ),
+            drift_word AS (
+                SELECT id FROM words WHERE word = 'drift'
+            )
+            INSERT INTO markov_sequences (p1, p2, next_id, freq)
+            VALUES
+                ((SELECT id FROM empty_word), (SELECT id FROM empty_word), (SELECT id FROM clockwork_word), 50),
+                ((SELECT id FROM empty_word), (SELECT id FROM clockwork_word), (SELECT id FROM lemur_word), 50),
+                ((SELECT id FROM clockwork_word), (SELECT id FROM lemur_word), (SELECT id FROM taxonomy_word), 50),
+                ((SELECT id FROM lemur_word), (SELECT id FROM taxonomy_word), (SELECT id FROM drift_word), 50),
+                ((SELECT id FROM taxonomy_word), (SELECT id FROM drift_word), (SELECT id FROM clockwork_word), 50)
+            ON CONFLICT (p1, p2, next_id)
+            DO UPDATE SET freq = EXCLUDED.freq;
+            """;
+
+        await using var seedCommand = new NpgsqlCommand(seedSql, connection);
+        await seedCommand.ExecuteNonQueryAsync();
+    }
+}
+
+public sealed class IntegrationTestHost : IAsyncDisposable
+{
+    public IntegrationTestHost(WebApplicationFactory<Program> factory, HttpClient client, string auditDatabasePath)
+    {
+        Factory = factory;
+        Client = client;
+        AuditDatabasePath = auditDatabasePath;
+    }
+
+    public WebApplicationFactory<Program> Factory { get; }
+
+    public HttpClient Client { get; }
+
+    public string AuditDatabasePath { get; }
+
+    public ValueTask DisposeAsync()
+    {
+        Client.Dispose();
+        Factory.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/AiScrapingDefense.IntegrationTests/EndToEndCollection.cs
+++ b/AiScrapingDefense.IntegrationTests/EndToEndCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace AiScrapingDefense.IntegrationTests;
+
+[CollectionDefinition(Name)]
+public sealed class EndToEndCollection : ICollectionFixture<DefenseStackFixture>
+{
+    public const string Name = "end-to-end";
+}

--- a/AiScrapingDefense.IntegrationTests/EndToEndFlowTests.cs
+++ b/AiScrapingDefense.IntegrationTests/EndToEndFlowTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace AiScrapingDefense.IntegrationTests;
+
+[Collection(EndToEndCollection.Name)]
+public sealed class EndToEndFlowTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly DefenseStackFixture _fixture;
+
+    public EndToEndFlowTests(DefenseStackFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task SuspiciousRequests_AreAnalyzed_AndEventuallyBlocked()
+    {
+        await using var host = await _fixture.CreateHostAsync();
+        var client = host.Client;
+
+        using var suspiciousRequest = new HttpRequestMessage(HttpMethod.Get, "/docs");
+        suspiciousRequest.Headers.Add(HeaderDrivenClientIpResolver.HeaderName, "198.51.100.51");
+        suspiciousRequest.Headers.UserAgent.ParseAdd("Mozilla/5.0");
+        suspiciousRequest.Headers.Accept.ParseAdd("*/*");
+        var firstResponse = await client.SendAsync(suspiciousRequest);
+
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        Assert.Equal("text/html", firstResponse.Content.Headers.ContentType?.MediaType);
+
+        using var secondRequest = new HttpRequestMessage(HttpMethod.Get, "/docs");
+        secondRequest.Headers.Add(HeaderDrivenClientIpResolver.HeaderName, "198.51.100.51");
+        secondRequest.Headers.UserAgent.ParseAdd("Mozilla/5.0");
+        secondRequest.Headers.Accept.ParseAdd("*/*");
+        var secondResponse = await client.SendAsync(secondRequest);
+
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+
+        var blockedDecision = await WaitForAsync(async () =>
+        {
+            var decisions = await GetEventsAsync(client);
+            return decisions.FirstOrDefault(decision => string.Equals(decision.Action, "blocked", StringComparison.OrdinalIgnoreCase));
+        });
+
+        Assert.NotNull(blockedDecision);
+
+        var blockStatus = await GetBlockStatusAsync(client, blockedDecision!.IpAddress);
+        Assert.True(blockStatus.Blocked);
+
+        using var thirdRequest = new HttpRequestMessage(HttpMethod.Get, "/docs");
+        thirdRequest.Headers.Add(HeaderDrivenClientIpResolver.HeaderName, "198.51.100.51");
+        thirdRequest.Headers.UserAgent.ParseAdd("Mozilla/5.0");
+        thirdRequest.Headers.Accept.ParseAdd("*/*");
+        var deniedResponse = await client.SendAsync(thirdRequest);
+
+        Assert.Equal(HttpStatusCode.Forbidden, deniedResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task ManualBlocklistEndpoints_Block_And_Unblock()
+    {
+        await using var host = await _fixture.CreateHostAsync();
+        var client = host.Client;
+        const string ipAddress = "198.51.100.44";
+
+        using var blockRequest = CreateManagementRequest(HttpMethod.Post, $"/defense/blocklist?ip={Uri.EscapeDataString(ipAddress)}&reason=manual_test");
+        var blockResponse = await client.SendAsync(blockRequest);
+        Assert.True(
+            blockResponse.StatusCode == HttpStatusCode.Accepted,
+            $"Expected Accepted but received {(int)blockResponse.StatusCode} {blockResponse.StatusCode}: {await blockResponse.Content.ReadAsStringAsync()}");
+
+        var blockedStatus = await GetBlockStatusAsync(client, ipAddress);
+        Assert.True(blockedStatus.Blocked);
+
+        using var unblockRequest = CreateManagementRequest(HttpMethod.Delete, $"/defense/blocklist?ip={Uri.EscapeDataString(ipAddress)}");
+        var unblockResponse = await client.SendAsync(unblockRequest);
+        Assert.Equal(HttpStatusCode.OK, unblockResponse.StatusCode);
+
+        var unblockedStatus = await GetBlockStatusAsync(client, ipAddress);
+        Assert.False(unblockedStatus.Blocked);
+    }
+
+    [Fact]
+    public async Task WebhookIntake_BlocksIp_AndPersistsDecision()
+    {
+        await using var host = await _fixture.CreateHostAsync();
+        var client = host.Client;
+        const string ipAddress = "198.51.100.77";
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/analyze")
+        {
+            Content = JsonContent.Create(new
+            {
+                event_type = "ml_verdict",
+                reason = "confirmed_bot",
+                timestamp_utc = DateTimeOffset.UtcNow,
+                details = new
+                {
+                    ip = ipAddress,
+                    method = "GET",
+                    path = "/pricing",
+                    query_string = "",
+                    user_agent = "integration-test",
+                    signals = new[] { "model_positive" }
+                }
+            })
+        };
+        request.Headers.Add("X-Webhook-Key", _fixture.IntakeApiKey);
+
+        var response = await client.SendAsync(request);
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Accepted,
+            $"Expected Accepted but received {(int)response.StatusCode} {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+
+        var blockStatus = await WaitForAsync(async () =>
+        {
+            var status = await GetBlockStatusAsync(client, ipAddress);
+            return status.Blocked ? status : null;
+        });
+
+        Assert.NotNull(blockStatus);
+
+        var decisions = await GetEventsAsync(client);
+        Assert.Contains(decisions, decision => decision.IpAddress == ipAddress && decision.Signals.Contains("model_positive"));
+    }
+
+    [Fact]
+    public async Task Tarpit_UsesPostgresMarkovCorpus_WhenEnabled()
+    {
+        await using var host = await _fixture.CreateHostAsync();
+        var client = host.Client;
+
+        var response = await client.GetAsync("/anti-scrape-tarpit/reference/manual");
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains("clockwork", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<IReadOnlyList<DefenseDecisionDto>> GetEventsAsync(HttpClient client)
+    {
+        using var request = CreateManagementRequest(HttpMethod.Get, "/defense/events?count=20");
+        var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<IReadOnlyList<DefenseDecisionDto>>(JsonOptions) ?? [];
+    }
+
+    private async Task<BlockStatusDto> GetBlockStatusAsync(HttpClient client, string ipAddress)
+    {
+        using var request = CreateManagementRequest(HttpMethod.Get, $"/defense/blocklist?ip={Uri.EscapeDataString(ipAddress)}");
+        var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<BlockStatusDto>(JsonOptions))!;
+    }
+
+    private HttpRequestMessage CreateManagementRequest(HttpMethod method, string uri)
+    {
+        var request = new HttpRequestMessage(method, uri);
+        request.Headers.Add("X-API-Key", _fixture.ManagementApiKey);
+        return request;
+    }
+
+    private static async Task<T?> WaitForAsync<T>(Func<Task<T?>> action)
+        where T : class
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var result = await action();
+            if (result is not null)
+            {
+                return result;
+            }
+
+            await Task.Delay(200);
+        }
+
+        return null;
+    }
+
+    private sealed record BlockStatusDto(string Ip, bool Blocked);
+
+    private sealed record DefenseDecisionDto(
+        string IpAddress,
+        string Action,
+        int Score,
+        long Frequency,
+        string Path,
+        IReadOnlyList<string> Signals,
+        string Summary);
+}

--- a/AiScrapingDefense.IntegrationTests/HeaderDrivenClientIpResolver.cs
+++ b/AiScrapingDefense.IntegrationTests/HeaderDrivenClientIpResolver.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace AiScrapingDefense.IntegrationTests;
+
+internal sealed class HeaderDrivenClientIpResolver : IClientIpResolver
+{
+    public const string HeaderName = "X-Integration-Client-IP";
+
+    public string? Resolve(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(HeaderName, out var suppliedIp) &&
+            IPAddress.TryParse(suppliedIp.ToString(), out var parsedFromHeader))
+        {
+            return parsedFromHeader.IsIPv4MappedToIPv6
+                ? parsedFromHeader.MapToIPv4().ToString()
+                : parsedFromHeader.ToString();
+        }
+
+        var remoteIp = context.Connection.RemoteIpAddress;
+        if (remoteIp is null)
+        {
+            return "198.51.100.150";
+        }
+
+        return remoteIp.IsIPv4MappedToIPv6
+            ? remoteIp.MapToIPv4().ToString()
+            : remoteIp.ToString();
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Containerized deployment artifacts for the .NET runtime (`Dockerfile`, `compose.yaml`).
+* A GitHub Actions workflow that restores, builds, and tests the solution on every push and pull request.
+* A containerized integration-test project covering suspicious request handling, management blocklist operations, webhook intake, and PostgreSQL-backed tarpit rendering.
+* Prometheus/OTLP observability options and runtime instrumentation for defense decisions, tarpit responses, webhook intake, and sync activity.
+* Release documentation for parity, operator operations, and release validation.
+
+### Changed
+
+* Suspicious requests now render tarpit responses directly from middleware instead of relying on late path rewrites.
+* The fallback 404 path now uses `MapFallback` so routed endpoints remain reachable in real hosts and test hosts.
+* Operator and intake endpoints are explicitly bypassed by edge inspection to avoid tarpitting internal control surfaces.
+
 ## [0.0.3] - 2025-04-22
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY . .
+RUN mv global.json /tmp/global.json \
+    && dotnet restore anti-scraping-defense-iis.sln \
+    && dotnet publish RedisBlocklistMiddlewareApp/RedisBlocklistMiddlewareApp.csproj \
+        -c Release \
+        -o /app/publish \
+        /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+
+ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_ENVIRONMENT=Production
+
+COPY --from=build /app/publish .
+RUN mkdir -p /app/data
+
+VOLUME ["/app/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "AiScrapingDefense.EdgeGateway.dll"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The first commercial release is a single deployable ASP.NET Core service that pr
 This is intentionally a single-deployable, multi-project .NET stack for v1. It preserves the upstream functional roles, but keeps them in one runtime deployment until separate service contracts and operational behavior settle.
 
 See [docs/architecture.md](docs/architecture.md) for the current architecture, [docs/commercial_scope.md](docs/commercial_scope.md) for the v1 definition, and [docs/dotnet_parity_roadmap.md](docs/dotnet_parity_roadmap.md) for the post-v1 parity queue.
+Operational release documentation now lives in [docs/parity_matrix.md](docs/parity_matrix.md), [docs/operator_runbook.md](docs/operator_runbook.md), and [docs/release_checklist.md](docs/release_checklist.md).
 
 ## Implemented Endpoints
 
@@ -114,6 +115,7 @@ Key areas:
 - `DefenseEngine:PeerSync`
 - `DefenseEngine:Queue`
 - `DefenseEngine:Tarpit`
+- `DefenseEngine:Observability`
 
 For direct edge deployments, leave `DefenseEngine:Networking:ClientIpResolutionMode` as `Direct`. If the app is behind a reverse proxy or CDN, switch it to `TrustedProxy` and populate `DefenseEngine:Networking:TrustedProxies` with the proxy IPs you explicitly trust.
 
@@ -124,3 +126,13 @@ In `Production`, startup now fails fast if Redis still points at a loopback endp
 ## Status
 
 The project now has an explicit commercial-v1 target, but release readiness still depends on closing the remaining items in [docs/release_blockers.md](docs/release_blockers.md) and the post-v1 parity queue in [docs/dotnet_parity_roadmap.md](docs/dotnet_parity_roadmap.md).
+
+## Packaging
+
+The repository now includes:
+
+- a production-oriented multi-stage [Dockerfile](Dockerfile)
+- a local smoke/deployment [compose.yaml](compose.yaml)
+- a GitHub Actions CI workflow at [.github/workflows/dotnet-ci.yml](.github/workflows/dotnet-ci.yml)
+
+Use `docker compose up --build` for a quick end-to-end environment with Redis and PostgreSQL.

--- a/RedisBlocklistMiddlewareApp.Tests/CommunityBlocklistSyncRunnerTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/CommunityBlocklistSyncRunnerTests.cs
@@ -33,6 +33,7 @@ public sealed class CommunityBlocklistSyncRunnerTests
             new TestFeedClient(["198.51.100.10", "127.0.0.1", "not-an-ip"]),
             blocklist,
             statusStore,
+            TestTelemetryFactory.Create(),
             NullLogger<CommunityBlocklistSyncRunner>.Instance);
 
         var status = await runner.RunOnceAsync(CancellationToken.None);
@@ -64,6 +65,7 @@ public sealed class CommunityBlocklistSyncRunnerTests
             new TestFeedClient([]),
             new TestBlocklistService(),
             new CommunityBlocklistSyncStatusStore(options),
+            TestTelemetryFactory.Create(),
             NullLogger<CommunityBlocklistSyncRunner>.Instance);
 
         var status = await runner.RunOnceAsync(CancellationToken.None);
@@ -97,6 +99,7 @@ public sealed class CommunityBlocklistSyncRunnerTests
             new CancelingFeedClient(),
             new TestBlocklistService(),
             new CommunityBlocklistSyncStatusStore(options),
+            TestTelemetryFactory.Create(),
             NullLogger<CommunityBlocklistSyncRunner>.Instance);
 
         await Assert.ThrowsAsync<OperationCanceledException>(() => runner.RunOnceAsync(cancellationTokenSource.Token));
@@ -127,6 +130,7 @@ public sealed class CommunityBlocklistSyncRunnerTests
             new TestFeedClient(["198.51.100.1", "198.51.100.2", "198.51.100.3", "198.51.100.4"]),
             blocklist,
             new CommunityBlocklistSyncStatusStore(options),
+            TestTelemetryFactory.Create(),
             NullLogger<CommunityBlocklistSyncRunner>.Instance);
 
         var status = await runner.RunOnceAsync(CancellationToken.None);

--- a/RedisBlocklistMiddlewareApp.Tests/PeerSyncRunnerTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/PeerSyncRunnerTests.cs
@@ -29,6 +29,7 @@ public sealed class PeerSyncRunnerTests
             blocklist,
             eventStore,
             new PeerSyncStatusStore(options),
+            TestTelemetryFactory.Create(),
             NullLogger<PeerSyncRunner>.Instance);
 
         var status = await runner.RunOnceAsync(CancellationToken.None);
@@ -62,6 +63,7 @@ public sealed class PeerSyncRunnerTests
             blocklist,
             eventStore,
             new PeerSyncStatusStore(options),
+            TestTelemetryFactory.Create(),
             NullLogger<PeerSyncRunner>.Instance);
 
         var status = await runner.RunOnceAsync(CancellationToken.None);
@@ -92,6 +94,7 @@ public sealed class PeerSyncRunnerTests
             blocklist,
             eventStore,
             new PeerSyncStatusStore(options),
+            TestTelemetryFactory.Create(),
             NullLogger<PeerSyncRunner>.Instance);
 
         var status = await runner.RunOnceAsync(CancellationToken.None);
@@ -118,6 +121,7 @@ public sealed class PeerSyncRunnerTests
             blocklist,
             eventStore,
             new PeerSyncStatusStore(options),
+            TestTelemetryFactory.Create(),
             NullLogger<PeerSyncRunner>.Instance);
 
         var status = await runner.RunOnceAsync(CancellationToken.None);
@@ -162,6 +166,7 @@ public sealed class PeerSyncRunnerTests
             blocklist,
             new TestDefenseEventStore(),
             new PeerSyncStatusStore(options),
+            TestTelemetryFactory.Create(),
             NullLogger<PeerSyncRunner>.Instance);
 
         var status = await runner.RunOnceAsync(CancellationToken.None);

--- a/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
@@ -61,6 +61,54 @@ public sealed class RedisBlocklistMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_BypassesIntakeEndpoints()
+    {
+        var blocklist = new FakeBlocklistService { IsBlockedResult = true };
+        var queue = new FakeSuspiciousRequestQueue();
+        var eventStore = new FakeDefenseEventStore();
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            blocklist,
+            new FakeRequestSignalEvaluator(new RequestSignalEvaluation(false, string.Empty, [])),
+            queue,
+            eventStore,
+            new FakeClientIpResolver("198.51.100.13"));
+        var context = CreateContext("/analyze");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextState.WasCalled);
+        Assert.Equal(0, blocklist.IsBlockedCallCount);
+        Assert.Empty(queue.Requests);
+        Assert.Empty(eventStore.Decisions);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_BypassesPeerSyncEndpoints()
+    {
+        var blocklist = new FakeBlocklistService { IsBlockedResult = true };
+        var queue = new FakeSuspiciousRequestQueue();
+        var eventStore = new FakeDefenseEventStore();
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            blocklist,
+            new FakeRequestSignalEvaluator(new RequestSignalEvaluation(false, string.Empty, [])),
+            queue,
+            eventStore,
+            new FakeClientIpResolver("198.51.100.14"));
+        var context = CreateContext("/peer-sync/signals");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextState.WasCalled);
+        Assert.Equal(0, blocklist.IsBlockedCallCount);
+        Assert.Empty(queue.Requests);
+        Assert.Empty(eventStore.Decisions);
+    }
+
+    [Fact]
     public async Task InvokeAsync_BypassesTarpitEndpoints()
     {
         var blocklist = new FakeBlocklistService { IsBlockedResult = true };
@@ -134,7 +182,7 @@ public sealed class RedisBlocklistMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeAsync_QueuesSuspiciousRequests_AndRewritesIntoTarpit()
+    public async Task InvokeAsync_QueuesSuspiciousRequests_AndRendersTarpit()
     {
         var queue = new FakeSuspiciousRequestQueue();
         var nextState = new NextDelegateState();
@@ -153,8 +201,9 @@ public sealed class RedisBlocklistMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        Assert.True(nextState.WasCalled);
-        Assert.Equal("/anti-scrape-tarpit/probe", nextState.PathSeenByNext);
+        Assert.False(nextState.WasCalled);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Equal("text/html", context.Response.ContentType);
         Assert.Single(queue.Requests);
         Assert.Equal("/probe", queue.Requests[0].Path);
         Assert.Equal("missing_accept_language", context.Request.Headers["X-Tarpit-Reason"].ToString());
@@ -214,6 +263,8 @@ public sealed class RedisBlocklistMiddlewareTests
             queue,
             eventStore,
             clientIpResolver,
+            new FakeTarpitPageService(),
+            TestTelemetryFactory.Create(),
             Options.Create(options));
     }
 
@@ -333,6 +384,14 @@ public sealed class RedisBlocklistMiddlewareTests
         public string? Resolve(HttpContext context)
         {
             return _ipAddress;
+        }
+    }
+
+    private sealed class FakeTarpitPageService : ITarpitPageService
+    {
+        public string GeneratePage(string path, string clientIp)
+        {
+            return $"<html><body>{path}:{clientIp}</body></html>";
         }
     }
 }

--- a/RedisBlocklistMiddlewareApp.Tests/TestTelemetryFactory.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/TestTelemetryFactory.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+internal static class TestTelemetryFactory
+{
+    public static DefenseTelemetry Create()
+    {
+        return new DefenseTelemetry(Options.Create(new DefenseEngineOptions()));
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/WebhookIntakeProcessingServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/WebhookIntakeProcessingServiceTests.cs
@@ -17,6 +17,7 @@ public sealed class WebhookIntakeProcessingServiceTests
             inbox,
             blocklist,
             eventStore,
+            TestTelemetryFactory.Create(),
             NullLogger<WebhookIntakeProcessingService>.Instance);
 
         await inbox.EnqueueAsync(new WebhookInboxItem(

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -2,6 +2,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Prometheus;
 using RedisBlocklistMiddlewareApp;
 using RedisBlocklistMiddlewareApp.Configuration;
 using RedisBlocklistMiddlewareApp.Models;
@@ -56,6 +60,13 @@ builder.Services
             ? "markov_sequences"
             : options.Tarpit.PostgresMarkov.SequencesTableName.Trim();
         options.Tarpit.PostgresMarkov.RefreshMinutes = Math.Max(1, options.Tarpit.PostgresMarkov.RefreshMinutes);
+        options.Observability.ServiceName = string.IsNullOrWhiteSpace(options.Observability.ServiceName)
+            ? "ai-scraping-defense-dotnet"
+            : options.Observability.ServiceName.Trim();
+        options.Observability.PrometheusEndpointPath = string.IsNullOrWhiteSpace(options.Observability.PrometheusEndpointPath)
+            ? "/metrics"
+            : NormalizeObservabilityPath(options.Observability.PrometheusEndpointPath);
+        options.Observability.OtlpEndpoint = options.Observability.OtlpEndpoint.Trim();
 
         options.Management.ApiKeyHeaderName = string.IsNullOrWhiteSpace(options.Management.ApiKeyHeaderName)
             ? "X-API-Key"
@@ -170,6 +181,29 @@ builder.Services
     });
 
 builder.Services.AddSingleton<IConfigureOptions<ForwardedHeadersOptions>, ForwardedHeadersOptionsSetup>();
+builder.Services.AddSingleton<DefenseTelemetry>();
+
+var observabilityOptions = builder.Configuration
+    .GetSection(DefenseEngineOptions.SectionName)
+    .Get<DefenseEngineOptions>()?.Observability ?? new ObservabilityOptions();
+var otlpEndpoint = observabilityOptions.OtlpEndpoint?.Trim() ?? string.Empty;
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService(observabilityOptions.ServiceName))
+    .WithTracing(tracing =>
+    {
+        tracing
+            .AddSource(DefenseTelemetry.ActivitySourceName)
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation();
+
+        if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+        {
+            tracing.AddOtlpExporter(options =>
+            {
+                options.Endpoint = new Uri(otlpEndpoint);
+            });
+        }
+    });
 
 builder.Services.AddSingleton<IRedisConnectionProvider, RedisConnectionProvider>();
 builder.Services.AddSingleton<IBlocklistService, RedisBlocklistService>();
@@ -214,6 +248,12 @@ if (Program.ShouldUseForwardedHeaders(runtimeOptions))
 
 app.UseMiddleware<RedisBlocklistMiddleware>();
 
+if (runtimeOptions.Observability.EnablePrometheusEndpoint)
+{
+    app.UseHttpMetrics();
+    app.MapMetrics(runtimeOptions.Observability.PrometheusEndpointPath);
+}
+
 app.MapGet("/", () => Results.Ok(new
 {
     service = "ai-scraping-defense-dotnet",
@@ -255,6 +295,7 @@ app.MapGet(tarpitRoutePattern, async (
     string? path,
     ITarpitPageService tarpitPageService,
     IClientIpResolver clientIpResolver,
+    DefenseTelemetry telemetry,
     IOptions<DefenseEngineOptions> options,
     CancellationToken cancellationToken) =>
 {
@@ -267,10 +308,11 @@ app.MapGet(tarpitRoutePattern, async (
 
     var clientIp = clientIpResolver.Resolve(context) ?? "unknown";
     var content = tarpitPageService.GeneratePage(path ?? string.Empty, clientIp);
+    telemetry.RecordTarpitRender();
     return Results.Content(content, "text/html");
 });
 
-app.Run(async context =>
+app.MapFallback(async context =>
 {
     context.Response.StatusCode = StatusCodes.Status404NotFound;
     await context.Response.WriteAsync("Endpoint not found.");
@@ -480,6 +522,7 @@ public partial class Program
         app.MapPost("/analyze", async (
             IntakeWebhookEvent webhookEvent,
             IWebhookEventInbox inbox,
+            [FromServices] DefenseTelemetry telemetry,
             CancellationToken cancellationToken) =>
         {
             if (!TryNormalizeIpAddress(webhookEvent.Details.IpAddress, out var normalizedIp))
@@ -499,6 +542,7 @@ public partial class Program
             };
 
             var itemId = await inbox.EnqueueAsync(normalizedEvent, cancellationToken);
+            telemetry.RecordWebhookAccepted();
 
             return Results.Accepted($"/analyze/{itemId}", new
             {
@@ -583,5 +627,12 @@ public partial class Program
 
         normalizedIp = address.ToString();
         return true;
+    }
+
+    private static string NormalizeObservabilityPath(string path)
+    {
+        return path.StartsWith("/", StringComparison.Ordinal)
+            ? path.TrimEnd('/')
+            : "/" + path.Trim().TrimEnd('/');
     }
 }

--- a/RedisBlocklistMiddlewareApp/RedisBlocklistMiddleware.cs
+++ b/RedisBlocklistMiddlewareApp/RedisBlocklistMiddleware.cs
@@ -16,6 +16,8 @@ public sealed class RedisBlocklistMiddleware
     private readonly ISuspiciousRequestQueue _queue;
     private readonly IDefenseEventStore _eventStore;
     private readonly IClientIpResolver _clientIpResolver;
+    private readonly ITarpitPageService _tarpitPageService;
+    private readonly DefenseTelemetry _telemetry;
     private readonly DefenseEngineOptions _options;
 
     public RedisBlocklistMiddleware(
@@ -26,6 +28,8 @@ public sealed class RedisBlocklistMiddleware
         ISuspiciousRequestQueue queue,
         IDefenseEventStore eventStore,
         IClientIpResolver clientIpResolver,
+        ITarpitPageService tarpitPageService,
+        DefenseTelemetry telemetry,
         IOptions<DefenseEngineOptions> options)
     {
         _next = next;
@@ -35,6 +39,8 @@ public sealed class RedisBlocklistMiddleware
         _queue = queue;
         _eventStore = eventStore;
         _clientIpResolver = clientIpResolver;
+        _tarpitPageService = tarpitPageService;
+        _telemetry = telemetry;
         _options = options.Value;
     }
 
@@ -56,6 +62,7 @@ public sealed class RedisBlocklistMiddleware
         if (await _blocklistService.IsBlockedAsync(ipAddress, context.RequestAborted))
         {
             _logger.LogWarning("Blocking request from IP {IpAddress} via Redis blocklist.", ipAddress);
+            _telemetry.RecordDecision("blocked", "redis_blocklist");
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             await context.Response.WriteAsync("Access denied.");
             return;
@@ -64,6 +71,10 @@ public sealed class RedisBlocklistMiddleware
         var evaluation = _signalEvaluator.Evaluate(context);
         if (evaluation.BlockImmediately)
         {
+            using var activity = _telemetry.StartActivity("edge.immediate_block");
+            activity?.SetTag("ip", ipAddress);
+            activity?.SetTag("reason", evaluation.BlockReason);
+
             await _blocklistService.BlockAsync(
                 ipAddress,
                 evaluation.BlockReason,
@@ -93,6 +104,7 @@ public sealed class RedisBlocklistMiddleware
                             "Edge heuristics produced an immediate block verdict.")
                     ])));
 
+            _telemetry.RecordDecision("blocked", "edge_heuristics");
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             await context.Response.WriteAsync("Access denied.");
             return;
@@ -100,6 +112,7 @@ public sealed class RedisBlocklistMiddleware
 
         if (evaluation.Signals.Count > 0)
         {
+            _telemetry.RecordSuspiciousRequest(evaluation.Signals[0]);
             var queued = await _queue.QueueAsync(
                 new SuspiciousRequest(
                     ipAddress,
@@ -120,12 +133,14 @@ public sealed class RedisBlocklistMiddleware
 
             if (_options.Heuristics.TarpitSuspiciousRequests)
             {
-                var originalPath = context.Request.Path.HasValue
-                    ? context.Request.Path.Value!
-                    : "/";
-
+                var originalPath = context.Request.Path.HasValue ? context.Request.Path.Value! : "/";
                 context.Request.Headers["X-Tarpit-Reason"] = string.Join(';', evaluation.Signals);
-                context.Request.Path = new PathString($"{_options.Tarpit.PathPrefix}{originalPath}");
+                var content = _tarpitPageService.GeneratePage(originalPath, ipAddress);
+                _telemetry.RecordTarpitRender();
+                context.Response.StatusCode = StatusCodes.Status200OK;
+                context.Response.ContentType = "text/html";
+                await context.Response.WriteAsync(content, context.RequestAborted);
+                return;
             }
         }
 
@@ -137,6 +152,8 @@ public sealed class RedisBlocklistMiddleware
         var value = path.Value ?? string.Empty;
         return value.StartsWith(_options.Tarpit.PathPrefix, StringComparison.OrdinalIgnoreCase) ||
                value.StartsWith("/health", StringComparison.OrdinalIgnoreCase) ||
-               value.StartsWith("/defense", StringComparison.OrdinalIgnoreCase);
+               value.StartsWith("/defense", StringComparison.OrdinalIgnoreCase) ||
+               value.StartsWith("/analyze", StringComparison.OrdinalIgnoreCase) ||
+               value.StartsWith("/peer-sync", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/RedisBlocklistMiddlewareApp/RedisBlocklistMiddlewareApp.csproj
+++ b/RedisBlocklistMiddlewareApp/RedisBlocklistMiddlewareApp.csproj
@@ -10,6 +10,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.15" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.31" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>

--- a/RedisBlocklistMiddlewareApp/Services/CommunityBlocklistSyncRunner.cs
+++ b/RedisBlocklistMiddlewareApp/Services/CommunityBlocklistSyncRunner.cs
@@ -11,6 +11,7 @@ public sealed class CommunityBlocklistSyncRunner
     private readonly ICommunityBlocklistFeedClient _feedClient;
     private readonly IBlocklistService _blocklistService;
     private readonly ICommunityBlocklistSyncStatusStore _statusStore;
+    private readonly DefenseTelemetry _telemetry;
     private readonly ILogger<CommunityBlocklistSyncRunner> _logger;
 
     public CommunityBlocklistSyncRunner(
@@ -18,12 +19,14 @@ public sealed class CommunityBlocklistSyncRunner
         ICommunityBlocklistFeedClient feedClient,
         IBlocklistService blocklistService,
         ICommunityBlocklistSyncStatusStore statusStore,
+        DefenseTelemetry telemetry,
         ILogger<CommunityBlocklistSyncRunner> logger)
     {
         _options = options.Value.CommunityBlocklist;
         _feedClient = feedClient;
         _blocklistService = blocklistService;
         _statusStore = statusStore;
+        _telemetry = telemetry;
         _logger = logger;
     }
 
@@ -43,6 +46,8 @@ public sealed class CommunityBlocklistSyncRunner
         var rejectedCount = 0;
         string? lastError = null;
         DateTimeOffset? lastSuccessAtUtc = null;
+
+        using var activity = _telemetry.StartActivity("sync.community_blocklist");
 
         foreach (var source in _options.Sources)
         {
@@ -126,6 +131,7 @@ public sealed class CommunityBlocklistSyncRunner
             rejectedCount,
             lastError,
             sourceStatuses.ToArray());
+        _telemetry.RecordCommunitySync(importedCount, rejectedCount);
         _statusStore.Update(status);
         return status;
     }

--- a/RedisBlocklistMiddlewareApp/Services/DefenseAnalysisService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/DefenseAnalysisService.cs
@@ -12,6 +12,7 @@ public sealed class DefenseAnalysisService : BackgroundService
     private readonly IThreatAssessmentService _threatAssessmentService;
     private readonly IBlocklistService _blocklistService;
     private readonly IDefenseEventStore _eventStore;
+    private readonly DefenseTelemetry _telemetry;
     private readonly ILogger<DefenseAnalysisService> _logger;
 
     public DefenseAnalysisService(
@@ -19,12 +20,14 @@ public sealed class DefenseAnalysisService : BackgroundService
         IThreatAssessmentService threatAssessmentService,
         IBlocklistService blocklistService,
         IDefenseEventStore eventStore,
+        DefenseTelemetry telemetry,
         ILogger<DefenseAnalysisService> logger)
     {
         _queue = queue;
         _threatAssessmentService = threatAssessmentService;
         _blocklistService = blocklistService;
         _eventStore = eventStore;
+        _telemetry = telemetry;
         _logger = logger;
     }
 
@@ -34,6 +37,9 @@ public sealed class DefenseAnalysisService : BackgroundService
         {
             try
             {
+                using var activity = _telemetry.StartActivity("analysis.queued_request");
+                activity?.SetTag("ip", request.IpAddress);
+                activity?.SetTag("path", request.Path);
                 var assessment = await _threatAssessmentService.AssessAsync(request, stoppingToken);
                 var action = assessment.ShouldBlock ? "blocked" : "observed";
 
@@ -71,6 +77,7 @@ public sealed class DefenseAnalysisService : BackgroundService
                     request.ObservedAtUtc,
                     DateTimeOffset.UtcNow,
                     assessment.Breakdown));
+                _telemetry.RecordDecision(action, "queued_analysis");
             }
             catch (Exception ex)
             {

--- a/RedisBlocklistMiddlewareApp/Services/DefenseTelemetry.cs
+++ b/RedisBlocklistMiddlewareApp/Services/DefenseTelemetry.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Options;
+using Prometheus;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class DefenseTelemetry
+{
+    public const string ActivitySourceName = "AiScrapingDefense";
+
+    private static readonly ActivitySource SharedActivitySource = new(ActivitySourceName);
+    private static readonly Counter SuspiciousRequests = Metrics.CreateCounter(
+        "ai_scraping_defense_suspicious_requests_total",
+        "Suspicious requests observed by the edge middleware.",
+        new CounterConfiguration
+        {
+            LabelNames = ["reason"]
+        });
+    private static readonly Counter BlockDecisions = Metrics.CreateCounter(
+        "ai_scraping_defense_block_decisions_total",
+        "Defense decisions that resulted in blocking.",
+        new CounterConfiguration
+        {
+            LabelNames = ["source"]
+        });
+    private static readonly Counter ObservedDecisions = Metrics.CreateCounter(
+        "ai_scraping_defense_observed_decisions_total",
+        "Defense decisions retained without immediate blocking.",
+        new CounterConfiguration
+        {
+            LabelNames = ["source"]
+        });
+    private static readonly Counter TarpitRenders = Metrics.CreateCounter(
+        "ai_scraping_defense_tarpit_renders_total",
+        "Rendered tarpit responses.");
+    private static readonly Counter WebhookAccepted = Metrics.CreateCounter(
+        "ai_scraping_defense_webhook_intake_total",
+        "Webhook intake events accepted for durable processing.");
+    private static readonly Counter CommunityImports = Metrics.CreateCounter(
+        "ai_scraping_defense_community_imports_total",
+        "Community-blocklist import outcomes.",
+        new CounterConfiguration
+        {
+            LabelNames = ["result"]
+        });
+    private static readonly Counter PeerImports = Metrics.CreateCounter(
+        "ai_scraping_defense_peer_imports_total",
+        "Peer-sync import outcomes.",
+        new CounterConfiguration
+        {
+            LabelNames = ["result"]
+        });
+
+    private readonly ObservabilityOptions _options;
+
+    public DefenseTelemetry(IOptions<DefenseEngineOptions> options)
+    {
+        _options = options.Value.Observability;
+    }
+
+    public string ServiceName => _options.ServiceName;
+
+    public Activity? StartActivity(string name, ActivityKind kind = ActivityKind.Internal)
+    {
+        return SharedActivitySource.StartActivity(name, kind);
+    }
+
+    public void RecordSuspiciousRequest(string reason)
+    {
+        SuspiciousRequests.WithLabels(SanitizeLabel(reason)).Inc();
+    }
+
+    public void RecordDecision(string action, string source)
+    {
+        if (string.Equals(action, "blocked", StringComparison.OrdinalIgnoreCase))
+        {
+            BlockDecisions.WithLabels(SanitizeLabel(source)).Inc();
+            return;
+        }
+
+        ObservedDecisions.WithLabels(SanitizeLabel(source)).Inc();
+    }
+
+    public void RecordTarpitRender()
+    {
+        TarpitRenders.Inc();
+    }
+
+    public void RecordWebhookAccepted()
+    {
+        WebhookAccepted.Inc();
+    }
+
+    public void RecordCommunitySync(int importedCount, int rejectedCount)
+    {
+        if (importedCount > 0)
+        {
+            CommunityImports.WithLabels("imported").Inc(importedCount);
+        }
+
+        if (rejectedCount > 0)
+        {
+            CommunityImports.WithLabels("rejected").Inc(rejectedCount);
+        }
+    }
+
+    public void RecordPeerSync(int blockedCount, int observedCount, int rejectedCount)
+    {
+        if (blockedCount > 0)
+        {
+            PeerImports.WithLabels("blocked").Inc(blockedCount);
+        }
+
+        if (observedCount > 0)
+        {
+            PeerImports.WithLabels("observed").Inc(observedCount);
+        }
+
+        if (rejectedCount > 0)
+        {
+            PeerImports.WithLabels("rejected").Inc(rejectedCount);
+        }
+    }
+
+    private static string SanitizeLabel(string value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? "unknown"
+            : value.Trim().Replace(' ', '_').ToLowerInvariant();
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/PeerSyncRunner.cs
+++ b/RedisBlocklistMiddlewareApp/Services/PeerSyncRunner.cs
@@ -11,6 +11,7 @@ public sealed class PeerSyncRunner
     private readonly IBlocklistService _blocklistService;
     private readonly IDefenseEventStore _eventStore;
     private readonly IPeerSyncStatusStore _statusStore;
+    private readonly DefenseTelemetry _telemetry;
     private readonly ILogger<PeerSyncRunner> _logger;
 
     public PeerSyncRunner(
@@ -19,6 +20,7 @@ public sealed class PeerSyncRunner
         IBlocklistService blocklistService,
         IDefenseEventStore eventStore,
         IPeerSyncStatusStore statusStore,
+        DefenseTelemetry telemetry,
         ILogger<PeerSyncRunner> logger)
     {
         _options = options.Value.PeerSync;
@@ -26,6 +28,7 @@ public sealed class PeerSyncRunner
         _blocklistService = blocklistService;
         _eventStore = eventStore;
         _statusStore = statusStore;
+        _telemetry = telemetry;
         _logger = logger;
     }
 
@@ -47,6 +50,8 @@ public sealed class PeerSyncRunner
         var rejectedCount = 0;
         string? lastError = null;
         DateTimeOffset? lastSuccessAtUtc = null;
+
+        using var activity = _telemetry.StartActivity("sync.peer");
 
         foreach (var peer in _options.Peers)
         {
@@ -174,6 +179,7 @@ public sealed class PeerSyncRunner
             rejectedCount,
             lastError,
             peerStatuses.ToArray());
+        _telemetry.RecordPeerSync(blockedCount, observedCount, rejectedCount);
         _statusStore.Update(status);
         return status;
     }

--- a/RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs
@@ -9,17 +9,20 @@ public sealed class WebhookIntakeProcessingService : BackgroundService
     private readonly IWebhookEventInbox _inbox;
     private readonly IBlocklistService _blocklistService;
     private readonly IDefenseEventStore _eventStore;
+    private readonly DefenseTelemetry _telemetry;
     private readonly ILogger<WebhookIntakeProcessingService> _logger;
 
     public WebhookIntakeProcessingService(
         IWebhookEventInbox inbox,
         IBlocklistService blocklistService,
         IDefenseEventStore eventStore,
+        DefenseTelemetry telemetry,
         ILogger<WebhookIntakeProcessingService> logger)
     {
         _inbox = inbox;
         _blocklistService = blocklistService;
         _eventStore = eventStore;
+        _telemetry = telemetry;
         _logger = logger;
     }
 
@@ -29,6 +32,9 @@ public sealed class WebhookIntakeProcessingService : BackgroundService
         {
             try
             {
+                using var activity = _telemetry.StartActivity("intake.webhook");
+                activity?.SetTag("item.id", item.Id);
+                activity?.SetTag("ip", item.Event.Details.IpAddress);
                 var normalizedIp = item.Event.Details.IpAddress;
                 var reason = string.IsNullOrWhiteSpace(item.Event.Reason)
                     ? "external_webhook"
@@ -66,6 +72,7 @@ public sealed class WebhookIntakeProcessingService : BackgroundService
                                 $"Webhook intake supplied a blocking verdict: {reason}")
                         ])));
 
+                _telemetry.RecordDecision("blocked", "webhook_intake");
                 await _inbox.CompleteAsync(item.Id, stoppingToken);
             }
             catch (Exception ex)

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -141,6 +141,12 @@
         "SequencesTableName": "markov_sequences",
         "RefreshMinutes": 30
       }
+    },
+    "Observability": {
+      "ServiceName": "ai-scraping-defense-dotnet",
+      "EnablePrometheusEndpoint": true,
+      "PrometheusEndpointPath": "/metrics",
+      "OtlpEndpoint": ""
     }
   }
 }

--- a/anti-scraping-defense-iis.sln
+++ b/anti-scraping-defense-iis.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiScrapingDefense.EdgeGateway", "RedisBlocklistMiddlewareApp\RedisBlocklistMiddlewareApp.csproj", "{4A336096-1DA9-4AAA-B974-D563B1CECEBC}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedisBlocklistMiddlewareApp", "RedisBlocklistMiddlewareApp\RedisBlocklistMiddlewareApp.csproj", "{4A336096-1DA9-4AAA-B974-D563B1CECEBC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedisBlocklistMiddlewareApp.Tests", "RedisBlocklistMiddlewareApp.Tests\RedisBlocklistMiddlewareApp.Tests.csproj", "{89AFAC57-9886-4C6D-A883-7947967447D6}"
 EndProject
@@ -12,6 +12,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiScrapingDefense.EscalationEngine", "AiScrapingDefense.EscalationEngine\AiScrapingDefense.EscalationEngine.csproj", "{EABCF0B7-FBF2-42FD-BF7F-710879AA6A57}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiScrapingDefense.TarpitApi", "AiScrapingDefense.TarpitApi\AiScrapingDefense.TarpitApi.csproj", "{E5AED81A-BDCE-48FE-9D78-62575BA0934C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiScrapingDefense.IntegrationTests", "AiScrapingDefense.IntegrationTests\AiScrapingDefense.IntegrationTests.csproj", "{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -83,6 +85,18 @@ Global
 		{E5AED81A-BDCE-48FE-9D78-62575BA0934C}.Release|x64.Build.0 = Release|Any CPU
 		{E5AED81A-BDCE-48FE-9D78-62575BA0934C}.Release|x86.ActiveCfg = Release|Any CPU
 		{E5AED81A-BDCE-48FE-9D78-62575BA0934C}.Release|x86.Build.0 = Release|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Debug|x64.Build.0 = Debug|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Debug|x86.Build.0 = Debug|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Release|x64.ActiveCfg = Release|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Release|x64.Build.0 = Release|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Release|x86.ActiveCfg = Release|Any CPU
+		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,59 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_started
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__RedisConnection: redis:6379
+      DefenseEngine__Redis__ConnectionString: redis:6379
+      DefenseEngine__Redis__AllowLoopbackConnectionStringInProduction: "true"
+      DefenseEngine__Management__ApiKey: change-me-management-key
+      DefenseEngine__Intake__ApiKey: change-me-intake-key
+      DefenseEngine__Audit__DatabasePath: /app/data/defense-events.db
+      DefenseEngine__Tarpit__ResponseDelayMilliseconds: "0"
+      DefenseEngine__Tarpit__PostgresMarkov__Enabled: "true"
+      DefenseEngine__Tarpit__PostgresMarkov__ConnectionString: Host=postgres;Database=markov;Username=postgres;Password=postgres
+      DefenseEngine__Observability__EnablePrometheusEndpoint: "true"
+      DefenseEngine__Observability__PrometheusEndpointPath: /metrics
+    ports:
+      - "8080:8080"
+    volumes:
+      - app-data:/app/data
+
+  redis:
+    image: redis:7.2-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: markov
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./db/init_markov.sql:/docker-entrypoint-initdb.d/01-init_markov.sql:ro
+
+volumes:
+  app-data:
+  redis-data:
+  postgres-data:
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,72 +1,28 @@
-# **AI Scraping Defense Stack Documentation (IIS Version)**
+# AI Scraping Defense Documentation
 
-Welcome to the official documentation for the **AI Scraping Defense Stack (IIS Version)** — a modular system adapted for deployment on Windows Server with IIS, designed for detecting and deterring AI-based web scrapers, bots, and unauthorized data miners.
+This documentation index is for the current .NET implementation in this repository, not the older IIS/Python deployment path.
 
-## **🚀 Overview**
+## Core docs
 
-This project includes:
+- [Architecture](architecture.md)
+- [Commercial v1 Scope](commercial_scope.md)
+- [Parity Matrix](parity_matrix.md)
+- [Post-v1 Parity Roadmap](dotnet_parity_roadmap.md)
+- [API References](api_references.md)
+- [Release Blockers](release_blockers.md)
+- [Release Checklist](release_checklist.md)
+- [Operator Runbook](operator_runbook.md)
 
-* ✅ IIS-hosted request filtering (ASP.NET Core Middleware \+ URL Rewrite)  
-* ✅ IP Blocklisting via Redis  
-* ✅ Tarpit API (FastAPI \+ PostgreSQL) hosted via IIS to delay/confuse bots  
-* ✅ Escalation engine (FastAPI) for behavioral analysis (heuristics, ML model, optional LLM/API calls) hosted via IIS  
-* ✅ AI Service (FastAPI) for blocklist management and alerting hosted via IIS  
-* ✅ Admin UI (Flask) with real-time metrics hosted via IIS  
-* ✅ Markov-based fake text generation using PostgreSQL  
-* ✅ Supporting scripts for training, honeypot generation, etc.
+## Deployment
 
-This stack is modular, extensible, and designed for deployment within a Windows Server / IIS environment.
+- [Dockerfile](../Dockerfile)
+- [Compose Stack](../compose.yaml)
+- [IIS Deployment Guide](iis_deployment_guide.md)
 
-## **📚 Documentation Sections**
+## Project and policy
 
-### **🧭 Architecture & Setup**
-
-* [System Architecture](http://docs.google.com/architecture.md)  
-* [IIS Deployment Guide](http://docs.google.com/iis_deployment_guide.md)
-
-### **💻 API Reference**
-
-* [Endpoint Reference](http://docs.google.com/api_references.md)
-
-### **🛠 Microservice Details**
-
-*(These READMEs describe the Python code and logic within each service folder. For deployment configuration specific to IIS, refer to the [IIS Deployment Guide](http://docs.google.com/iis_deployment_guide.md) and the READMEs within the iis\_configs/ subdirectories).*
-
-* Tarpit Service Logic: [tarpit/README.md](http://docs.google.com/tarpit/README.md) *(Review recommended)*  
-* Escalation Engine Logic: [escalation/README.md](http://docs.google.com/escalation/README.md)  
-* AI Service Logic: [ai\_service/README.md](http://docs.google.com/ai_service/README.md)  
-* Admin UI Logic: [admin\_ui/README.md](http://docs.google.com/admin_ui/README.md)
-
-## **⚖️ Legal & Compliance**
-
-* [License Summary](http://docs.google.com/license_summary.md)  
-* [Third-Party Licenses](http://docs.google.com/third_party_licenses.md)  
-* [Security Disclosure Policy](http://docs.google.com/SECURITY.md)
-
-## **🤝 Contributing**
-
-* [How to Contribute](http://docs.google.com/CONTRIBUTING.md)  
-* [Changelog](http://docs.google.com/CHANGELOG.md)  
-* [Code of Conduct](http://docs.google.com/code_of_conduct.md)
-
-## **📦 Deployment**
-
-Deployment for this version is handled directly on Windows Server using IIS.
-
-### **See the [IIS Deployment Guide](http://docs.google.com/iis_deployment_guide.md) for detailed instructions.**
-
-## **🔗 System Components**
-
-* C\# ASP.NET Core Filtering Middleware  
-* Tarpit API (FastAPI)  
-* Escalation Engine (FastAPI)  
-* AI Service (FastAPI)  
-* Admin UI (Flask)  
-* Supporting Python Modules & Scripts
-
-📈 Monitoring  
-Access the Admin UI via the alias configured during IIS setup (e.g., http://your-site/admin/).  
-💡 Learn More  
-Explore the source code repository for further details.  
-📢 Feedback & Security  
-To report bugs or vulnerabilities, refer to the Security Policy.
+- [Third-Party Licenses](third_party_licenses.md)
+- [Code of Conduct](code_of_conduct.md)
+- [Changelog](../CHANGELOG.md)
+- [Security Policy](../SECURITY.md)
+- [Contributing](../CONTRIBUTING.md)

--- a/docs/operator_runbook.md
+++ b/docs/operator_runbook.md
@@ -1,0 +1,162 @@
+# Operator Runbook
+
+This runbook covers the first commercial .NET deployment shape: one ASP.NET Core service with Redis for hot state, SQLite for durable audit/intake storage, and optional PostgreSQL for the tarpit Markov corpus.
+
+## Prerequisites
+
+- Redis reachable from the application
+- Write access to the configured SQLite audit path
+- Optional PostgreSQL instance if `DefenseEngine:Tarpit:PostgresMarkov:Enabled=true`
+- Configured management API key for operator access
+- Configured intake API key if `/analyze` is enabled
+
+## Local or Single-Node Bring-Up
+
+Use the bundled Compose stack for a quick smoke environment:
+
+```bash
+docker compose up --build
+```
+
+The app will be available on `http://localhost:8080`.
+
+## Required Production Configuration
+
+At minimum, set:
+
+- `DefenseEngine:Redis:ConnectionString`
+- `DefenseEngine:Management:ApiKey`
+- `DefenseEngine:Intake:ApiKey` if webhook intake is required
+- `DefenseEngine:Audit:DatabasePath`
+- `DefenseEngine:Networking:ClientIpResolutionMode`
+
+When behind a reverse proxy or CDN:
+
+- set `DefenseEngine:Networking:ClientIpResolutionMode=TrustedProxy`
+- populate `DefenseEngine:Networking:TrustedProxies`
+
+## Health and Smoke Checks
+
+Check health:
+
+```bash
+curl http://localhost:8080/health
+```
+
+Check the root descriptor:
+
+```bash
+curl http://localhost:8080/
+```
+
+Check authenticated metrics:
+
+```bash
+curl -H 'X-API-Key: <management-key>' http://localhost:8080/defense/metrics
+```
+
+## Dashboard Access
+
+Open:
+
+```text
+http://localhost:8080/defense/dashboard
+```
+
+Authenticate with the configured management API key. The dashboard can create a signed session cookie so the browser can call the operator endpoints without repeating the header manually.
+
+## Manual Blocklist Operations
+
+Inspect:
+
+```bash
+curl -H 'X-API-Key: <management-key>' \
+  'http://localhost:8080/defense/blocklist?ip=198.51.100.10'
+```
+
+Block:
+
+```bash
+curl -X POST \
+  -H 'X-API-Key: <management-key>' \
+  'http://localhost:8080/defense/blocklist?ip=198.51.100.10&reason=manual_block'
+```
+
+Unblock:
+
+```bash
+curl -X DELETE \
+  -H 'X-API-Key: <management-key>' \
+  'http://localhost:8080/defense/blocklist?ip=198.51.100.10'
+```
+
+## Webhook Intake
+
+Submit a webhook event:
+
+```bash
+curl -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'X-Webhook-Key: <intake-key>' \
+  http://localhost:8080/analyze \
+  -d '{
+    "event_type": "ml_verdict",
+    "reason": "confirmed_bot",
+    "timestamp_utc": "2026-03-15T00:00:00Z",
+    "details": {
+      "ip": "198.51.100.77",
+      "method": "GET",
+      "path": "/pricing",
+      "query_string": "",
+      "user_agent": "example-bot",
+      "signals": ["model_positive"]
+    }
+  }'
+```
+
+## Community and Peer Sync Checks
+
+Community blocklist status:
+
+```bash
+curl -H 'X-API-Key: <management-key>' \
+  http://localhost:8080/defense/community-blocklist/status
+```
+
+Peer-sync status:
+
+```bash
+curl -H 'X-API-Key: <management-key>' \
+  http://localhost:8080/defense/peer-sync/status
+```
+
+Peer export:
+
+```bash
+curl -H 'X-Peer-Key: <peer-export-key>' \
+  'http://localhost:8080/peer-sync/signals?count=50'
+```
+
+## Metrics and Tracing
+
+If `DefenseEngine:Observability:EnablePrometheusEndpoint=true`, scrape:
+
+```bash
+curl http://localhost:8080/metrics
+```
+
+If `DefenseEngine:Observability:OtlpEndpoint` is configured, traces are exported to that collector.
+
+## Backup and Recovery
+
+- Back up the SQLite audit database at `DefenseEngine:Audit:DatabasePath`
+- Back up Redis if you rely on durable Redis persistence for operational recovery
+- Back up PostgreSQL if you maintain a curated Markov corpus
+
+## Common Failure Cases
+
+- `503 /health`: Redis is unreachable or misconfigured
+- startup failure in `Production`: loopback Redis or unsafe proxy config is still present
+- missing real client IPs: proxy/CDN trust mode is not configured correctly
+- empty Markov tarpit output changes: PostgreSQL corpus is empty or unavailable, so synthetic fallback content is being used
+

--- a/docs/parity_matrix.md
+++ b/docs/parity_matrix.md
@@ -1,0 +1,29 @@
+# .NET Parity Matrix
+
+This matrix compares the current .NET stack to the functional roles in the upstream `ai-scraping-defense` project. The goal is to separate "commercial v1 ready" from "full upstream parity still pending."
+
+Status legend:
+
+- `Implemented`: shipped in the current .NET runtime
+- `Partial`: usable, but still missing important upstream behaviors or operator depth
+- `Deferred`: intentionally left out of commercial v1
+
+| Capability | .NET status | Notes | Follow-up |
+| --- | --- | --- | --- |
+| Edge request inspection and Redis blocklisting | Implemented | ASP.NET Core middleware handles heuristics, Redis blocklist checks, and queued escalation. | Keep hardening detection quality through additional reputation/model providers. |
+| Suspicious-request queue and background analysis | Implemented | Requests are queued, scored, persisted, and can trigger auto-blocking. | Expand scoring inputs and tuning ergonomics. |
+| Authenticated operator API | Implemented | `/defense/events`, `/defense/metrics`, blocklist controls, community status, and peer-sync status are protected. | Add richer operator workflows and filtering. |
+| Operator dashboard | Implemented | Browser dashboard ships inside the same deployable and uses the same protected management API. | Expand search, drill-down, and investigation ergonomics. |
+| Webhook intake for confirmed malicious traffic | Implemented | `/analyze` is authenticated, durable, and processed asynchronously. | Add alerting/reporting parity from the legacy AI-service path. See issue `#53`. |
+| Community blocklist sync | Implemented | Feed sync, status reporting, and import tracking are in place. | Add richer trust policies and reporting controls. See issue `#53`. |
+| Peer sync | Implemented | Timed imports, authenticated exports, and `ObserveOnly`/`BlockList` trust modes are implemented. | Add richer trust scoring and coordination. |
+| PostgreSQL-backed Markov tarpit | Implemented | The tarpit can load a Markov corpus from PostgreSQL and falls back safely when no snapshot exists. | Expand deeper decoy modes. See issue `#55`. |
+| Advanced tarpit decoys | Partial | Current tarpit modes cover deterministic HTML, archive, and API-catalog variants. | Port rotating archives and JavaScript ZIP honeypots. See issue `#55`. |
+| Reputation providers and classifier hooks | Partial | Configured ranges, HTTP reputation, and OpenAI-compatible model adapters exist. | Port trained ML lifecycle and richer provider orchestration. See issue `#54`. |
+| Alerting and operator/community reporting | Partial | Durable intake exists, but outbound alert/report workflows from the legacy AI service are not fully ported. | See issue `#53`. |
+| Structured telemetry export | Partial | Prometheus metrics and OTLP trace export are wired into the app. | Add dashboard examples, alert rules, and richer release telemetry guidance. |
+| Independent multi-service deployment | Deferred | v1 intentionally ships as a single deployable ASP.NET Core runtime. | Split into independently deployed roles only when operations justify it. |
+| SQL Server support | Deferred | Redis + SQLite + PostgreSQL are the supported data stores for v1. | Revisit only if customer demand justifies the extra provider surface. |
+
+Commercial v1 is feature-complete enough to package and validate, but full upstream parity still depends on closing issues `#53`, `#54`, and `#55`.
+

--- a/docs/release_blockers.md
+++ b/docs/release_blockers.md
@@ -20,7 +20,7 @@ This document turns release readiness into a tracked execution queue. Each block
 | 4 | Done | Replace lossy queue behavior with durable or backpressure-aware intake | Dropping suspicious events under load undermines the product during attacks. |
 | 5 | Done | Add automated tests for edge filtering, tarpit routing, auth, and persistence | A successful build alone is not release confidence. |
 | 6 | Done | Add production configuration validation and startup fail-fast checks | Default localhost Redis and empty trusted-proxy config are not market-safe defaults. |
-| 7 | In Progress | Add operational observability and admin controls | Release needs authenticated admin access, metrics, and actionable diagnostics. |
+| 7 | Done | Add operational observability and admin controls | Release needs authenticated admin access, metrics, and actionable diagnostics. |
 | 8 | Done | Close parity gaps required for the first commercial scope | Commercial v1 scope, supported storage, and deferred features are now explicitly defined. |
 
 ## Blocker 1
@@ -114,6 +114,12 @@ The service still lacks a minimally complete authenticated operator API for obse
 - Authenticated manual blocklist inspection and update endpoints are exposed.
 - The behavior is documented.
 - The behavior is covered by automated tests.
+
+### Completion Notes
+
+- Authenticated operator metrics and blocklist controls are now implemented under `/defense/*`.
+- Prometheus and OTLP observability wiring is now available under `DefenseEngine:Observability`.
+- Automated tests now cover the operator API plus end-to-end request, intake, and tarpit flows.
 
 ## Blocker 8
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,0 +1,43 @@
+# Release Checklist
+
+Use this checklist before cutting a commercial release candidate.
+
+## Build and Test
+
+- `dotnet build anti-scraping-defense-iis.sln`
+- `dotnet test anti-scraping-defense-iis.sln`
+- `docker build -t ai-scraping-defense-dotnet .`
+- `docker compose up --build` smoke run succeeds
+
+## Runtime Validation
+
+- `/health` reports healthy with production-like dependencies
+- management dashboard login works
+- authenticated operator endpoints work
+- webhook intake accepts and processes a known-good sample event
+- suspicious traffic is tarpitted and can escalate to a block
+- Prometheus metrics are reachable when enabled
+- OTLP export is verified if configured
+
+## Security and Configuration
+
+- management API key is non-empty and not a default placeholder
+- intake API key is non-empty if `/analyze` is enabled
+- Redis does not use a loopback endpoint in production unless explicitly allowed
+- proxy trust configuration matches the deployment topology
+- production secrets are injected from the deployment platform, not committed config
+
+## Data and Operations
+
+- SQLite audit path is persistent and writable
+- Redis persistence/backup expectations are defined
+- PostgreSQL schema is initialized if Markov tarpit mode is enabled
+- operator runbook has been validated against the target environment
+
+## Release Artifacts
+
+- `README.md` matches the shipped behavior
+- `docs/parity_matrix.md` reflects the current status honestly
+- `CHANGELOG.md` has an `Unreleased` entry summarizing the release-hardening work
+- remaining deferred parity items are tracked as GitHub issues, not hidden in review threads
+


### PR DESCRIPTION
## Summary
- add Prometheus/OTLP telemetry wiring and containerized integration tests for the .NET stack
- fix real runtime issues uncovered by end-to-end validation, including fallback routing, tarpit rendering, and endpoint bypasses
- add release packaging/docs artifacts: Dockerfile, Compose stack, CI workflow, parity matrix, runbook, and release checklist

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln
- docker build -t ai-scraping-defense-dotnet:test .

## Remaining tracked follow-up
- #53
- #54
- #55
- #56
- #57