### PR TITLE
Port intake alerting and community reporting

### DIFF
--- a/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
+++ b/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
@@ -125,6 +125,10 @@ public sealed class IntakeOptions
     public string ApiKeyHeaderName { get; set; } = "X-Webhook-Key";
 
     public string ApiKey { get; set; } = string.Empty;
+
+    public IntakeAlertingOptions Alerting { get; set; } = new();
+
+    public CommunityReportingOptions CommunityReporting { get; set; } = new();
 }
 
 public sealed class QueueOptions
@@ -301,6 +305,62 @@ public sealed class ObservabilityOptions
     public string PrometheusEndpointPath { get; set; } = "/metrics";
 
     public string OtlpEndpoint { get; set; } = string.Empty;
+}
+
+public sealed class IntakeAlertingOptions
+{
+    public GenericWebhookAlertOptions GenericWebhook { get; set; } = new();
+
+    public SmtpAlertOptions Smtp { get; set; } = new();
+}
+
+public sealed class GenericWebhookAlertOptions
+{
+    public bool Enabled { get; set; }
+
+    public string Url { get; set; } = string.Empty;
+
+    public string AuthorizationHeaderValue { get; set; } = string.Empty;
+
+    public int TimeoutSeconds { get; set; } = 10;
+}
+
+public sealed class SmtpAlertOptions
+{
+    public bool Enabled { get; set; }
+
+    public string Host { get; set; } = string.Empty;
+
+    public int Port { get; set; } = 587;
+
+    public string Username { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+
+    public bool UseTls { get; set; } = true;
+
+    public string From { get; set; } = string.Empty;
+
+    public string[] To { get; set; } = [];
+}
+
+public sealed class CommunityReportingOptions
+{
+    public bool Enabled { get; set; }
+
+    public string ProviderName { get; set; } = "AbuseIPDB";
+
+    public string Endpoint { get; set; } = string.Empty;
+
+    public string ApiKeyHeaderName { get; set; } = "Key";
+
+    public string ApiKey { get; set; } = string.Empty;
+
+    public int TimeoutSeconds { get; set; } = 10;
+
+    public string DefaultCategories { get; set; } = "19";
+
+    public string CommentPrefix { get; set; } = "AI Defense Stack detection";
 }
 
 public sealed class PostgresMarkovOptions

--- a/AiScrapingDefense.Contracts/Models/DefenseModels.cs
+++ b/AiScrapingDefense.Contracts/Models/DefenseModels.cs
@@ -65,6 +65,23 @@ public sealed record WebhookInboxItem(
     long Id,
     IntakeWebhookEvent Event);
 
+public sealed record IntakeDeliveryRecord(
+    string DeliveryType,
+    string Channel,
+    string IpAddress,
+    string Reason,
+    string Target,
+    string Status,
+    string Detail,
+    DateTimeOffset AttemptedAtUtc);
+
+public sealed record IntakeDeliveryMetrics(
+    long TotalAttempts,
+    long SucceededCount,
+    long FailedCount,
+    long SkippedCount,
+    DateTimeOffset? LatestAttemptAtUtc);
+
 public sealed record CommunityBlocklistSyncStatus(
     bool Enabled,
     DateTimeOffset? LastAttemptAtUtc,

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - Authenticated operator metrics and blocklist management endpoints under `/defense/*`.
 - A protected operator dashboard at `/defense/dashboard` backed by the same management API.
 - An authenticated `/analyze` webhook endpoint with durable SQLite-backed intake for confirmed malicious events.
+- Configurable webhook and SMTP alert dispatch for processed intake events.
+- Configurable outbound community reporting for processed intake events.
 - Optional community blocklist feed sync with authenticated status surfaced under `/defense/community-blocklist/status`.
 - Optional peer sync with explicit `ObserveOnly` and `BlockList` trust modes plus authenticated signal export at `/peer-sync/signals`.
 - Optional PostgreSQL-backed Markov tarpit content with deterministic render variants.
@@ -33,6 +35,7 @@ The first commercial release is a single deployable ASP.NET Core service that pr
 - tarpit suspicious traffic
 - persist defense decisions and operator-visible events
 - accept authenticated webhook intake for confirmed malicious traffic
+- dispatch operator alerts and optional community reports from confirmed malicious intake events
 - block and unblock IPs through authenticated operator endpoints
 
 This is intentionally a single-deployable, multi-project .NET stack for v1. It preserves the upstream functional roles, but keeps them in one runtime deployment until separate service contracts and operational behavior settle.
@@ -56,6 +59,8 @@ Management endpoints:
 - `DELETE /defense/dashboard/session`
 - `GET /defense/events?count=50`
 - `GET /defense/metrics`
+- `GET /defense/intake-deliveries?count=50`
+- `GET /defense/intake-delivery-metrics`
 - `GET /defense/community-blocklist/status`
 - `GET /defense/peer-sync/status`
 - `GET /defense/blocklist?ip=203.0.113.10`
@@ -109,6 +114,9 @@ Key areas:
 - `DefenseEngine:Management`
   - `DashboardSessionHours` controls the browser dashboard session lifetime after successful sign-in.
 - `DefenseEngine:Intake`
+  - `Alerting:GenericWebhook` controls optional outbound webhook alerts for processed intake events.
+  - `Alerting:Smtp` controls optional operator email alerts for processed intake events.
+  - `CommunityReporting` controls optional outbound reporting to providers like AbuseIPDB.
 - `DefenseEngine:Audit`
 - `DefenseEngine:Escalation`
 - `DefenseEngine:CommunityBlocklist`

--- a/RedisBlocklistMiddlewareApp.Tests/CommunityReporterTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/CommunityReporterTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class CommunityReporterTests
+{
+    [Fact]
+    public async Task ReportAsync_PostsExpectedFormPayload()
+    {
+        var handler = new RecordingHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var reporter = new CommunityReporter(
+            Options.Create(CreateOptions()),
+            new FakeHttpClientFactory(handler));
+
+        var result = await reporter.ReportAsync(CreateEvent("AI scraper detected"), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(IntakeDeliveryStatuses.Succeeded, result!.Status);
+        Assert.Equal(IntakeDeliveryTypes.CommunityReport, result.DeliveryType);
+        Assert.Equal("AbuseIPDB", result.Channel);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal("integration-key", handler.Request!.Headers.GetValues("Key").Single());
+        var body = await handler.Request.Content!.ReadAsStringAsync();
+        Assert.Contains("ip=198.51.100.44", body);
+        Assert.Contains("categories=19", body);
+        Assert.Contains("AI+Defense+Stack+detection", body);
+    }
+
+    [Fact]
+    public async Task ReportAsync_UsesDefaultCategoryWhenReasonDoesNotMatchKnownPatterns()
+    {
+        var handler = new RecordingHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var reporter = new CommunityReporter(
+            Options.Create(CreateOptions()),
+            new FakeHttpClientFactory(handler));
+
+        await reporter.ReportAsync(CreateEvent("manual review verdict"), CancellationToken.None);
+
+        var body = await handler.Request!.Content!.ReadAsStringAsync();
+        Assert.Contains("categories=18%2C20", body);
+    }
+
+    private static DefenseEngineOptions CreateOptions()
+    {
+        return new DefenseEngineOptions
+        {
+            Intake = new IntakeOptions
+            {
+                CommunityReporting = new CommunityReportingOptions
+                {
+                    Enabled = true,
+                    ProviderName = "AbuseIPDB",
+                    Endpoint = "https://abuse.example.test/report",
+                    ApiKeyHeaderName = "Key",
+                    ApiKey = "integration-key",
+                    TimeoutSeconds = 5,
+                    DefaultCategories = "18,20",
+                    CommentPrefix = "AI Defense Stack detection"
+                }
+            }
+        };
+    }
+
+    private static IntakeWebhookEvent CreateEvent(string reason)
+    {
+        return new IntakeWebhookEvent(
+            "confirmed_bot",
+            reason,
+            DateTimeOffset.Parse("2026-03-15T12:00:00Z"),
+            new IntakeWebhookDetails(
+                "198.51.100.44",
+                "GET",
+                "/reports/export",
+                string.Empty,
+                "bot-agent",
+                ["signal"]));
+    }
+
+    private sealed class FakeHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public FakeHttpClientFactory(HttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(_handler, disposeHandler: false);
+        }
+    }
+
+    private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public RecordingHttpMessageHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = CloneRequest(request);
+            return Task.FromResult(_response);
+        }
+
+        private static HttpRequestMessage CloneRequest(HttpRequestMessage request)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            if (request.Content is not null)
+            {
+                var body = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                clone.Content = new StringContent(body, Encoding.UTF8, "application/x-www-form-urlencoded");
+                foreach (var header in request.Content.Headers)
+                {
+                    clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            return clone;
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/IntakeAlertDispatcherTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/IntakeAlertDispatcherTests.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class IntakeAlertDispatcherTests
+{
+    [Fact]
+    public async Task DispatchAsync_SendsGenericWebhookAndSmtpAlerts()
+    {
+        var handler = new RecordingHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.Accepted));
+        var smtpSender = new RecordingSmtpAlertSender();
+        var dispatcher = new IntakeAlertDispatcher(
+            Options.Create(CreateOptions()),
+            new FakeHttpClientFactory(handler),
+            smtpSender);
+        var webhookEvent = CreateEvent();
+
+        var results = await dispatcher.DispatchAsync(webhookEvent, CancellationToken.None);
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, record =>
+            record.Channel == IntakeDeliveryChannels.GenericWebhook &&
+            record.Status == IntakeDeliveryStatuses.Succeeded);
+        Assert.Contains(results, record =>
+            record.Channel == IntakeDeliveryChannels.Smtp &&
+            record.Status == IntakeDeliveryStatuses.Succeeded);
+
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
+        Assert.Equal("Bearer test-token", handler.Request.Headers.Authorization!.ToString());
+        var requestJson = await handler.Request.Content!.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(requestJson);
+        Assert.Equal("AI_DEFENSE_BLOCK", json.RootElement.GetProperty("alert_type").GetString());
+        Assert.Equal("suspicious_activity_detected", json.RootElement.GetProperty("event_type").GetString());
+        Assert.Equal("198.51.100.30", json.RootElement.GetProperty("ip_address").GetString());
+
+        Assert.Single(smtpSender.Messages);
+        Assert.Contains("[AI Defense Alert]", smtpSender.Messages[0].Subject);
+        Assert.Contains("198.51.100.30", smtpSender.Messages[0].Body);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ReturnsFailedWebhookRecord_WhenWebhookCallThrows()
+    {
+        var dispatcher = new IntakeAlertDispatcher(
+            Options.Create(CreateOptions()),
+            new FakeHttpClientFactory(new ThrowingHttpMessageHandler(new HttpRequestException("network down"))),
+            new RecordingSmtpAlertSender());
+
+        var results = await dispatcher.DispatchAsync(CreateEvent(), CancellationToken.None);
+
+        var webhookResult = Assert.Single(results, record => record.Channel == IntakeDeliveryChannels.GenericWebhook);
+        Assert.Equal(IntakeDeliveryStatuses.Failed, webhookResult.Status);
+        Assert.Contains("network down", webhookResult.Detail);
+    }
+
+    private static DefenseEngineOptions CreateOptions()
+    {
+        return new DefenseEngineOptions
+        {
+            Intake = new IntakeOptions
+            {
+                Alerting = new IntakeAlertingOptions
+                {
+                    GenericWebhook = new GenericWebhookAlertOptions
+                    {
+                        Enabled = true,
+                        Url = "https://alerts.example.test/hooks/defense",
+                        AuthorizationHeaderValue = "Bearer test-token",
+                        TimeoutSeconds = 5
+                    },
+                    Smtp = new SmtpAlertOptions
+                    {
+                        Enabled = true,
+                        Host = "smtp.example.test",
+                        Port = 2525,
+                        Username = "alert-user",
+                        Password = "alert-pass",
+                        UseTls = true,
+                        From = "defense@example.test",
+                        To = ["ops@example.test", "security@example.test"]
+                    }
+                }
+            }
+        };
+    }
+
+    private static IntakeWebhookEvent CreateEvent()
+    {
+        return new IntakeWebhookEvent(
+            "suspicious_activity_detected",
+            "AI scraper detected",
+            DateTimeOffset.Parse("2026-03-15T12:00:00Z"),
+            new IntakeWebhookDetails(
+                "198.51.100.30",
+                "GET",
+                "/pricing",
+                string.Empty,
+                "test-bot",
+                ["webhook_signal"]));
+    }
+
+    private sealed class FakeHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public FakeHttpClientFactory(HttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(_handler, disposeHandler: false);
+        }
+    }
+
+    private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public RecordingHttpMessageHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = CloneRequest(request);
+            return await Task.FromResult(_response);
+        }
+
+        private static HttpRequestMessage CloneRequest(HttpRequestMessage request)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            if (request.Content is not null)
+            {
+                var body = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                clone.Content = new StringContent(body, Encoding.UTF8);
+                foreach (var header in request.Content.Headers)
+                {
+                    clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+
+            return clone;
+        }
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+
+        public ThrowingHttpMessageHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw _exception;
+        }
+    }
+
+    private sealed class RecordingSmtpAlertSender : ISmtpAlertSender
+    {
+        public List<SmtpMessage> Messages { get; } = [];
+
+        public Task SendAsync(
+            string host,
+            int port,
+            string username,
+            string password,
+            bool useTls,
+            string from,
+            IReadOnlyList<string> to,
+            string subject,
+            string body,
+            CancellationToken cancellationToken)
+        {
+            Messages.Add(new SmtpMessage(host, port, username, password, useTls, from, to, subject, body));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record SmtpMessage(
+        string Host,
+        int Port,
+        string Username,
+        string Password,
+        bool UseTls,
+        string From,
+        IReadOnlyList<string> To,
+        string Subject,
+        string Body);
+}

--- a/RedisBlocklistMiddlewareApp.Tests/IntakeDeliveryStoreTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/IntakeDeliveryStoreTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class IntakeDeliveryStoreTests
+{
+    [Fact]
+    public void GetRecent_ReturnsMostRecentAttemptsFirst()
+    {
+        using var harness = SqliteStoreHarness.Create();
+        var store = harness.CreateStore();
+        store.Add(CreateRecord("198.51.100.1", IntakeDeliveryStatuses.Succeeded, "first"));
+        store.Add(CreateRecord("198.51.100.2", IntakeDeliveryStatuses.Failed, "second"));
+        store.Add(CreateRecord("198.51.100.3", IntakeDeliveryStatuses.Succeeded, "third"));
+
+        var recent = store.GetRecent(2);
+
+        Assert.Equal(2, recent.Count);
+        Assert.Equal("198.51.100.3", recent[0].IpAddress);
+        Assert.Equal("198.51.100.2", recent[1].IpAddress);
+    }
+
+    [Fact]
+    public void GetMetrics_ReturnsAggregatedAttemptCounts()
+    {
+        using var harness = SqliteStoreHarness.Create();
+        var store = harness.CreateStore();
+        store.Add(CreateRecord("198.51.100.11", IntakeDeliveryStatuses.Succeeded, "ok"));
+        store.Add(CreateRecord("198.51.100.12", IntakeDeliveryStatuses.Failed, "fail"));
+        store.Add(CreateRecord("198.51.100.13", IntakeDeliveryStatuses.Skipped, "skip"));
+
+        var metrics = store.GetMetrics();
+
+        Assert.Equal(3, metrics.TotalAttempts);
+        Assert.Equal(1, metrics.SucceededCount);
+        Assert.Equal(1, metrics.FailedCount);
+        Assert.Equal(1, metrics.SkippedCount);
+        Assert.NotNull(metrics.LatestAttemptAtUtc);
+    }
+
+    [Fact]
+    public void Store_PersistsAttemptsAcrossInstances()
+    {
+        using var harness = SqliteStoreHarness.Create();
+        harness.CreateStore().Add(CreateRecord("198.51.100.25", IntakeDeliveryStatuses.Succeeded, "persisted"));
+
+        var recent = harness.CreateStore().GetRecent(10);
+
+        Assert.Single(recent);
+        Assert.Equal("198.51.100.25", recent[0].IpAddress);
+        Assert.Equal("persisted", recent[0].Detail);
+    }
+
+    private static IntakeDeliveryRecord CreateRecord(string ipAddress, string status, string detail)
+    {
+        return new IntakeDeliveryRecord(
+            IntakeDeliveryTypes.Alert,
+            IntakeDeliveryChannels.GenericWebhook,
+            ipAddress,
+            "AI scraper detected",
+            "https://alerts.example.test",
+            status,
+            detail,
+            DateTimeOffset.UtcNow);
+    }
+
+    private sealed class SqliteStoreHarness : IDisposable
+    {
+        private readonly string _rootPath;
+
+        private SqliteStoreHarness(string rootPath, int maxRecentEvents)
+        {
+            _rootPath = rootPath;
+            Options = Microsoft.Extensions.Options.Options.Create(new DefenseEngineOptions
+            {
+                Audit = new AuditOptions
+                {
+                    DatabasePath = "events.db",
+                    MaxRecentEvents = maxRecentEvents
+                }
+            });
+        }
+
+        public IOptions<DefenseEngineOptions> Options { get; }
+
+        public static SqliteStoreHarness Create(int maxRecentEvents = 500)
+        {
+            var rootPath = Path.Combine(Path.GetTempPath(), "ai-scraping-defense-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(rootPath);
+            return new SqliteStoreHarness(rootPath, maxRecentEvents);
+        }
+
+        public SqliteIntakeDeliveryStore CreateStore()
+        {
+            return new SqliteIntakeDeliveryStore(Options, new TestHostEnvironment(_rootPath));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_rootPath))
+            {
+                Directory.Delete(_rootPath, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public TestHostEnvironment(string contentRootPath)
+        {
+            ContentRootPath = contentRootPath;
+        }
+
+        public string EnvironmentName { get; set; } = "Development";
+
+        public string ApplicationName { get; set; } = "RedisBlocklistMiddlewareApp.Tests";
+
+        public string ContentRootPath { get; set; }
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
@@ -278,6 +278,8 @@ public sealed class ManagementEndpointTests
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/dashboard/session");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/events");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/metrics");
+        Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/intake-deliveries");
+        Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/intake-delivery-metrics");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/blocklist");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/community-blocklist/status");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/peer-sync/status");
@@ -293,6 +295,8 @@ public sealed class ManagementEndpointTests
         Assert.Contains("/defense/dashboard/session", html);
         Assert.Contains("/defense/events", html);
         Assert.Contains("/defense/metrics", html);
+        Assert.Contains("/defense/intake-deliveries", html);
+        Assert.Contains("/defense/intake-delivery-metrics", html);
         Assert.Contains("/defense/blocklist", html);
     }
 
@@ -397,6 +401,7 @@ public sealed class ManagementEndpointTests
         builder.Services.AddSingleton<PeerApiKeyEndpointFilter>();
         builder.Services.AddSingleton<IOperatorDashboardPageService, OperatorDashboardPageService>();
         builder.Services.AddSingleton<IDefenseEventStore, TestDefenseEventStore>();
+        builder.Services.AddSingleton<IIntakeDeliveryStore, TestIntakeDeliveryStore>();
         builder.Services.AddSingleton<IBlocklistService, TestBlocklistService>();
         builder.Services.AddSingleton<IWebhookEventInbox, TestWebhookEventInbox>();
         builder.Services.AddSingleton<IPeerSyncStatusStore, TestPeerSyncStatusStore>();
@@ -514,6 +519,23 @@ public sealed class ManagementEndpointTests
         public DefenseEventMetrics GetMetrics()
         {
             return new DefenseEventMetrics(0, 0, 0, null);
+        }
+    }
+
+    private sealed class TestIntakeDeliveryStore : IIntakeDeliveryStore
+    {
+        public void Add(IntakeDeliveryRecord record)
+        {
+        }
+
+        public IReadOnlyList<IntakeDeliveryRecord> GetRecent(int count)
+        {
+            return [];
+        }
+
+        public IntakeDeliveryMetrics GetMetrics()
+        {
+            return new IntakeDeliveryMetrics(0, 0, 0, 0, null);
         }
     }
 

--- a/RedisBlocklistMiddlewareApp.Tests/WebhookIntakeProcessingServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/WebhookIntakeProcessingServiceTests.cs
@@ -8,31 +8,59 @@ namespace RedisBlocklistMiddlewareApp.Tests;
 public sealed class WebhookIntakeProcessingServiceTests
 {
     [Fact]
-    public async Task ProcessingService_BlocklistsWebhookIp_AndRecordsDecision()
+    public async Task ProcessingService_BlocklistsWebhookIp_RecordsDecision_AndPersistsDeliveries()
     {
         var inbox = new TestWebhookEventInbox();
         var blocklist = new TestBlocklistService();
         var eventStore = new TestDefenseEventStore();
+        var alertDispatcher = new TestIntakeAlertDispatcher(
+            [
+                new IntakeDeliveryRecord(
+                    IntakeDeliveryTypes.Alert,
+                    IntakeDeliveryChannels.GenericWebhook,
+                    "198.51.100.20",
+                    "High Combined Score (0.95)",
+                    "https://alerts.example.test",
+                    IntakeDeliveryStatuses.Succeeded,
+                    "ok",
+                    DateTimeOffset.UtcNow)
+            ]);
+        var communityReporter = new TestCommunityReporter(
+            new IntakeDeliveryRecord(
+                IntakeDeliveryTypes.CommunityReport,
+                "AbuseIPDB",
+                "198.51.100.20",
+                "High Combined Score (0.95)",
+                "https://abuse.example.test",
+                IntakeDeliveryStatuses.Succeeded,
+                "ok",
+                DateTimeOffset.UtcNow));
+        var deliveryStore = new TestIntakeDeliveryStore();
         var service = new WebhookIntakeProcessingService(
             inbox,
             blocklist,
             eventStore,
+            alertDispatcher,
+            communityReporter,
+            deliveryStore,
             TestTelemetryFactory.Create(),
             NullLogger<WebhookIntakeProcessingService>.Instance);
 
+        var webhookEvent = new IntakeWebhookEvent(
+            "suspicious_activity_detected",
+            "High Combined Score (0.95)",
+            DateTimeOffset.UtcNow,
+            new IntakeWebhookDetails(
+                "198.51.100.20",
+                "GET",
+                "/upstream",
+                string.Empty,
+                "test-agent",
+                ["upstream_signal"]));
+
         await inbox.EnqueueAsync(new WebhookInboxItem(
             7,
-            new IntakeWebhookEvent(
-                "suspicious_activity_detected",
-                "High Combined Score (0.95)",
-                DateTimeOffset.UtcNow,
-                new IntakeWebhookDetails(
-                    "198.51.100.20",
-                    "GET",
-                    "/upstream",
-                    string.Empty,
-                    "test-agent",
-                    ["upstream_signal"]))), CancellationToken.None);
+            webhookEvent), CancellationToken.None);
 
         await service.StartAsync(CancellationToken.None);
         await inbox.WaitForCompletionAsync();
@@ -43,6 +71,13 @@ public sealed class WebhookIntakeProcessingServiceTests
         Assert.Single(eventStore.Decisions);
         Assert.Equal("blocked", eventStore.Decisions[0].Action);
         Assert.Equal("/upstream", eventStore.Decisions[0].Path);
+        Assert.Single(alertDispatcher.Events);
+        Assert.Same(webhookEvent, alertDispatcher.Events[0]);
+        Assert.Single(communityReporter.Events);
+        Assert.Same(webhookEvent, communityReporter.Events[0]);
+        Assert.Equal(2, deliveryStore.Records.Count);
+        Assert.Contains(deliveryStore.Records, record => record.DeliveryType == IntakeDeliveryTypes.Alert);
+        Assert.Contains(deliveryStore.Records, record => record.DeliveryType == IntakeDeliveryTypes.CommunityReport);
     }
 
     private sealed class TestWebhookEventInbox : IWebhookEventInbox
@@ -136,6 +171,73 @@ public sealed class WebhookIntakeProcessingServiceTests
                 Decisions.LongCount(decision => decision.Action == "observed"),
                 Decisions.OrderByDescending(decision => decision.DecidedAtUtc)
                     .Select(decision => (DateTimeOffset?)decision.DecidedAtUtc)
+                    .FirstOrDefault());
+        }
+    }
+
+    private sealed class TestIntakeAlertDispatcher : IIntakeAlertDispatcher
+    {
+        private readonly IReadOnlyList<IntakeDeliveryRecord> _deliveries;
+
+        public TestIntakeAlertDispatcher(IReadOnlyList<IntakeDeliveryRecord> deliveries)
+        {
+            _deliveries = deliveries;
+        }
+
+        public List<IntakeWebhookEvent> Events { get; } = [];
+
+        public Task<IReadOnlyList<IntakeDeliveryRecord>> DispatchAsync(
+            IntakeWebhookEvent webhookEvent,
+            CancellationToken cancellationToken)
+        {
+            Events.Add(webhookEvent);
+            return Task.FromResult(_deliveries);
+        }
+    }
+
+    private sealed class TestCommunityReporter : ICommunityReporter
+    {
+        private readonly IntakeDeliveryRecord? _delivery;
+
+        public TestCommunityReporter(IntakeDeliveryRecord? delivery)
+        {
+            _delivery = delivery;
+        }
+
+        public List<IntakeWebhookEvent> Events { get; } = [];
+
+        public Task<IntakeDeliveryRecord?> ReportAsync(
+            IntakeWebhookEvent webhookEvent,
+            CancellationToken cancellationToken)
+        {
+            Events.Add(webhookEvent);
+            return Task.FromResult(_delivery);
+        }
+    }
+
+    private sealed class TestIntakeDeliveryStore : IIntakeDeliveryStore
+    {
+        public List<IntakeDeliveryRecord> Records { get; } = [];
+
+        public void Add(IntakeDeliveryRecord record)
+        {
+            Records.Add(record);
+        }
+
+        public IReadOnlyList<IntakeDeliveryRecord> GetRecent(int count)
+        {
+            return Records.Take(count).ToArray();
+        }
+
+        public IntakeDeliveryMetrics GetMetrics()
+        {
+            return new IntakeDeliveryMetrics(
+                Records.Count,
+                Records.LongCount(record => record.Status == IntakeDeliveryStatuses.Succeeded),
+                Records.LongCount(record => record.Status == IntakeDeliveryStatuses.Failed),
+                Records.LongCount(record => record.Status == IntakeDeliveryStatuses.Skipped),
+                Records.OrderByDescending(record => record.AttemptedAtUtc)
+                    .Select(record => (DateTimeOffset?)record.AttemptedAtUtc)
                     .FirstOrDefault());
         }
     }

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -80,6 +80,41 @@ builder.Services
             : options.Intake.ApiKeyHeaderName.Trim();
 
         options.Intake.ApiKey = options.Intake.ApiKey.Trim();
+        options.Intake.Alerting.GenericWebhook.Url = options.Intake.Alerting.GenericWebhook.Url.Trim();
+        options.Intake.Alerting.GenericWebhook.AuthorizationHeaderValue =
+            options.Intake.Alerting.GenericWebhook.AuthorizationHeaderValue.Trim();
+        options.Intake.Alerting.GenericWebhook.TimeoutSeconds =
+            Math.Max(1, options.Intake.Alerting.GenericWebhook.TimeoutSeconds);
+        options.Intake.Alerting.Smtp.Host = options.Intake.Alerting.Smtp.Host.Trim();
+        options.Intake.Alerting.Smtp.Port = Math.Max(1, options.Intake.Alerting.Smtp.Port);
+        options.Intake.Alerting.Smtp.Username = options.Intake.Alerting.Smtp.Username.Trim();
+        options.Intake.Alerting.Smtp.Password = options.Intake.Alerting.Smtp.Password.Trim();
+        options.Intake.Alerting.Smtp.From = options.Intake.Alerting.Smtp.From.Trim();
+        options.Intake.Alerting.Smtp.To = options.Intake.Alerting.Smtp.To
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        options.Intake.CommunityReporting.ProviderName =
+            string.IsNullOrWhiteSpace(options.Intake.CommunityReporting.ProviderName)
+                ? "AbuseIPDB"
+                : options.Intake.CommunityReporting.ProviderName.Trim();
+        options.Intake.CommunityReporting.Endpoint = options.Intake.CommunityReporting.Endpoint.Trim();
+        options.Intake.CommunityReporting.ApiKeyHeaderName =
+            string.IsNullOrWhiteSpace(options.Intake.CommunityReporting.ApiKeyHeaderName)
+                ? "Key"
+                : options.Intake.CommunityReporting.ApiKeyHeaderName.Trim();
+        options.Intake.CommunityReporting.ApiKey = options.Intake.CommunityReporting.ApiKey.Trim();
+        options.Intake.CommunityReporting.TimeoutSeconds =
+            Math.Max(1, options.Intake.CommunityReporting.TimeoutSeconds);
+        options.Intake.CommunityReporting.DefaultCategories =
+            string.IsNullOrWhiteSpace(options.Intake.CommunityReporting.DefaultCategories)
+                ? "19"
+                : options.Intake.CommunityReporting.DefaultCategories.Trim();
+        options.Intake.CommunityReporting.CommentPrefix =
+            string.IsNullOrWhiteSpace(options.Intake.CommunityReporting.CommentPrefix)
+                ? "AI Defense Stack detection"
+                : options.Intake.CommunityReporting.CommentPrefix.Trim();
 
         options.Networking.ClientIpResolutionMode = string.IsNullOrWhiteSpace(options.Networking.ClientIpResolutionMode)
             ? ClientIpResolutionModes.Direct
@@ -209,6 +244,7 @@ builder.Services.AddSingleton<IRedisConnectionProvider, RedisConnectionProvider>
 builder.Services.AddSingleton<IBlocklistService, RedisBlocklistService>();
 builder.Services.AddSingleton<IRequestFrequencyTracker, RedisRequestFrequencyTracker>();
 builder.Services.AddSingleton<IDefenseEventStore, SqliteDefenseEventStore>();
+builder.Services.AddSingleton<IIntakeDeliveryStore, SqliteIntakeDeliveryStore>();
 builder.Services.AddSingleton<ISuspiciousRequestQueue, SuspiciousRequestQueue>();
 builder.Services.AddSingleton<IRequestSignalEvaluator, RequestSignalEvaluator>();
 builder.Services.AddSingleton<ITarpitMarkovStore, PostgresTarpitMarkovStore>();
@@ -230,6 +266,9 @@ builder.Services.AddSingleton<IntakeApiKeyEndpointFilter>();
 builder.Services.AddSingleton<PeerApiKeyEndpointFilter>();
 builder.Services.AddSingleton<IOperatorDashboardPageService, OperatorDashboardPageService>();
 builder.Services.AddSingleton<IWebhookEventInbox, SqliteWebhookEventInbox>();
+builder.Services.AddSingleton<IIntakeAlertDispatcher, IntakeAlertDispatcher>();
+builder.Services.AddSingleton<ICommunityReporter, CommunityReporter>();
+builder.Services.AddSingleton<ISmtpAlertSender, SmtpAlertSender>();
 builder.Services.AddHostedService<StartupValidationService>();
 builder.Services.AddHostedService<DefenseAnalysisService>();
 builder.Services.AddHostedService<WebhookIntakeProcessingService>();
@@ -412,6 +451,19 @@ public partial class Program
 
         management.MapGet("/metrics", (
             IDefenseEventStore store) =>
+        {
+            return Results.Ok(store.GetMetrics());
+        });
+
+        management.MapGet("/intake-deliveries", (
+            [FromServices] IIntakeDeliveryStore store,
+            int count = 50) =>
+        {
+            return Results.Ok(store.GetRecent(count));
+        });
+
+        management.MapGet("/intake-delivery-metrics", (
+            [FromServices] IIntakeDeliveryStore store) =>
         {
             return Results.Ok(store.GetMetrics());
         });

--- a/RedisBlocklistMiddlewareApp/Services/CommunityReporter.cs
+++ b/RedisBlocklistMiddlewareApp/Services/CommunityReporter.cs
@@ -1,0 +1,107 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class CommunityReporter : ICommunityReporter
+{
+    private readonly CommunityReportingOptions _options;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public CommunityReporter(
+        IOptions<DefenseEngineOptions> options,
+        IHttpClientFactory httpClientFactory)
+    {
+        _options = options.Value.Intake.CommunityReporting;
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<IntakeDeliveryRecord?> ReportAsync(
+        IntakeWebhookEvent webhookEvent,
+        CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled ||
+            string.IsNullOrWhiteSpace(_options.Endpoint) ||
+            string.IsNullOrWhiteSpace(_options.ApiKey))
+        {
+            return null;
+        }
+
+        var attemptedAtUtc = DateTimeOffset.UtcNow;
+        try
+        {
+            using var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(Math.Max(1, _options.TimeoutSeconds));
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, _options.Endpoint)
+            {
+                Content = new FormUrlEncodedContent(new Dictionary<string, string>
+                {
+                    ["ip"] = webhookEvent.Details.IpAddress,
+                    ["categories"] = SelectCategories(webhookEvent),
+                    ["comment"] = BuildComment(webhookEvent)
+                })
+            };
+            request.Headers.TryAddWithoutValidation(_options.ApiKeyHeaderName, _options.ApiKey);
+
+            using var response = await client.SendAsync(request, cancellationToken);
+            var detail = response.IsSuccessStatusCode
+                ? "Community report delivered successfully."
+                : $"Community report failed with status {(int)response.StatusCode}.";
+
+            return new IntakeDeliveryRecord(
+                IntakeDeliveryTypes.CommunityReport,
+                _options.ProviderName,
+                webhookEvent.Details.IpAddress,
+                webhookEvent.Reason,
+                _options.Endpoint,
+                response.IsSuccessStatusCode ? IntakeDeliveryStatuses.Succeeded : IntakeDeliveryStatuses.Failed,
+                detail,
+                attemptedAtUtc);
+        }
+        catch (Exception ex)
+        {
+            return new IntakeDeliveryRecord(
+                IntakeDeliveryTypes.CommunityReport,
+                _options.ProviderName,
+                webhookEvent.Details.IpAddress,
+                webhookEvent.Reason,
+                _options.Endpoint,
+                IntakeDeliveryStatuses.Failed,
+                ex.Message,
+                attemptedAtUtc);
+        }
+    }
+
+    private string SelectCategories(IntakeWebhookEvent webhookEvent)
+    {
+        var reason = webhookEvent.Reason;
+        if (reason.Contains("scan", StringComparison.OrdinalIgnoreCase))
+        {
+            return "14";
+        }
+
+        if (reason.Contains("honeypot", StringComparison.OrdinalIgnoreCase))
+        {
+            return "22";
+        }
+
+        if (reason.Contains("scrap", StringComparison.OrdinalIgnoreCase) ||
+            reason.Contains("crawler", StringComparison.OrdinalIgnoreCase) ||
+            reason.Contains("bot", StringComparison.OrdinalIgnoreCase))
+        {
+            return "19";
+        }
+
+        return _options.DefaultCategories;
+    }
+
+    private string BuildComment(IntakeWebhookEvent webhookEvent)
+    {
+        var detail = webhookEvent.Details;
+        return $"{_options.CommentPrefix}. Reason: {webhookEvent.Reason}. UA: {detail.UserAgent ?? "N/A"}. Path: {detail.Path ?? "/"}.";
+    }
+}
+

--- a/RedisBlocklistMiddlewareApp/Services/DefenseTelemetry.cs
+++ b/RedisBlocklistMiddlewareApp/Services/DefenseTelemetry.cs
@@ -37,6 +37,13 @@ public sealed class DefenseTelemetry
     private static readonly Counter WebhookAccepted = Metrics.CreateCounter(
         "ai_scraping_defense_webhook_intake_total",
         "Webhook intake events accepted for durable processing.");
+    private static readonly Counter IntakeDeliveryAttempts = Metrics.CreateCounter(
+        "ai_scraping_defense_intake_delivery_total",
+        "Intake alert/report delivery outcomes.",
+        new CounterConfiguration
+        {
+            LabelNames = ["delivery_type", "channel", "status"]
+        });
     private static readonly Counter CommunityImports = Metrics.CreateCounter(
         "ai_scraping_defense_community_imports_total",
         "Community-blocklist import outcomes.",
@@ -90,6 +97,13 @@ public sealed class DefenseTelemetry
     public void RecordWebhookAccepted()
     {
         WebhookAccepted.Inc();
+    }
+
+    public void RecordIntakeDelivery(string deliveryType, string channel, string status)
+    {
+        IntakeDeliveryAttempts
+            .WithLabels(SanitizeLabel(deliveryType), SanitizeLabel(channel), SanitizeLabel(status))
+            .Inc();
     }
 
     public void RecordCommunitySync(int importedCount, int rejectedCount)

--- a/RedisBlocklistMiddlewareApp/Services/ICommunityReporter.cs
+++ b/RedisBlocklistMiddlewareApp/Services/ICommunityReporter.cs
@@ -1,0 +1,11 @@
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface ICommunityReporter
+{
+    Task<IntakeDeliveryRecord?> ReportAsync(
+        IntakeWebhookEvent webhookEvent,
+        CancellationToken cancellationToken);
+}
+

--- a/RedisBlocklistMiddlewareApp/Services/IIntakeAlertDispatcher.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IIntakeAlertDispatcher.cs
@@ -1,0 +1,11 @@
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface IIntakeAlertDispatcher
+{
+    Task<IReadOnlyList<IntakeDeliveryRecord>> DispatchAsync(
+        IntakeWebhookEvent webhookEvent,
+        CancellationToken cancellationToken);
+}
+

--- a/RedisBlocklistMiddlewareApp/Services/IIntakeDeliveryStore.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IIntakeDeliveryStore.cs
@@ -1,0 +1,13 @@
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface IIntakeDeliveryStore
+{
+    void Add(IntakeDeliveryRecord record);
+
+    IReadOnlyList<IntakeDeliveryRecord> GetRecent(int count);
+
+    IntakeDeliveryMetrics GetMetrics();
+}
+

--- a/RedisBlocklistMiddlewareApp/Services/ISmtpAlertSender.cs
+++ b/RedisBlocklistMiddlewareApp/Services/ISmtpAlertSender.cs
@@ -1,0 +1,17 @@
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface ISmtpAlertSender
+{
+    Task SendAsync(
+        string host,
+        int port,
+        string username,
+        string password,
+        bool useTls,
+        string from,
+        IReadOnlyList<string> to,
+        string subject,
+        string body,
+        CancellationToken cancellationToken);
+}
+

--- a/RedisBlocklistMiddlewareApp/Services/IntakeAlertDispatcher.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IntakeAlertDispatcher.cs
@@ -1,0 +1,176 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class IntakeAlertDispatcher : IIntakeAlertDispatcher
+{
+    private readonly IntakeAlertingOptions _options;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ISmtpAlertSender _smtpAlertSender;
+
+    public IntakeAlertDispatcher(
+        IOptions<DefenseEngineOptions> options,
+        IHttpClientFactory httpClientFactory,
+        ISmtpAlertSender smtpAlertSender)
+    {
+        _options = options.Value.Intake.Alerting;
+        _httpClientFactory = httpClientFactory;
+        _smtpAlertSender = smtpAlertSender;
+    }
+
+    public async Task<IReadOnlyList<IntakeDeliveryRecord>> DispatchAsync(
+        IntakeWebhookEvent webhookEvent,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<IntakeDeliveryRecord>(2);
+        var webhookResult = await SendGenericWebhookAsync(webhookEvent, cancellationToken);
+        if (webhookResult is not null)
+        {
+            results.Add(webhookResult);
+        }
+
+        var smtpResult = await SendSmtpAsync(webhookEvent, cancellationToken);
+        if (smtpResult is not null)
+        {
+            results.Add(smtpResult);
+        }
+
+        return results;
+    }
+
+    private async Task<IntakeDeliveryRecord?> SendGenericWebhookAsync(
+        IntakeWebhookEvent webhookEvent,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.GenericWebhook;
+        if (!options.Enabled || string.IsNullOrWhiteSpace(options.Url))
+        {
+            return null;
+        }
+
+        var attemptedAtUtc = DateTimeOffset.UtcNow;
+        try
+        {
+            using var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(Math.Max(1, options.TimeoutSeconds));
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, options.Url)
+            {
+                Content = JsonContent.Create(new
+                {
+                    alert_type = "AI_DEFENSE_BLOCK",
+                    event_type = webhookEvent.EventType,
+                    webhookEvent.Reason,
+                    timestamp_utc = webhookEvent.TimestampUtc,
+                    ip_address = webhookEvent.Details.IpAddress,
+                    webhookEvent.Details
+                })
+            };
+
+            if (!string.IsNullOrWhiteSpace(options.AuthorizationHeaderValue))
+            {
+                request.Headers.Authorization = AuthenticationHeaderValue.Parse(options.AuthorizationHeaderValue);
+            }
+
+            using var response = await client.SendAsync(request, cancellationToken);
+            var detail = response.IsSuccessStatusCode
+                ? "Alert delivered successfully."
+                : $"Alert delivery failed with status {(int)response.StatusCode}.";
+
+            return new IntakeDeliveryRecord(
+                IntakeDeliveryTypes.Alert,
+                IntakeDeliveryChannels.GenericWebhook,
+                webhookEvent.Details.IpAddress,
+                webhookEvent.Reason,
+                options.Url,
+                response.IsSuccessStatusCode ? IntakeDeliveryStatuses.Succeeded : IntakeDeliveryStatuses.Failed,
+                detail,
+                attemptedAtUtc);
+        }
+        catch (Exception ex)
+        {
+            return new IntakeDeliveryRecord(
+                IntakeDeliveryTypes.Alert,
+                IntakeDeliveryChannels.GenericWebhook,
+                webhookEvent.Details.IpAddress,
+                webhookEvent.Reason,
+                options.Url,
+                IntakeDeliveryStatuses.Failed,
+                ex.Message,
+                attemptedAtUtc);
+        }
+    }
+
+    private async Task<IntakeDeliveryRecord?> SendSmtpAsync(
+        IntakeWebhookEvent webhookEvent,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.Smtp;
+        if (!options.Enabled || string.IsNullOrWhiteSpace(options.Host) || string.IsNullOrWhiteSpace(options.From) || options.To.Length == 0)
+        {
+            return null;
+        }
+
+        var attemptedAtUtc = DateTimeOffset.UtcNow;
+        try
+        {
+            var subject = $"[AI Defense Alert] {webhookEvent.Reason}";
+            var body = BuildSmtpBody(webhookEvent);
+            await _smtpAlertSender.SendAsync(
+                options.Host,
+                options.Port,
+                options.Username,
+                options.Password,
+                options.UseTls,
+                options.From,
+                options.To,
+                subject,
+                body,
+                cancellationToken);
+
+            return new IntakeDeliveryRecord(
+                IntakeDeliveryTypes.Alert,
+                IntakeDeliveryChannels.Smtp,
+                webhookEvent.Details.IpAddress,
+                webhookEvent.Reason,
+                string.Join(",", options.To),
+                IntakeDeliveryStatuses.Succeeded,
+                "Alert delivered successfully.",
+                attemptedAtUtc);
+        }
+        catch (Exception ex)
+        {
+            return new IntakeDeliveryRecord(
+                IntakeDeliveryTypes.Alert,
+                IntakeDeliveryChannels.Smtp,
+                webhookEvent.Details.IpAddress,
+                webhookEvent.Reason,
+                string.Join(",", options.To),
+                IntakeDeliveryStatuses.Failed,
+                ex.Message,
+                attemptedAtUtc);
+        }
+    }
+
+    private static string BuildSmtpBody(IntakeWebhookEvent webhookEvent)
+    {
+        var detail = webhookEvent.Details;
+        var builder = new StringBuilder();
+        builder.AppendLine("Confirmed malicious traffic was processed by the intake pipeline.");
+        builder.AppendLine();
+        builder.AppendLine($"Reason: {webhookEvent.Reason}");
+        builder.AppendLine($"Timestamp (UTC): {webhookEvent.TimestampUtc:O}");
+        builder.AppendLine($"IP Address: {detail.IpAddress}");
+        builder.AppendLine($"Method: {detail.Method ?? "N/A"}");
+        builder.AppendLine($"Path: {detail.Path ?? "/"}");
+        builder.AppendLine($"User Agent: {detail.UserAgent ?? "N/A"}");
+        builder.AppendLine($"Signals: {string.Join(", ", detail.Signals ?? [])}");
+        return builder.ToString();
+    }
+}
+

--- a/RedisBlocklistMiddlewareApp/Services/IntakeDeliveryConstants.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IntakeDeliveryConstants.cs
@@ -1,0 +1,25 @@
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public static class IntakeDeliveryTypes
+{
+    public const string Alert = "alert";
+
+    public const string CommunityReport = "community_report";
+}
+
+public static class IntakeDeliveryChannels
+{
+    public const string GenericWebhook = "generic_webhook";
+
+    public const string Smtp = "smtp";
+}
+
+public static class IntakeDeliveryStatuses
+{
+    public const string Succeeded = "succeeded";
+
+    public const string Failed = "failed";
+
+    public const string Skipped = "skipped";
+}
+

--- a/RedisBlocklistMiddlewareApp/Services/OperatorDashboardPageService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/OperatorDashboardPageService.cs
@@ -187,7 +187,7 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
 
     .status-grid {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 12px;
     }
 
@@ -354,7 +354,7 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
       <div class="hero-grid">
         <div>
           <h1>Scraping defense command board.</h1>
-          <p>Recent decisions, edge metrics, peer and community sync health, and manual blocklist controls all live here. Every action still flows through the authenticated management API.</p>
+          <p>Recent decisions, edge metrics, intake delivery health, peer and community sync health, and manual blocklist controls all live here. Every action still flows through the authenticated management API.</p>
         </div>
         <aside class="login-panel">
           <div class="status-bar">
@@ -463,6 +463,11 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
           <p class="mono">No lookup performed yet.</p>
         </div>
         <div class="status-grid">
+          <section class="status-card">
+            <h3>Intake deliveries</h3>
+            <p id="intakeStatusCopy">Waiting for session.</p>
+            <p class="inline-note">Summary from `/defense/intake-delivery-metrics`; detailed attempts remain available at `/defense/intake-deliveries`.</p>
+          </section>
           <section class="status-card">
             <h3>Community feeds</h3>
             <p id="communityStatusCopy">Waiting for session.</p>
@@ -610,11 +615,13 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
     }
 
     async function refreshStatuses() {
-      const [community, peer] = await Promise.all([
+      const [intake, community, peer] = await Promise.all([
+        fetchJson("/defense/intake-delivery-metrics"),
         fetchJson("/defense/community-blocklist/status"),
         fetchJson("/defense/peer-sync/status")
       ]);
 
+      document.getElementById("intakeStatusCopy").textContent = summarizeIntakeStatus(intake);
       document.getElementById("communityStatusCopy").textContent = summarizeStatus(community.enabled, community.importedCount, community.rejectedCount, community.lastSuccessAtUtc, community.lastError);
       document.getElementById("peerStatusCopy").textContent = summarizePeerStatus(peer);
     }
@@ -718,6 +725,7 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
       document.getElementById("metricObserved").textContent = "0";
       document.getElementById("metricLatest").textContent = "none";
       eventsTableBody.innerHTML = '<tr><td colspan="6" class="empty">Sign in to load recent defense decisions.</td></tr>';
+      document.getElementById("intakeStatusCopy").textContent = "Waiting for session.";
       document.getElementById("communityStatusCopy").textContent = "Waiting for session.";
       document.getElementById("peerStatusCopy").textContent = "Waiting for session.";
       blocklistResult.innerHTML = '<h3>Blocklist result</h3><p class="mono">No lookup performed yet.</p>';
@@ -744,6 +752,10 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
       }
 
       return `${number(imported)} imported, ${number(rejected)} rejected, last success ${lastSuccessAtUtc ? formatDate(lastSuccessAtUtc) : "never"}${lastError ? ", error: " + lastError : ""}`;
+    }
+
+    function summarizeIntakeStatus(intake) {
+      return `${number(intake.totalAttempts)} attempts, ${number(intake.succeededCount)} succeeded, ${number(intake.failedCount)} failed, ${number(intake.skippedCount)} skipped, latest ${intake.latestAttemptAtUtc ? formatDate(intake.latestAttemptAtUtc) : "never"}`;
     }
 
     function summarizePeerStatus(peer) {

--- a/RedisBlocklistMiddlewareApp/Services/SmtpAlertSender.cs
+++ b/RedisBlocklistMiddlewareApp/Services/SmtpAlertSender.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Net.Mail;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class SmtpAlertSender : ISmtpAlertSender
+{
+    public Task SendAsync(
+        string host,
+        int port,
+        string username,
+        string password,
+        bool useTls,
+        string from,
+        IReadOnlyList<string> to,
+        string subject,
+        string body,
+        CancellationToken cancellationToken)
+    {
+        using var client = new SmtpClient(host, port)
+        {
+            EnableSsl = useTls
+        };
+
+        if (!string.IsNullOrWhiteSpace(username))
+        {
+            client.Credentials = new NetworkCredential(username, password);
+        }
+
+        using var message = new MailMessage
+        {
+            From = new MailAddress(from),
+            Subject = subject,
+            Body = body
+        };
+
+        foreach (var recipient in to)
+        {
+            message.To.Add(recipient);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        client.Send(message);
+        return Task.CompletedTask;
+    }
+}
+

--- a/RedisBlocklistMiddlewareApp/Services/SqliteIntakeDeliveryStore.cs
+++ b/RedisBlocklistMiddlewareApp/Services/SqliteIntakeDeliveryStore.cs
@@ -1,0 +1,187 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class SqliteIntakeDeliveryStore : IIntakeDeliveryStore
+{
+    private readonly string _connectionString;
+    private readonly int _maxRecentEvents;
+    private readonly object _gate = new();
+
+    public SqliteIntakeDeliveryStore(
+        IOptions<DefenseEngineOptions> options,
+        IHostEnvironment environment)
+    {
+        var databasePath = options.Value.Audit.DatabasePath;
+        var resolvedDatabasePath = Path.IsPathRooted(databasePath)
+            ? databasePath
+            : Path.Combine(environment.ContentRootPath, databasePath);
+
+        var directory = Path.GetDirectoryName(resolvedDatabasePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = resolvedDatabasePath
+        }.ToString();
+        _maxRecentEvents = options.Value.Audit.MaxRecentEvents;
+        EnsureSchema();
+    }
+
+    public void Add(IntakeDeliveryRecord record)
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                INSERT INTO intake_delivery_events
+                (
+                    delivery_type,
+                    channel,
+                    ip_address,
+                    reason,
+                    target,
+                    status,
+                    detail,
+                    attempted_at_utc
+                )
+                VALUES
+                (
+                    $deliveryType,
+                    $channel,
+                    $ipAddress,
+                    $reason,
+                    $target,
+                    $status,
+                    $detail,
+                    $attemptedAtUtc
+                );
+                """;
+            command.Parameters.AddWithValue("$deliveryType", record.DeliveryType);
+            command.Parameters.AddWithValue("$channel", record.Channel);
+            command.Parameters.AddWithValue("$ipAddress", record.IpAddress);
+            command.Parameters.AddWithValue("$reason", record.Reason);
+            command.Parameters.AddWithValue("$target", record.Target);
+            command.Parameters.AddWithValue("$status", record.Status);
+            command.Parameters.AddWithValue("$detail", record.Detail);
+            command.Parameters.AddWithValue("$attemptedAtUtc", record.AttemptedAtUtc.UtcDateTime.ToString("O"));
+            command.ExecuteNonQuery();
+        }
+    }
+
+    public IReadOnlyList<IntakeDeliveryRecord> GetRecent(int count)
+    {
+        var safeCount = Math.Clamp(count, 1, _maxRecentEvents);
+        var results = new List<IntakeDeliveryRecord>(safeCount);
+
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                SELECT
+                    delivery_type,
+                    channel,
+                    ip_address,
+                    reason,
+                    target,
+                    status,
+                    detail,
+                    attempted_at_utc
+                FROM intake_delivery_events
+                ORDER BY attempted_at_utc DESC, id DESC
+                LIMIT $limit;
+                """;
+            command.Parameters.AddWithValue("$limit", safeCount);
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                results.Add(new IntakeDeliveryRecord(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.GetString(2),
+                    reader.GetString(3),
+                    reader.GetString(4),
+                    reader.GetString(5),
+                    reader.GetString(6),
+                    DateTimeOffset.Parse(reader.GetString(7))));
+            }
+        }
+
+        return results;
+    }
+
+    public IntakeDeliveryMetrics GetMetrics()
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                SELECT
+                    COUNT(*),
+                    COALESCE(SUM(CASE WHEN status = 'succeeded' THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END), 0),
+                    MAX(attempted_at_utc)
+                FROM intake_delivery_events;
+                """;
+
+            using var reader = command.ExecuteReader();
+            reader.Read();
+
+            return new IntakeDeliveryMetrics(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetInt64(2),
+                reader.GetInt64(3),
+                reader.IsDBNull(4) ? null : DateTimeOffset.Parse(reader.GetString(4)));
+        }
+    }
+
+    private void EnsureSchema()
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                CREATE TABLE IF NOT EXISTS intake_delivery_events
+                (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    delivery_type TEXT NOT NULL,
+                    channel TEXT NOT NULL,
+                    ip_address TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    target TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    detail TEXT NOT NULL,
+                    attempted_at_utc TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_intake_delivery_events_attempted_at
+                    ON intake_delivery_events (attempted_at_utc DESC, id DESC);
+                """;
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private SqliteConnection OpenConnection()
+    {
+        var connection = new SqliteConnection(_connectionString);
+        connection.Open();
+        return connection;
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/WebhookIntakeProcessingService.cs
@@ -9,6 +9,9 @@ public sealed class WebhookIntakeProcessingService : BackgroundService
     private readonly IWebhookEventInbox _inbox;
     private readonly IBlocklistService _blocklistService;
     private readonly IDefenseEventStore _eventStore;
+    private readonly IIntakeAlertDispatcher _alertDispatcher;
+    private readonly ICommunityReporter _communityReporter;
+    private readonly IIntakeDeliveryStore _deliveryStore;
     private readonly DefenseTelemetry _telemetry;
     private readonly ILogger<WebhookIntakeProcessingService> _logger;
 
@@ -16,12 +19,18 @@ public sealed class WebhookIntakeProcessingService : BackgroundService
         IWebhookEventInbox inbox,
         IBlocklistService blocklistService,
         IDefenseEventStore eventStore,
+        IIntakeAlertDispatcher alertDispatcher,
+        ICommunityReporter communityReporter,
+        IIntakeDeliveryStore deliveryStore,
         DefenseTelemetry telemetry,
         ILogger<WebhookIntakeProcessingService> logger)
     {
         _inbox = inbox;
         _blocklistService = blocklistService;
         _eventStore = eventStore;
+        _alertDispatcher = alertDispatcher;
+        _communityReporter = communityReporter;
+        _deliveryStore = deliveryStore;
         _telemetry = telemetry;
         _logger = logger;
     }
@@ -73,6 +82,23 @@ public sealed class WebhookIntakeProcessingService : BackgroundService
                         ])));
 
                 _telemetry.RecordDecision("blocked", "webhook_intake");
+                var alertDeliveries = await _alertDispatcher.DispatchAsync(item.Event, stoppingToken);
+                foreach (var delivery in alertDeliveries)
+                {
+                    _deliveryStore.Add(delivery);
+                    _telemetry.RecordIntakeDelivery(delivery.DeliveryType, delivery.Channel, delivery.Status);
+                }
+
+                var communityDelivery = await _communityReporter.ReportAsync(item.Event, stoppingToken);
+                if (communityDelivery is not null)
+                {
+                    _deliveryStore.Add(communityDelivery);
+                    _telemetry.RecordIntakeDelivery(
+                        communityDelivery.DeliveryType,
+                        communityDelivery.Channel,
+                        communityDelivery.Status);
+                }
+
                 await _inbox.CompleteAsync(item.Id, stoppingToken);
             }
             catch (Exception ex)

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -71,7 +71,35 @@
     },
     "Intake": {
       "ApiKeyHeaderName": "X-Webhook-Key",
-      "ApiKey": ""
+      "ApiKey": "",
+      "Alerting": {
+        "GenericWebhook": {
+          "Enabled": false,
+          "Url": "",
+          "AuthorizationHeaderValue": "",
+          "TimeoutSeconds": 10
+        },
+        "Smtp": {
+          "Enabled": false,
+          "Host": "",
+          "Port": 587,
+          "Username": "",
+          "Password": "",
+          "UseTls": true,
+          "From": "",
+          "To": []
+        }
+      },
+      "CommunityReporting": {
+        "Enabled": false,
+        "ProviderName": "AbuseIPDB",
+        "Endpoint": "",
+        "ApiKeyHeaderName": "Key",
+        "ApiKey": "",
+        "TimeoutSeconds": 10,
+        "DefaultCategories": "19",
+        "CommentPrefix": "AI Defense Stack detection"
+      }
     },
     "Audit": {
       "DatabasePath": "data/defense-events.db",

--- a/docs/commercial_scope.md
+++ b/docs/commercial_scope.md
@@ -15,6 +15,7 @@ Included in v1:
 - authenticated operator endpoints for events, metrics, and manual blocklist actions
 - protected operator dashboard on top of the authenticated management API
 - authenticated `/analyze` intake for externally confirmed malicious events
+- configurable alert dispatch and outbound community reporting for processed intake events
 - durable SQLite-backed audit and webhook inbox persistence
 - configurable community blocklist sync with operator-visible status
 - peer sync with authenticated export and explicit trust modes

--- a/docs/operator_runbook.md
+++ b/docs/operator_runbook.md
@@ -27,6 +27,8 @@ At minimum, set:
 - `DefenseEngine:Redis:ConnectionString`
 - `DefenseEngine:Management:ApiKey`
 - `DefenseEngine:Intake:ApiKey` if webhook intake is required
+- `DefenseEngine:Intake:Alerting:*` if webhook or SMTP alerts are required
+- `DefenseEngine:Intake:CommunityReporting:*` if outbound community reporting is required
 - `DefenseEngine:Audit:DatabasePath`
 - `DefenseEngine:Networking:ClientIpResolutionMode`
 
@@ -53,6 +55,12 @@ Check authenticated metrics:
 
 ```bash
 curl -H 'X-API-Key: <management-key>' http://localhost:8080/defense/metrics
+```
+
+Check intake delivery metrics:
+
+```bash
+curl -H 'X-API-Key: <management-key>' http://localhost:8080/defense/intake-delivery-metrics
 ```
 
 ## Dashboard Access
@@ -114,6 +122,13 @@ curl -X POST \
   }'
 ```
 
+Inspect recent intake delivery attempts:
+
+```bash
+curl -H 'X-API-Key: <management-key>' \
+  'http://localhost:8080/defense/intake-deliveries?count=20'
+```
+
 ## Community and Peer Sync Checks
 
 Community blocklist status:
@@ -158,5 +173,5 @@ If `DefenseEngine:Observability:OtlpEndpoint` is configured, traces are exported
 - `503 /health`: Redis is unreachable or misconfigured
 - startup failure in `Production`: loopback Redis or unsafe proxy config is still present
 - missing real client IPs: proxy/CDN trust mode is not configured correctly
+- intake delivery failures: inspect `/defense/intake-deliveries` for failed webhook, SMTP, or community-report attempts
 - empty Markov tarpit output changes: PostgreSQL corpus is empty or unavailable, so synthetic fallback content is being used
-

--- a/docs/parity_matrix.md
+++ b/docs/parity_matrix.md
@@ -14,16 +14,15 @@ Status legend:
 | Suspicious-request queue and background analysis | Implemented | Requests are queued, scored, persisted, and can trigger auto-blocking. | Expand scoring inputs and tuning ergonomics. |
 | Authenticated operator API | Implemented | `/defense/events`, `/defense/metrics`, blocklist controls, community status, and peer-sync status are protected. | Add richer operator workflows and filtering. |
 | Operator dashboard | Implemented | Browser dashboard ships inside the same deployable and uses the same protected management API. | Expand search, drill-down, and investigation ergonomics. |
-| Webhook intake for confirmed malicious traffic | Implemented | `/analyze` is authenticated, durable, and processed asynchronously. | Add alerting/reporting parity from the legacy AI-service path. See issue `#53`. |
-| Community blocklist sync | Implemented | Feed sync, status reporting, and import tracking are in place. | Add richer trust policies and reporting controls. See issue `#53`. |
+| Webhook intake for confirmed malicious traffic | Implemented | `/analyze` is authenticated, durable, processed asynchronously, and can trigger outbound alert/report workflows. | Keep expanding provider coverage only when operational demand justifies it. |
+| Community blocklist sync | Implemented | Feed sync, status reporting, import tracking, and outbound community reporting for intake events are in place. | Add richer trust policies and provider-specific controls as needed. |
 | Peer sync | Implemented | Timed imports, authenticated exports, and `ObserveOnly`/`BlockList` trust modes are implemented. | Add richer trust scoring and coordination. |
 | PostgreSQL-backed Markov tarpit | Implemented | The tarpit can load a Markov corpus from PostgreSQL and falls back safely when no snapshot exists. | Expand deeper decoy modes. See issue `#55`. |
 | Advanced tarpit decoys | Partial | Current tarpit modes cover deterministic HTML, archive, and API-catalog variants. | Port rotating archives and JavaScript ZIP honeypots. See issue `#55`. |
 | Reputation providers and classifier hooks | Partial | Configured ranges, HTTP reputation, and OpenAI-compatible model adapters exist. | Port trained ML lifecycle and richer provider orchestration. See issue `#54`. |
-| Alerting and operator/community reporting | Partial | Durable intake exists, but outbound alert/report workflows from the legacy AI service are not fully ported. | See issue `#53`. |
+| Alerting and operator/community reporting | Partial | Confirmed malicious intake events can dispatch generic webhook alerts, SMTP alerts, and configurable community reports with durable delivery visibility. | Slack-specific alert channel parity still remains. See issue `#60`. |
 | Structured telemetry export | Partial | Prometheus metrics and OTLP trace export are wired into the app. | Add dashboard examples, alert rules, and richer release telemetry guidance. |
 | Independent multi-service deployment | Deferred | v1 intentionally ships as a single deployable ASP.NET Core runtime. | Split into independently deployed roles only when operations justify it. |
 | SQL Server support | Deferred | Redis + SQLite + PostgreSQL are the supported data stores for v1. | Revisit only if customer demand justifies the extra provider surface. |
 
-Commercial v1 is feature-complete enough to package and validate, but full upstream parity still depends on closing issues `#53`, `#54`, and `#55`.
-
+Commercial v1 is feature-complete enough to package and validate, but fuller upstream parity still depends on closing issues `#54`, `#55`, and `#60`.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -15,6 +15,7 @@ Use this checklist before cutting a commercial release candidate.
 - management dashboard login works
 - authenticated operator endpoints work
 - webhook intake accepts and processes a known-good sample event
+- configured webhook/SMTP/community-report deliveries succeed or fail observably during a sample intake event
 - suspicious traffic is tarpitted and can escalate to a block
 - Prometheus metrics are reachable when enabled
 - OTLP export is verified if configured
@@ -40,4 +41,3 @@ Use this checklist before cutting a commercial release candidate.
 - `docs/parity_matrix.md` reflects the current status honestly
 - `CHANGELOG.md` has an `Unreleased` entry summarizing the release-hardening work
 - remaining deferred parity items are tracked as GitHub issues, not hidden in review threads
-


### PR DESCRIPTION
## Summary
- add durable intake delivery records plus management endpoints and dashboard visibility
- dispatch webhook and SMTP alerts plus configurable outbound community reports from processed intake events
- add unit coverage for intake processing, alert dispatch, reporting, and delivery storage

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

## Follow-up
- Slack-specific alert channel parity remains tracked in #60
- closes #53
