### PR TITLE
Add production observability pack

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -29,3 +29,5 @@ jobs:
       - name: Test
         run: dotnet test anti-scraping-defense-iis.sln --no-build
 
+      - name: Validate Observability Compose Stack
+        run: docker compose -f compose.yaml -f compose.observability.yaml config > /tmp/compose-observability.yml

--- a/AiScrapingDefense.IntegrationTests/DefenseStackFixture.cs
+++ b/AiScrapingDefense.IntegrationTests/DefenseStackFixture.cs
@@ -45,7 +45,7 @@ public sealed class DefenseStackFixture : IAsyncLifetime
         await _redisContainer.DisposeAsync();
     }
 
-    public async Task<IntegrationTestHost> CreateHostAsync()
+    public async Task<IntegrationTestHost> CreateHostAsync(IReadOnlyDictionary<string, string?>? overrides = null)
     {
         const int redisDatabaseBase = 0;
         var auditDirectory = Path.Combine(Path.GetTempPath(), "ai-scraping-defense-tests", Guid.NewGuid().ToString("N"));
@@ -77,6 +77,22 @@ public sealed class DefenseStackFixture : IAsyncLifetime
             ["DefenseEngine:Observability:EnablePrometheusEndpoint"] = "false"
         };
 
+        if (overrides is not null)
+        {
+            foreach (var pair in overrides)
+            {
+                settings[pair.Key] = pair.Value;
+            }
+        }
+
+        var enablePrometheusEndpoint = string.Equals(
+            settings["DefenseEngine:Observability:EnablePrometheusEndpoint"],
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+        var otlpEndpoint = settings.TryGetValue("DefenseEngine:Observability:OtlpEndpoint", out var configuredOtlpEndpoint)
+            ? configuredOtlpEndpoint ?? string.Empty
+            : string.Empty;
+
         var factory = new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
             {
@@ -106,7 +122,8 @@ public sealed class DefenseStackFixture : IAsyncLifetime
                         options.Tarpit.PostgresMarkov.ConnectionString = _postgresContainer.GetConnectionString();
                         options.PeerSync.Enabled = false;
                         options.CommunityBlocklist.Enabled = false;
-                        options.Observability.EnablePrometheusEndpoint = false;
+                        options.Observability.EnablePrometheusEndpoint = enablePrometheusEndpoint;
+                        options.Observability.OtlpEndpoint = otlpEndpoint;
                     });
                 });
             });

--- a/AiScrapingDefense.IntegrationTests/ObservabilityFlowTests.cs
+++ b/AiScrapingDefense.IntegrationTests/ObservabilityFlowTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+
+namespace AiScrapingDefense.IntegrationTests;
+
+[Collection(EndToEndCollection.Name)]
+public sealed class ObservabilityFlowTests
+{
+    private readonly DefenseStackFixture _fixture;
+
+    public ObservabilityFlowTests(DefenseStackFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task MetricsEndpoint_ExposesDefenseMetrics_WhenPrometheusIsEnabled()
+    {
+        await using var host = await _fixture.CreateHostAsync(new Dictionary<string, string?>
+        {
+            ["DefenseEngine:Observability:EnablePrometheusEndpoint"] = "true"
+        });
+        var client = host.Client;
+
+        using (var suspiciousRequest = new HttpRequestMessage(HttpMethod.Get, "/docs"))
+        {
+            suspiciousRequest.Headers.Add(HeaderDrivenClientIpResolver.HeaderName, "198.51.100.71");
+            suspiciousRequest.Headers.UserAgent.ParseAdd("Mozilla/5.0");
+            suspiciousRequest.Headers.Accept.ParseAdd("*/*");
+            var response = await client.SendAsync(suspiciousRequest);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        var metricsBody = await WaitForMetricsAsync(client, body =>
+            body.Contains("ai_scraping_defense_suspicious_requests_total", StringComparison.Ordinal) &&
+            body.Contains("ai_scraping_defense_queue_depth", StringComparison.Ordinal) &&
+            body.Contains("ai_scraping_defense_queue_capacity", StringComparison.Ordinal));
+
+        Assert.NotNull(metricsBody);
+    }
+
+    private static async Task<string?> WaitForMetricsAsync(HttpClient client, Func<string, bool> predicate)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var response = await client.GetAsync("/metrics");
+            if (response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                if (predicate(body))
+                {
+                    return body;
+                }
+            }
+
+            await Task.Delay(200);
+        }
+
+        return null;
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Containerized deployment artifacts for the .NET runtime (`Dockerfile`, `compose.yaml`).
+* An observability overlay with Prometheus, Grafana provisioning, alert rules, and an OTLP collector example (`compose.observability.yaml`, `deploy/observability/*`).
 * A GitHub Actions workflow that restores, builds, and tests the solution on every push and pull request.
 * A containerized integration-test project covering suspicious request handling, management blocklist operations, webhook intake, and PostgreSQL-backed tarpit rendering.
 * Prometheus/OTLP observability options and runtime instrumentation for defense decisions, tarpit responses, webhook intake, and sync activity.
+* Queue depth and capacity telemetry for queued suspicious-request pressure monitoring.
 * Release documentation for parity, operator operations, and release validation.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ The repository now includes:
 
 - a production-oriented multi-stage [Dockerfile](Dockerfile)
 - a local smoke/deployment [compose.yaml](compose.yaml)
+- an observability overlay at [compose.observability.yaml](compose.observability.yaml)
 - a GitHub Actions CI workflow at [.github/workflows/dotnet-ci.yml](.github/workflows/dotnet-ci.yml)
 
 Use `docker compose up --build` for a quick end-to-end environment with Redis and PostgreSQL.
+Use `docker compose -f compose.yaml -f compose.observability.yaml up --build` to include Prometheus, Grafana, and the OpenTelemetry Collector.

--- a/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
@@ -61,6 +61,35 @@ public sealed class RedisBlocklistMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_BypassesPrometheusMetricsEndpoint_WhenEnabled()
+    {
+        var blocklist = new FakeBlocklistService { IsBlockedResult = true };
+        var queue = new FakeSuspiciousRequestQueue();
+        var eventStore = new FakeDefenseEventStore();
+        var nextState = new NextDelegateState();
+        var middleware = CreateMiddleware(
+            nextState,
+            blocklist,
+            new FakeRequestSignalEvaluator(new RequestSignalEvaluation(false, string.Empty, [])),
+            queue,
+            eventStore,
+            new FakeClientIpResolver("198.51.100.15"),
+            options =>
+            {
+                options.Observability.EnablePrometheusEndpoint = true;
+                options.Observability.PrometheusEndpointPath = "/metrics";
+            });
+        var context = CreateContext("/metrics");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextState.WasCalled);
+        Assert.Equal(0, blocklist.IsBlockedCallCount);
+        Assert.Empty(queue.Requests);
+        Assert.Empty(eventStore.Decisions);
+    }
+
+    [Fact]
     public async Task InvokeAsync_BypassesIntakeEndpoints()
     {
         var blocklist = new FakeBlocklistService { IsBlockedResult = true };

--- a/RedisBlocklistMiddlewareApp.Tests/SuspiciousRequestQueueTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/SuspiciousRequestQueueTests.cs
@@ -60,7 +60,7 @@ public sealed class SuspiciousRequestQueueTests
             {
                 Capacity = capacity
             }
-        }));
+        }), TestTelemetryFactory.Create());
     }
 
     private static SuspiciousRequest CreateRequest(string ipAddress, string path)

--- a/RedisBlocklistMiddlewareApp/RedisBlocklistMiddleware.cs
+++ b/RedisBlocklistMiddlewareApp/RedisBlocklistMiddleware.cs
@@ -152,6 +152,8 @@ public sealed class RedisBlocklistMiddleware
         var value = path.Value ?? string.Empty;
         return value.StartsWith(_options.Tarpit.PathPrefix, StringComparison.OrdinalIgnoreCase) ||
                value.StartsWith("/health", StringComparison.OrdinalIgnoreCase) ||
+               (_options.Observability.EnablePrometheusEndpoint &&
+                value.StartsWith(_options.Observability.PrometheusEndpointPath, StringComparison.OrdinalIgnoreCase)) ||
                value.StartsWith("/defense", StringComparison.OrdinalIgnoreCase) ||
                value.StartsWith("/analyze", StringComparison.OrdinalIgnoreCase) ||
                value.StartsWith("/peer-sync", StringComparison.OrdinalIgnoreCase);

--- a/RedisBlocklistMiddlewareApp/Services/DefenseTelemetry.cs
+++ b/RedisBlocklistMiddlewareApp/Services/DefenseTelemetry.cs
@@ -44,6 +44,12 @@ public sealed class DefenseTelemetry
         {
             LabelNames = ["delivery_type", "channel", "status"]
         });
+    private static readonly Gauge QueueDepth = Metrics.CreateGauge(
+        "ai_scraping_defense_queue_depth",
+        "Current number of suspicious requests waiting in the analysis queue.");
+    private static readonly Gauge QueueCapacity = Metrics.CreateGauge(
+        "ai_scraping_defense_queue_capacity",
+        "Configured maximum number of suspicious requests that can wait in the analysis queue.");
     private static readonly Counter CommunityImports = Metrics.CreateCounter(
         "ai_scraping_defense_community_imports_total",
         "Community-blocklist import outcomes.",
@@ -104,6 +110,12 @@ public sealed class DefenseTelemetry
         IntakeDeliveryAttempts
             .WithLabels(SanitizeLabel(deliveryType), SanitizeLabel(channel), SanitizeLabel(status))
             .Inc();
+    }
+
+    public void UpdateQueueDepth(int depth, int capacity)
+    {
+        QueueDepth.Set(Math.Max(0, depth));
+        QueueCapacity.Set(Math.Max(1, capacity));
     }
 
     public void RecordCommunitySync(int importedCount, int rejectedCount)

--- a/RedisBlocklistMiddlewareApp/Services/SuspiciousRequestQueue.cs
+++ b/RedisBlocklistMiddlewareApp/Services/SuspiciousRequestQueue.cs
@@ -8,16 +8,23 @@ namespace RedisBlocklistMiddlewareApp.Services;
 public sealed class SuspiciousRequestQueue : ISuspiciousRequestQueue
 {
     private readonly Channel<SuspiciousRequest> _channel;
+    private readonly DefenseTelemetry _telemetry;
+    private readonly int _capacity;
+    private int _depth;
 
-    public SuspiciousRequestQueue(IOptions<DefenseEngineOptions> options)
+    public SuspiciousRequestQueue(
+        IOptions<DefenseEngineOptions> options,
+        DefenseTelemetry telemetry)
     {
-        _channel = Channel.CreateBounded<SuspiciousRequest>(new BoundedChannelOptions(
-            Math.Max(1, options.Value.Queue.Capacity))
+        _telemetry = telemetry;
+        _capacity = Math.Max(1, options.Value.Queue.Capacity);
+        _channel = Channel.CreateBounded<SuspiciousRequest>(new BoundedChannelOptions(_capacity)
         {
             SingleReader = true,
             SingleWriter = false,
             FullMode = BoundedChannelFullMode.Wait
         });
+        _telemetry.UpdateQueueDepth(0, _capacity);
     }
 
     public async ValueTask<bool> QueueAsync(
@@ -26,8 +33,20 @@ public sealed class SuspiciousRequestQueue : ISuspiciousRequestQueue
     {
         try
         {
-            await _channel.Writer.WriteAsync(request, cancellationToken);
-            return true;
+            while (await _channel.Writer.WaitToWriteAsync(cancellationToken))
+            {
+                var depth = Interlocked.Increment(ref _depth);
+                if (_channel.Writer.TryWrite(request))
+                {
+                    _telemetry.UpdateQueueDepth(depth, _capacity);
+                    return true;
+                }
+
+                depth = Interlocked.Decrement(ref _depth);
+                _telemetry.UpdateQueueDepth(depth, _capacity);
+            }
+
+            return false;
         }
         catch (OperationCanceledException)
         {
@@ -37,6 +56,17 @@ public sealed class SuspiciousRequestQueue : ISuspiciousRequestQueue
 
     public IAsyncEnumerable<SuspiciousRequest> ReadAllAsync(CancellationToken cancellationToken)
     {
-        return _channel.Reader.ReadAllAsync(cancellationToken);
+        return ReadAllCoreAsync(cancellationToken);
+    }
+
+    private async IAsyncEnumerable<SuspiciousRequest> ReadAllCoreAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (var request in _channel.Reader.ReadAllAsync(cancellationToken))
+        {
+            var depth = Interlocked.Decrement(ref _depth);
+            _telemetry.UpdateQueueDepth(depth, _capacity);
+            yield return request;
+        }
     }
 }

--- a/compose.observability.yaml
+++ b/compose.observability.yaml
@@ -1,0 +1,55 @@
+services:
+  app:
+    environment:
+      DefenseEngine__Observability__EnablePrometheusEndpoint: "true"
+      DefenseEngine__Observability__PrometheusEndpointPath: /metrics
+      DefenseEngine__Observability__OtlpEndpoint: http://otel-collector:4317
+    depends_on:
+      otel-collector:
+        condition: service_started
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-lifecycle
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./deploy/observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./deploy/observability/prometheus/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro
+    depends_on:
+      app:
+        condition: service_started
+      otel-collector:
+        condition: service_started
+
+  grafana:
+    image: grafana/grafana:11.2.2
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./deploy/observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./deploy/observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      prometheus:
+        condition: service_started
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.111.0
+    command:
+      - --config=/etc/otelcol-contrib/config.yaml
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "13133:13133"
+    volumes:
+      - ./deploy/observability/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+
+volumes:
+  grafana-data:

--- a/deploy/observability/grafana/dashboards/ai-scraping-defense-overview.json
+++ b/deploy/observability/grafana/dashboards/ai-scraping-defense-overview.json
@@ -1,0 +1,405 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(ai_scraping_defense_suspicious_requests_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Suspicious Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(ai_scraping_defense_block_decisions_total[15m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocks Last 15m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "max(ai_scraping_defense_queue_depth / clamp_min(ai_scraping_defense_queue_capacity, 1))",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Pressure",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (channel) (rate(ai_scraping_defense_intake_delivery_total{status=\"failed\"}[15m]))",
+          "legendFormat": "{{channel}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Intake Delivery Failure Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(ai_scraping_defense_tarpit_renders_total[5m]))",
+          "legendFormat": "tarpit renders",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(ai_scraping_defense_webhook_intake_total[5m]))",
+          "legendFormat": "webhook intake",
+          "refId": "B"
+        }
+      ],
+      "title": "Tarpit and Intake Activity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(ai_scraping_defense_community_imports_total{result=\"rejected\"}[15m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Community Rejects Last 15m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(ai_scraping_defense_peer_imports_total{result=\"rejected\"}[15m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Peer Rejects Last 15m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(ai_scraping_defense_observed_decisions_total[5m]))",
+          "legendFormat": "observed",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(ai_scraping_defense_block_decisions_total[5m]))",
+          "legendFormat": "blocked",
+          "refId": "B"
+        }
+      ],
+      "title": "Decision Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "ai-scraping-defense",
+    "observability"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "AI Scraping Defense Overview",
+  "uid": "ai-scraping-defense-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: ai-scraping-defense
+    orgId: 1
+    folder: AI Scraping Defense
+    type: file
+    disableDeletion: true
+    editable: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/observability/grafana/provisioning/datasources/datasources.yml
+++ b/deploy/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/observability/otel-collector-config.yaml
+++ b/deploy/observability/otel-collector-config.yaml
@@ -1,0 +1,33 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  debug:
+    verbosity: basic
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions:
+    - health_check
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8888
+  pipelines:
+    traces:
+      receivers:
+        - otlp
+      processors:
+        - batch
+      exporters:
+        - debug

--- a/deploy/observability/prometheus/alert_rules.yml
+++ b/deploy/observability/prometheus/alert_rules.yml
@@ -1,0 +1,38 @@
+groups:
+  - name: ai-scraping-defense
+    rules:
+      - alert: AiScrapingDefenseBlockSpike
+        expr: sum(increase(ai_scraping_defense_block_decisions_total[5m])) > 25
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Block decisions are spiking
+          description: The defense stack has blocked more than 25 requests in the last 5 minutes.
+
+      - alert: AiScrapingDefenseQueuePressure
+        expr: max(ai_scraping_defense_queue_depth / clamp_min(ai_scraping_defense_queue_capacity, 1)) > 0.8
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: Suspicious-request queue is under sustained pressure
+          description: The queued analysis backlog is above 80 percent of configured capacity for 10 minutes.
+
+      - alert: AiScrapingDefenseSyncFailures
+        expr: sum(increase(ai_scraping_defense_community_imports_total{result="rejected"}[15m])) + sum(increase(ai_scraping_defense_peer_imports_total{result="rejected"}[15m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Community or peer sync failures detected
+          description: The defense stack has rejected community-feed or peer-sync records in the last 15 minutes.
+
+      - alert: AiScrapingDefenseIntakeDeliveryFailures
+        expr: sum(increase(ai_scraping_defense_intake_delivery_total{status="failed"}[15m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Intake alert or reporting deliveries are failing
+          description: One or more webhook, SMTP, or community-report deliveries failed in the last 15 minutes.

--- a/deploy/observability/prometheus/prometheus.yml
+++ b/deploy/observability/prometheus/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alert_rules.yml
+
+scrape_configs:
+  - job_name: ai-scraping-defense
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - app:8080
+
+  - job_name: otel-collector
+    static_configs:
+      - targets:
+          - otel-collector:8888

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,13 @@ This documentation index is for the current .NET implementation in this reposito
 - [Release Blockers](release_blockers.md)
 - [Release Checklist](release_checklist.md)
 - [Operator Runbook](operator_runbook.md)
+- [Observability Pack](observability_pack.md)
 
 ## Deployment
 
 - [Dockerfile](../Dockerfile)
 - [Compose Stack](../compose.yaml)
+- [Observability Overlay](../compose.observability.yaml)
 - [IIS Deployment Guide](iis_deployment_guide.md)
 
 ## Project and policy

--- a/docs/observability_pack.md
+++ b/docs/observability_pack.md
@@ -1,0 +1,92 @@
+# Observability Pack
+
+This repository ships a starter observability bundle for the commercial .NET deployment path. It is designed to make the built-in Prometheus metrics and OTLP trace export operational without forcing operators to wire the whole stack from scratch.
+
+## Included Assets
+
+- `compose.observability.yaml` extends the base compose stack with Prometheus, Grafana, and an OpenTelemetry Collector.
+- `deploy/observability/prometheus/prometheus.yml` scrapes the app and collector metrics.
+- `deploy/observability/prometheus/alert_rules.yml` provides starter rules for block spikes, queue pressure, sync failures, and intake-delivery failures.
+- `deploy/observability/grafana/...` provisions a dashboard and data source automatically.
+- `deploy/observability/otel-collector-config.yaml` receives OTLP traces from the app and exports them through the collector's debug exporter by default.
+
+## Running the Stack
+
+Start the base runtime plus observability services:
+
+```bash
+docker compose -f compose.yaml -f compose.observability.yaml up --build
+```
+
+The stack will expose:
+
+- app: `http://localhost:8080`
+- Prometheus: `http://localhost:9090`
+- Grafana: `http://localhost:3000`
+- OTLP gRPC: `localhost:4317`
+- OTLP HTTP: `localhost:4318`
+- Collector health: `http://localhost:13133`
+
+Grafana defaults:
+
+- username: `admin`
+- password: `admin`
+
+## What the Dashboard Covers
+
+The bundled Grafana dashboard focuses on the core operational questions for this stack:
+
+- suspicious request rate by reason
+- block rate over the last 15 minutes
+- queue pressure using `ai_scraping_defense_queue_depth` and `ai_scraping_defense_queue_capacity`
+- intake delivery failure rate by channel
+- tarpit and webhook intake activity
+- recent rejected records from community and peer sync
+
+## Alert Rules
+
+Starter Prometheus alerts are bundled for:
+
+- sustained spikes in block decisions
+- suspicious-request queue saturation
+- rejected community or peer sync imports
+- failed webhook, SMTP, or community-report deliveries from the intake pipeline
+
+Treat the thresholds as starting values. They are intentionally conservative and should be tuned against real traffic after deployment.
+
+## OTLP Collector Notes
+
+The collector config is intentionally minimal:
+
+- it receives OTLP traces over gRPC and HTTP
+- it batches traces
+- it exports them through the `debug` exporter
+
+For a real production trace backend, replace the `debug` exporter in `deploy/observability/otel-collector-config.yaml` with your chosen OTLP, Tempo, vendor, or other supported exporter.
+
+## Validation
+
+Validate the compose configuration:
+
+```bash
+docker compose -f compose.yaml -f compose.observability.yaml config
+```
+
+Check that the app metrics are visible:
+
+```bash
+curl http://localhost:8080/metrics
+```
+
+Trigger a suspicious request, then confirm metrics such as:
+
+- `ai_scraping_defense_suspicious_requests_total`
+- `ai_scraping_defense_block_decisions_total`
+- `ai_scraping_defense_queue_depth`
+- `ai_scraping_defense_intake_delivery_total`
+
+Check that the collector is healthy:
+
+```bash
+curl http://localhost:13133/
+```

--- a/docs/operator_runbook.md
+++ b/docs/operator_runbook.md
@@ -20,6 +20,12 @@ docker compose up --build
 
 The app will be available on `http://localhost:8080`.
 
+To include the bundled monitoring stack:
+
+```bash
+docker compose -f compose.yaml -f compose.observability.yaml up --build
+```
+
 ## Required Production Configuration
 
 At minimum, set:
@@ -161,6 +167,14 @@ curl http://localhost:8080/metrics
 ```
 
 If `DefenseEngine:Observability:OtlpEndpoint` is configured, traces are exported to that collector.
+
+The bundled observability overlay provisions:
+
+- Prometheus at `http://localhost:9090`
+- Grafana at `http://localhost:3000`
+- an OpenTelemetry Collector with OTLP on `4317` and `4318`
+
+See [observability_pack.md](observability_pack.md) for the packaged monitoring assets and default alert rules.
 
 ## Backup and Recovery
 

--- a/docs/parity_matrix.md
+++ b/docs/parity_matrix.md
@@ -21,7 +21,7 @@ Status legend:
 | Advanced tarpit decoys | Partial | Current tarpit modes cover deterministic HTML, archive, and API-catalog variants. | Port rotating archives and JavaScript ZIP honeypots. See issue `#55`. |
 | Reputation providers and classifier hooks | Partial | Configured ranges, HTTP reputation, and OpenAI-compatible model adapters exist. | Port trained ML lifecycle and richer provider orchestration. See issue `#54`. |
 | Alerting and operator/community reporting | Partial | Confirmed malicious intake events can dispatch generic webhook alerts, SMTP alerts, and configurable community reports with durable delivery visibility. | Slack-specific alert channel parity still remains. See issue `#60`. |
-| Structured telemetry export | Partial | Prometheus metrics and OTLP trace export are wired into the app. | Add dashboard examples, alert rules, and richer release telemetry guidance. |
+| Structured telemetry export | Implemented | Prometheus metrics, OTLP trace export, packaged scrape/alert config, and a bundled Grafana dashboard are included. | Tune thresholds and dashboard panels against production traffic after deployment. |
 | Independent multi-service deployment | Deferred | v1 intentionally ships as a single deployable ASP.NET Core runtime. | Split into independently deployed roles only when operations justify it. |
 | SQL Server support | Deferred | Redis + SQLite + PostgreSQL are the supported data stores for v1. | Revisit only if customer demand justifies the extra provider surface. |
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -8,6 +8,7 @@ Use this checklist before cutting a commercial release candidate.
 - `dotnet test anti-scraping-defense-iis.sln`
 - `docker build -t ai-scraping-defense-dotnet .`
 - `docker compose up --build` smoke run succeeds
+- `docker compose -f compose.yaml -f compose.observability.yaml config` validates the packaged monitoring overlay
 
 ## Runtime Validation
 
@@ -19,6 +20,7 @@ Use this checklist before cutting a commercial release candidate.
 - suspicious traffic is tarpitted and can escalate to a block
 - Prometheus metrics are reachable when enabled
 - OTLP export is verified if configured
+- Grafana loads the bundled dashboard against the packaged Prometheus data source
 
 ## Security and Configuration
 


### PR DESCRIPTION
## Summary
- add queue-pressure telemetry plus an integration test for the Prometheus endpoint
- package Prometheus, Grafana, alert rules, and an OpenTelemetry Collector overlay for compose deployments
- document and validate the observability stack in CI and operator docs

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln
- docker compose -f compose.yaml -f compose.observability.yaml config
- jq empty deploy/observability/grafana/dashboards/ai-scraping-defense-overview.json
- python3 YAML validation for observability assets

closes #56
