### PR TITLE
Publish signed release images and provenance

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,116 @@
+name: release-images
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Log In To GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive Release Image Tags
+        id: refs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_name="ghcr.io/${GITHUB_REPOSITORY,,}"
+          ref_name="${GITHUB_REF_NAME}"
+          version="${ref_name#v}"
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tags must follow v<semver>; received '$ref_name'." >&2
+            exit 1
+          fi
+
+          tags=(
+            "${image_name}:${ref_name}"
+            "${image_name}:${version}"
+          )
+
+          if [[ "$version" != *-* ]]; then
+            tags+=(
+              "${image_name}:${version%.*}"
+              "${image_name}:latest"
+            )
+          fi
+
+          {
+            echo "image_name=${image_name}"
+            echo "version=${version}"
+            echo "primary_tag=${image_name}:${ref_name}"
+            echo "tags<<EOF"
+            printf '%s\n' "${tags[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build And Push Release Image
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: .
+          push: true
+          sbom: true
+          provenance: false
+          tags: ${{ steps.refs.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=ai-scraping-defense-iis
+            org.opencontainers.image.description=Commercial .NET AI scraping defense runtime
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.refs.outputs.version }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9
+
+      - name: Sign Release Image
+        env:
+          IMAGE_NAME: ${{ steps.refs.outputs.image_name }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${IMAGE_NAME}@${IMAGE_DIGEST}"
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661
+        with:
+          subject-name: ${{ steps.refs.outputs.image_name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Summarize Release Artifacts
+        env:
+          IMAGE_NAME: ${{ steps.refs.outputs.image_name }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE_TAGS: ${{ steps.refs.outputs.tags }}
+        run: |
+          {
+            echo "Published release image:"
+            echo ""
+            echo "- \`${IMAGE_NAME}@${IMAGE_DIGEST}\`"
+            echo ""
+            echo "Tags:"
+            while IFS= read -r tag; do
+              echo "- \`${tag}\`"
+            done <<< "${IMAGE_TAGS}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Containerized deployment artifacts for the .NET runtime (`Dockerfile`, `compose.yaml`).
 * An observability overlay with Prometheus, Grafana provisioning, alert rules, and an OTLP collector example (`compose.observability.yaml`, `deploy/observability/*`).
 * A GitHub Actions workflow that restores, builds, and tests the solution on every push and pull request.
+* A tagged release workflow that publishes signed GHCR images with provenance (`.github/workflows/release-images.yml`).
 * A containerized integration-test project covering suspicious request handling, management blocklist operations, webhook intake, and PostgreSQL-backed tarpit rendering.
 * Prometheus/OTLP observability options and runtime instrumentation for defense decisions, tarpit responses, webhook intake, and sync activity.
 * Queue depth and capacity telemetry for queued suspicious-request pressure monitoring.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This is intentionally a single-deployable, multi-project .NET stack for v1. It p
 
 See [docs/architecture.md](docs/architecture.md) for the current architecture, [docs/commercial_scope.md](docs/commercial_scope.md) for the v1 definition, and [docs/dotnet_parity_roadmap.md](docs/dotnet_parity_roadmap.md) for the post-v1 parity queue.
 Operational release documentation now lives in [docs/parity_matrix.md](docs/parity_matrix.md), [docs/operator_runbook.md](docs/operator_runbook.md), and [docs/release_checklist.md](docs/release_checklist.md).
+Release artifact policy now lives in [docs/release_artifacts.md](docs/release_artifacts.md).
 
 ## Implemented Endpoints
 
@@ -143,6 +144,8 @@ The repository now includes:
 - a local smoke/deployment [compose.yaml](compose.yaml)
 - an observability overlay at [compose.observability.yaml](compose.observability.yaml)
 - a GitHub Actions CI workflow at [.github/workflows/dotnet-ci.yml](.github/workflows/dotnet-ci.yml)
+- a tagged-release image workflow at [.github/workflows/release-images.yml](.github/workflows/release-images.yml)
 
 Use `docker compose up --build` for a quick end-to-end environment with Redis and PostgreSQL.
 Use `docker compose -f compose.yaml -f compose.observability.yaml up --build` to include Prometheus, Grafana, and the OpenTelemetry Collector.
+Tagged releases publish signed GHCR images with provenance as documented in [docs/release_artifacts.md](docs/release_artifacts.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ This documentation index is for the current .NET implementation in this reposito
 - [API References](api_references.md)
 - [Release Blockers](release_blockers.md)
 - [Release Checklist](release_checklist.md)
+- [Release Artifacts](release_artifacts.md)
 - [Operator Runbook](operator_runbook.md)
 - [Observability Pack](observability_pack.md)
 

--- a/docs/release_artifacts.md
+++ b/docs/release_artifacts.md
@@ -1,0 +1,78 @@
+# Release Artifacts
+
+This document defines the commercial release artifact policy for the .NET stack.
+
+## Registry
+
+Tagged releases publish container images to GitHub Container Registry:
+
+```text
+ghcr.io/<owner>/ai-scraping-defense-iis
+```
+
+The release workflow is implemented in [release-images.yml](../.github/workflows/release-images.yml) and runs on Git tags that match `v*`.
+
+## Tagging Policy
+
+For a stable release tag such as `v1.4.2`, the workflow publishes:
+
+- `ghcr.io/<owner>/ai-scraping-defense-iis:v1.4.2`
+- `ghcr.io/<owner>/ai-scraping-defense-iis:1.4.2`
+- `ghcr.io/<owner>/ai-scraping-defense-iis:1.4`
+- `ghcr.io/<owner>/ai-scraping-defense-iis:latest`
+
+For a prerelease tag such as `v1.4.2-rc.1`, the workflow publishes only:
+
+- `ghcr.io/<owner>/ai-scraping-defense-iis:v1.4.2-rc.1`
+- `ghcr.io/<owner>/ai-scraping-defense-iis:1.4.2-rc.1`
+
+This keeps prereleases from mutating `latest` or the rolling minor tag.
+
+## Release Metadata
+
+Each tagged build publishes:
+
+- an OCI image in GHCR
+- OCI labels for source repository, revision, and version
+- a Sigstore keyless signature over the pushed image digest
+- a GitHub build-provenance attestation pushed to the registry
+- a BuildKit SBOM attestation from the image build step
+
+## Verification
+
+Verify GitHub provenance:
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/<owner>/ai-scraping-defense-iis:v1.4.2 \
+  --repo <owner>/ai-scraping-defense-iis
+```
+
+Verify the Sigstore keyless signature for a released digest:
+
+```bash
+cosign verify \
+  ghcr.io/<owner>/ai-scraping-defense-iis@sha256:<digest> \
+  --certificate-identity https://github.com/<owner>/ai-scraping-defense-iis/.github/workflows/release-images.yml@refs/tags/v1.4.2 \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+## Upgrade Path
+
+Recommended operator behavior:
+
+1. Track release notes and changelog entries for the target version.
+2. Pull and verify the released image by digest, not just by mutable tag.
+3. For production, pin deployments to the verified digest.
+4. Roll forward within the same major version unless release notes explicitly state otherwise.
+5. Keep the previous verified digest available for rollback.
+
+## Commercial v1 Boundary
+
+The release workflow is intentionally narrow for commercial v1:
+
+- one runtime image
+- one primary registry (`ghcr.io`)
+- one signed and attestable release path driven by Git tags
+
+If later commercial packaging requires additional registries, separate base images, or OS-specific variants, that should be tracked as explicit post-v1 work rather than folded into this baseline workflow silently.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -41,5 +41,8 @@ Use this checklist before cutting a commercial release candidate.
 
 - `README.md` matches the shipped behavior
 - `docs/parity_matrix.md` reflects the current status honestly
+- `docs/release_artifacts.md` matches the tag and image policy implemented in CI
 - `CHANGELOG.md` has an `Unreleased` entry summarizing the release-hardening work
+- the tagged release workflow publishes to GHCR and emits both signature and provenance metadata
+- image provenance verification succeeds with `gh attestation verify`
 - remaining deferred parity items are tracked as GitHub issues, not hidden in review threads


### PR DESCRIPTION
## Summary
- add a tag-driven GHCR release workflow with keyless cosign signing and GitHub build-provenance attestations
- define release image naming, verification, and upgrade policy in release docs
- wire the new release artifact expectations into the README and release checklist

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln
- docker compose -f compose.yaml -f compose.observability.yaml config
- python3 YAML validation for workflow and compose assets

closes #57
