### PR TITLE
Add local trained model escalation path

### DIFF
--- a/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
+++ b/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
@@ -149,6 +149,8 @@ public sealed class EscalationOptions
 
     public HttpReputationProviderOptions HttpReputation { get; set; } = new();
 
+    public LocalTrainedModelOptions LocalTrainedModel { get; set; } = new();
+
     public OpenAiCompatibleModelAdapterOptions OpenAiCompatibleModel { get; set; } = new();
 }
 
@@ -207,6 +209,23 @@ public sealed class OpenAiCompatibleModelAdapterOptions
     public int BenignCrawlerScoreAdjustment { get; set; } = -5;
 
     public int HumanScoreAdjustment { get; set; } = -15;
+}
+
+public sealed class LocalTrainedModelOptions
+{
+    public bool Enabled { get; set; }
+
+    public string ModelPath { get; set; } = "models/local-bot-detector.zip";
+
+    public string MetadataPath { get; set; } = string.Empty;
+
+    public string RequiredModelVersion { get; set; } = string.Empty;
+
+    public float MaliciousProbabilityThreshold { get; set; } = 0.75f;
+
+    public int MaliciousScoreAdjustment { get; set; } = 35;
+
+    public int BenignScoreAdjustment { get; set; } = -10;
 }
 
 public sealed class CommunityBlocklistOptions

--- a/AiScrapingDefense.EscalationEngine/AiScrapingDefense.EscalationEngine.csproj
+++ b/AiScrapingDefense.EscalationEngine/AiScrapingDefense.EscalationEngine.csproj
@@ -14,4 +14,9 @@
     <ProjectReference Include="..\AiScrapingDefense.Contracts\AiScrapingDefense.Contracts.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML" Version="5.0.0" />
+    <PackageReference Include="Microsoft.ML.FastTree" Version="5.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/AiScrapingDefense.EscalationEngine/Services/LocalModelFeatureEngineering.cs
+++ b/AiScrapingDefense.EscalationEngine/Services/LocalModelFeatureEngineering.cs
@@ -1,0 +1,229 @@
+using System.Text.Json.Serialization;
+using Microsoft.ML.Data;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public static class LocalModelFeatureEngineering
+{
+    public const string SchemaVersion = "local-trained-model/v1";
+
+    public static readonly string[] FeatureColumnNames =
+    [
+        nameof(LocalModelFeatureVector.BaseSignalScore),
+        nameof(LocalModelFeatureVector.FrequencyScore),
+        nameof(LocalModelFeatureVector.SignalCount),
+        nameof(LocalModelFeatureVector.Frequency),
+        nameof(LocalModelFeatureVector.PathLength),
+        nameof(LocalModelFeatureVector.QueryLength),
+        nameof(LocalModelFeatureVector.UserAgentLength),
+        nameof(LocalModelFeatureVector.PathSegmentCount),
+        nameof(LocalModelFeatureVector.QueryParameterCount),
+        nameof(LocalModelFeatureVector.KnownBadUserAgentSignal),
+        nameof(LocalModelFeatureVector.SuspiciousPathSignal),
+        nameof(LocalModelFeatureVector.EmptyUserAgentSignal),
+        nameof(LocalModelFeatureVector.MissingAcceptLanguageSignal),
+        nameof(LocalModelFeatureVector.GenericAcceptAnySignal),
+        nameof(LocalModelFeatureVector.LongQueryStringSignal)
+    ];
+
+    public static LocalModelFeatureVector FromThreatContext(ThreatAssessmentContext context)
+    {
+        var path = context.Path ?? string.Empty;
+        var query = context.QueryString ?? string.Empty;
+        var userAgent = context.UserAgent ?? string.Empty;
+        var signals = context.Signals ?? [];
+
+        return new LocalModelFeatureVector
+        {
+            BaseSignalScore = context.BaseSignalScore,
+            FrequencyScore = context.FrequencyScore,
+            SignalCount = signals.Count,
+            Frequency = context.Frequency,
+            PathLength = path.Length,
+            QueryLength = query.Length,
+            UserAgentLength = userAgent.Length,
+            PathSegmentCount = CountPathSegments(path),
+            QueryParameterCount = CountQueryParameters(query),
+            KnownBadUserAgentSignal = HasSignalPrefix(signals, "known_bad_user_agent:") ? 1f : 0f,
+            SuspiciousPathSignal = HasSignalPrefix(signals, "suspicious_path:") ? 1f : 0f,
+            EmptyUserAgentSignal = HasSignal(signals, "empty_user_agent") ? 1f : 0f,
+            MissingAcceptLanguageSignal = HasSignal(signals, "missing_accept_language") ? 1f : 0f,
+            GenericAcceptAnySignal = HasSignal(signals, "generic_accept_any") ? 1f : 0f,
+            LongQueryStringSignal = HasSignal(signals, "long_query_string") ? 1f : 0f
+        };
+    }
+
+    public static LocalModelTrainingRow FromTrainingDocument(LocalModelTrainingDocument document)
+    {
+        var context = new ThreatAssessmentContext(
+            "training",
+            document.Method,
+            document.Path,
+            document.QueryString,
+            document.UserAgent,
+            document.Signals,
+            document.Frequency,
+            ScoreSignals(document.Signals),
+            (int)Math.Min(25, document.Frequency * 5));
+        var vector = FromThreatContext(context);
+
+        return new LocalModelTrainingRow
+        {
+            Label = document.Label,
+            BaseSignalScore = vector.BaseSignalScore,
+            FrequencyScore = vector.FrequencyScore,
+            SignalCount = vector.SignalCount,
+            Frequency = vector.Frequency,
+            PathLength = vector.PathLength,
+            QueryLength = vector.QueryLength,
+            UserAgentLength = vector.UserAgentLength,
+            PathSegmentCount = vector.PathSegmentCount,
+            QueryParameterCount = vector.QueryParameterCount,
+            KnownBadUserAgentSignal = vector.KnownBadUserAgentSignal,
+            SuspiciousPathSignal = vector.SuspiciousPathSignal,
+            EmptyUserAgentSignal = vector.EmptyUserAgentSignal,
+            MissingAcceptLanguageSignal = vector.MissingAcceptLanguageSignal,
+            GenericAcceptAnySignal = vector.GenericAcceptAnySignal,
+            LongQueryStringSignal = vector.LongQueryStringSignal
+        };
+    }
+
+    private static bool HasSignal(IReadOnlyList<string> signals, string value)
+    {
+        return signals.Any(signal => string.Equals(signal, value, StringComparison.Ordinal));
+    }
+
+    private static bool HasSignalPrefix(IReadOnlyList<string> signals, string prefix)
+    {
+        return signals.Any(signal => signal.StartsWith(prefix, StringComparison.Ordinal));
+    }
+
+    private static float CountPathSegments(string path)
+    {
+        return path
+            .Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Length;
+    }
+
+    private static float CountQueryParameters(string queryString)
+    {
+        var query = queryString.StartsWith('?')
+            ? queryString[1..]
+            : queryString;
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return 0f;
+        }
+
+        return query
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Length;
+    }
+
+    private static int ScoreSignals(IReadOnlyList<string> signals)
+    {
+        var score = 0;
+
+        foreach (var signal in signals)
+        {
+            if (signal.StartsWith("known_bad_user_agent:", StringComparison.Ordinal))
+            {
+                score += 100;
+            }
+            else if (signal.StartsWith("suspicious_path:", StringComparison.Ordinal))
+            {
+                score += 30;
+            }
+            else if (string.Equals(signal, "empty_user_agent", StringComparison.Ordinal))
+            {
+                score += 25;
+            }
+            else if (string.Equals(signal, "missing_accept_language", StringComparison.Ordinal))
+            {
+                score += 15;
+            }
+            else if (string.Equals(signal, "generic_accept_any", StringComparison.Ordinal))
+            {
+                score += 15;
+            }
+            else if (string.Equals(signal, "long_query_string", StringComparison.Ordinal))
+            {
+                score += 10;
+            }
+        }
+
+        return score;
+    }
+}
+
+public class LocalModelFeatureVector
+{
+    public float BaseSignalScore { get; set; }
+
+    public float FrequencyScore { get; set; }
+
+    public float SignalCount { get; set; }
+
+    public float Frequency { get; set; }
+
+    public float PathLength { get; set; }
+
+    public float QueryLength { get; set; }
+
+    public float UserAgentLength { get; set; }
+
+    public float PathSegmentCount { get; set; }
+
+    public float QueryParameterCount { get; set; }
+
+    public float KnownBadUserAgentSignal { get; set; }
+
+    public float SuspiciousPathSignal { get; set; }
+
+    public float EmptyUserAgentSignal { get; set; }
+
+    public float MissingAcceptLanguageSignal { get; set; }
+
+    public float GenericAcceptAnySignal { get; set; }
+
+    public float LongQueryStringSignal { get; set; }
+}
+
+public sealed class LocalModelTrainingRow : LocalModelFeatureVector
+{
+    public bool Label { get; set; }
+}
+
+public sealed class LocalModelPrediction
+{
+    [ColumnName("PredictedLabel")]
+    public bool PredictedLabel { get; set; }
+
+    public float Probability { get; set; }
+
+    public float Score { get; set; }
+}
+
+public sealed record LocalModelTrainingDocument(
+    [property: JsonPropertyName("label")] bool Label,
+    [property: JsonPropertyName("method")] string Method,
+    [property: JsonPropertyName("path")] string Path,
+    [property: JsonPropertyName("query_string")] string QueryString,
+    [property: JsonPropertyName("user_agent")] string UserAgent,
+    [property: JsonPropertyName("signals")] IReadOnlyList<string> Signals,
+    [property: JsonPropertyName("frequency")] long Frequency);
+
+public sealed record LocalTrainedModelMetadata(
+    [property: JsonPropertyName("schema_version")] string SchemaVersion,
+    [property: JsonPropertyName("model_version")] string ModelVersion,
+    [property: JsonPropertyName("algorithm")] string Algorithm,
+    [property: JsonPropertyName("trained_at_utc")] DateTimeOffset TrainedAtUtc,
+    [property: JsonPropertyName("malicious_probability_threshold")] float MaliciousProbabilityThreshold,
+    [property: JsonPropertyName("training_example_count")] int TrainingExampleCount,
+    [property: JsonPropertyName("feature_columns")] IReadOnlyList<string> FeatureColumns);
+
+public sealed record LocalTrainedModelArtifacts(
+    string ModelPath,
+    string MetadataPath,
+    LocalTrainedModelMetadata Metadata);

--- a/AiScrapingDefense.EscalationEngine/Services/LocalTrainedModelAdapter.cs
+++ b/AiScrapingDefense.EscalationEngine/Services/LocalTrainedModelAdapter.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.ML;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class LocalTrainedModelAdapter : IThreatModelAdapter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly LocalTrainedModelOptions _options;
+    private readonly IHostEnvironment _environment;
+    private readonly ILogger<LocalTrainedModelAdapter> _logger;
+    private readonly object _gate = new();
+    private RuntimeState? _state;
+    private bool _loadAttempted;
+
+    public LocalTrainedModelAdapter(
+        IOptions<DefenseEngineOptions> options,
+        IHostEnvironment environment,
+        ILogger<LocalTrainedModelAdapter> logger)
+    {
+        _options = options.Value.Escalation.LocalTrainedModel;
+        _environment = environment;
+        _logger = logger;
+    }
+
+    public string Name => "local_trained_model";
+
+    public Task<ModelAssessment?> AssessAsync(
+        ThreatAssessmentContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled)
+        {
+            return Task.FromResult<ModelAssessment?>(null);
+        }
+
+        var state = EnsureLoaded();
+        if (state is null)
+        {
+            return Task.FromResult<ModelAssessment?>(null);
+        }
+
+        LocalModelPrediction prediction;
+        var features = LocalModelFeatureEngineering.FromThreatContext(context);
+        lock (_gate)
+        {
+            prediction = state.Engine.Predict(features);
+        }
+
+        var probability = prediction.Probability;
+        if (prediction.PredictedLabel || probability >= _options.MaliciousProbabilityThreshold)
+        {
+            return Task.FromResult<ModelAssessment?>(new ModelAssessment(
+                Name,
+                _options.MaliciousScoreAdjustment,
+                true,
+                "MALICIOUS_BOT",
+                ["local_model:malicious"],
+                BuildSummary("malicious", probability, state.Metadata)));
+        }
+
+        if (!prediction.PredictedLabel && probability <= 1f - _options.MaliciousProbabilityThreshold)
+        {
+            return Task.FromResult<ModelAssessment?>(new ModelAssessment(
+                Name,
+                _options.BenignScoreAdjustment,
+                false,
+                "BENIGN_CRAWLER",
+                ["local_model:benign"],
+                BuildSummary("benign", probability, state.Metadata)));
+        }
+
+        return Task.FromResult<ModelAssessment?>(new ModelAssessment(
+            Name,
+            0,
+            null,
+            "INCONCLUSIVE",
+            [],
+            BuildSummary("inconclusive", probability, state.Metadata)));
+    }
+
+    private RuntimeState? EnsureLoaded()
+    {
+        lock (_gate)
+        {
+            if (_state is not null)
+            {
+                return _state;
+            }
+
+            if (_loadAttempted)
+            {
+                return null;
+            }
+
+            _loadAttempted = true;
+            var resolvedModelPath = ResolvePath(_options.ModelPath);
+            if (string.IsNullOrWhiteSpace(resolvedModelPath) || !File.Exists(resolvedModelPath))
+            {
+                _logger.LogWarning(
+                    "Local trained model adapter is enabled but model file {ModelPath} was not found.",
+                    resolvedModelPath);
+                return null;
+            }
+
+            try
+            {
+                var mlContext = new MLContext(seed: 1);
+                using var stream = File.OpenRead(resolvedModelPath);
+                var model = mlContext.Model.Load(stream, out _);
+                var engine = mlContext.Model.CreatePredictionEngine<LocalModelFeatureVector, LocalModelPrediction>(model);
+                var metadata = LoadMetadata(resolvedModelPath);
+
+                if (!string.IsNullOrWhiteSpace(_options.RequiredModelVersion) &&
+                    !string.Equals(metadata.ModelVersion, _options.RequiredModelVersion, StringComparison.Ordinal))
+                {
+                    _logger.LogWarning(
+                        "Local trained model version mismatch. Required {RequiredVersion}, found {ModelVersion}.",
+                        _options.RequiredModelVersion,
+                        metadata.ModelVersion);
+                    return null;
+                }
+
+                _state = new RuntimeState(engine, metadata);
+                _logger.LogInformation(
+                    "Loaded local trained model version {ModelVersion} from {ModelPath}.",
+                    metadata.ModelVersion,
+                    resolvedModelPath);
+                return _state;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to load local trained model from {ModelPath}.", resolvedModelPath);
+                return null;
+            }
+        }
+    }
+
+    private LocalTrainedModelMetadata LoadMetadata(string modelPath)
+    {
+        var configuredMetadataPath = ResolvePath(_options.MetadataPath);
+        var metadataPath = string.IsNullOrWhiteSpace(configuredMetadataPath)
+            ? LocalTrainedModelTrainer.GetMetadataPath(modelPath)
+            : configuredMetadataPath;
+
+        if (!File.Exists(metadataPath))
+        {
+            return new LocalTrainedModelMetadata(
+                LocalModelFeatureEngineering.SchemaVersion,
+                "unknown",
+                "FastForestBinaryTrainer",
+                DateTimeOffset.MinValue,
+                _options.MaliciousProbabilityThreshold,
+                0,
+                LocalModelFeatureEngineering.FeatureColumnNames);
+        }
+
+        using var stream = File.OpenRead(metadataPath);
+        var metadata = JsonSerializer.Deserialize<LocalTrainedModelMetadata>(stream, JsonOptions);
+        if (metadata is null)
+        {
+            throw new InvalidOperationException($"Metadata file {metadataPath} did not deserialize.");
+        }
+
+        if (!string.Equals(metadata.SchemaVersion, LocalModelFeatureEngineering.SchemaVersion, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Model schema version {metadata.SchemaVersion} is not supported.");
+        }
+
+        return metadata;
+    }
+
+    private string ResolvePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return string.Empty;
+        }
+
+        return Path.IsPathRooted(path)
+            ? path
+            : Path.Combine(_environment.ContentRootPath, path);
+    }
+
+    private static string BuildSummary(string verdict, float probability, LocalTrainedModelMetadata metadata)
+    {
+        return $"Local trained model {metadata.ModelVersion} produced a {verdict} verdict with probability {probability:0.000}.";
+    }
+
+    private sealed record RuntimeState(
+        PredictionEngine<LocalModelFeatureVector, LocalModelPrediction> Engine,
+        LocalTrainedModelMetadata Metadata);
+}

--- a/AiScrapingDefense.EscalationEngine/Services/LocalTrainedModelTrainer.cs
+++ b/AiScrapingDefense.EscalationEngine/Services/LocalTrainedModelTrainer.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+using Microsoft.ML.Trainers.FastTree;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class LocalTrainedModelTrainer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+
+    private readonly MLContext _mlContext;
+
+    public LocalTrainedModelTrainer(int? seed = 1)
+    {
+        _mlContext = new MLContext(seed);
+    }
+
+    public LocalTrainedModelArtifacts TrainAndSave(
+        IEnumerable<LocalModelTrainingDocument> documents,
+        string modelPath,
+        string modelVersion,
+        float maliciousProbabilityThreshold)
+    {
+        var rows = documents
+            .Select(LocalModelFeatureEngineering.FromTrainingDocument)
+            .ToArray();
+
+        if (rows.Length < 2)
+        {
+            throw new InvalidOperationException("At least two training examples are required.");
+        }
+
+        if (rows.All(row => row.Label) || rows.All(row => !row.Label))
+        {
+            throw new InvalidOperationException("Training data must contain both malicious and benign examples.");
+        }
+
+        var data = _mlContext.Data.LoadFromEnumerable(rows);
+        var pipeline = _mlContext.Transforms.Concatenate("Features", LocalModelFeatureEngineering.FeatureColumnNames)
+            .Append(_mlContext.BinaryClassification.Trainers.FastForest(new FastForestBinaryTrainer.Options
+            {
+                LabelColumnName = nameof(LocalModelTrainingRow.Label),
+                FeatureColumnName = "Features",
+                NumberOfTrees = 128,
+                NumberOfLeaves = 32,
+                MinimumExampleCountPerLeaf = 1
+            }));
+        var model = pipeline.Fit(data);
+
+        var directory = Path.GetDirectoryName(modelPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using (var stream = File.Create(modelPath))
+        {
+            _mlContext.Model.Save(model, data.Schema, stream);
+        }
+
+        var metadata = new LocalTrainedModelMetadata(
+            LocalModelFeatureEngineering.SchemaVersion,
+            modelVersion,
+            "FastForestBinaryTrainer",
+            DateTimeOffset.UtcNow,
+            maliciousProbabilityThreshold,
+            rows.Length,
+            LocalModelFeatureEngineering.FeatureColumnNames);
+        var metadataPath = GetMetadataPath(modelPath);
+        File.WriteAllText(metadataPath, JsonSerializer.Serialize(metadata, JsonOptions));
+
+        return new LocalTrainedModelArtifacts(modelPath, metadataPath, metadata);
+    }
+
+    public static string GetMetadataPath(string modelPath)
+    {
+        return modelPath + ".metadata.json";
+    }
+}

--- a/AiScrapingDefense.ModelTrainer/AiScrapingDefense.ModelTrainer.csproj
+++ b/AiScrapingDefense.ModelTrainer/AiScrapingDefense.ModelTrainer.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AiScrapingDefense.EscalationEngine\AiScrapingDefense.EscalationEngine.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AiScrapingDefense.ModelTrainer/Program.cs
+++ b/AiScrapingDefense.ModelTrainer/Program.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using RedisBlocklistMiddlewareApp.Services;
+
+var arguments = ParseArguments(args);
+if (!arguments.TryGetValue("--input", out var inputPath) ||
+    !arguments.TryGetValue("--output", out var outputPath) ||
+    !arguments.TryGetValue("--version", out var modelVersion))
+{
+    WriteUsage();
+    return 1;
+}
+
+var threshold = 0.75f;
+if (arguments.TryGetValue("--threshold", out var thresholdValue) &&
+    !float.TryParse(thresholdValue, out threshold))
+{
+    Console.Error.WriteLine("The --threshold value must be a floating-point number.");
+    return 1;
+}
+
+threshold = Math.Clamp(threshold, 0.5f, 0.99f);
+
+if (!File.Exists(inputPath))
+{
+    Console.Error.WriteLine($"Training input file '{inputPath}' was not found.");
+    return 1;
+}
+
+var documents = LoadDocuments(inputPath);
+var trainer = new LocalTrainedModelTrainer();
+var artifacts = trainer.TrainAndSave(documents, outputPath, modelVersion, threshold);
+
+Console.WriteLine($"Model written to {artifacts.ModelPath}");
+Console.WriteLine($"Metadata written to {artifacts.MetadataPath}");
+Console.WriteLine($"Model version: {artifacts.Metadata.ModelVersion}");
+Console.WriteLine($"Training examples: {artifacts.Metadata.TrainingExampleCount}");
+return 0;
+
+static Dictionary<string, string> ParseArguments(string[] args)
+{
+    var results = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    for (var i = 0; i < args.Length; i++)
+    {
+        if (!args[i].StartsWith("--", StringComparison.Ordinal))
+        {
+            continue;
+        }
+
+        if (i + 1 >= args.Length || args[i + 1].StartsWith("--", StringComparison.Ordinal))
+        {
+            results[args[i]] = string.Empty;
+            continue;
+        }
+
+        results[args[i]] = args[i + 1];
+        i++;
+    }
+
+    return results;
+}
+
+static IReadOnlyList<LocalModelTrainingDocument> LoadDocuments(string inputPath)
+{
+    var lines = File.ReadAllLines(inputPath)
+        .Where(line => !string.IsNullOrWhiteSpace(line))
+        .ToArray();
+    var documents = new List<LocalModelTrainingDocument>(lines.Length);
+
+    foreach (var line in lines)
+    {
+        var document = JsonSerializer.Deserialize<LocalModelTrainingDocument>(line);
+        if (document is null)
+        {
+            throw new InvalidOperationException("Training input contained an invalid JSON line.");
+        }
+
+        documents.Add(document);
+    }
+
+    return documents;
+}
+
+static void WriteUsage()
+{
+    Console.Error.WriteLine(
+        "Usage: dotnet run --project AiScrapingDefense.ModelTrainer -- " +
+        "--input <training.jsonl> --output <model.zip> --version <model-version> [--threshold 0.75]");
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A GitHub Actions workflow that restores, builds, and tests the solution on every push and pull request.
 * A tagged release workflow that publishes signed GHCR images with provenance (`.github/workflows/release-images.yml`).
 * A containerized integration-test project covering suspicious request handling, management blocklist operations, webhook intake, and PostgreSQL-backed tarpit rendering.
+* A .NET-native local trained-model path plus trainer CLI for the escalation engine (`AiScrapingDefense.ModelTrainer`, `DefenseEngine:Escalation:LocalTrainedModel`).
 * Prometheus/OTLP observability options and runtime instrumentation for defense decisions, tarpit responses, webhook intake, and sync activity.
 * Queue depth and capacity telemetry for queued suspicious-request pressure monitoring.
 * Release documentation for parity, operator operations, and release validation.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - Heuristic request inspection for known bad user agents, malformed headers, and suspicious paths.
 - A bounded suspicious-request queue with a background analysis worker.
 - Redis-backed request-frequency tracking for simple escalation decisions.
-- Pluggable escalation via configured CIDR reputation ranges, optional HTTP reputation checks, and an optional OpenAI-compatible classifier hook.
+- Pluggable escalation via configured CIDR reputation ranges, an optional local trained model, optional HTTP reputation checks, and an optional OpenAI-compatible classifier hook.
 - A deterministic tarpit endpoint that returns synthetic HTML and recursive links.
 - A lightweight authenticated event feed at `/defense/events` for recent decisions.
 - Authenticated operator metrics and blocklist management endpoints under `/defense/*`.
@@ -94,10 +94,12 @@ Queued suspicious-request analysis now persists a score breakdown with named con
 - base edge heuristics
 - short-window request frequency
 - configured CIDR reputation ranges
+- an optional local trained model
 - optional HTTP reputation providers
 - an optional OpenAI-compatible classifier endpoint
 
 The default configuration keeps the external reputation/model hooks disabled. They are exposed under `DefenseEngine:Escalation` so production deployments can opt in without changing the rest of the request pipeline.
+See [docs/local_model_training.md](docs/local_model_training.md) for the local model artifact format and trainer CLI.
 
 ## PostgreSQL Tarpit
 
@@ -120,6 +122,7 @@ Key areas:
   - `CommunityReporting` controls optional outbound reporting to providers like AbuseIPDB.
 - `DefenseEngine:Audit`
 - `DefenseEngine:Escalation`
+  - `LocalTrainedModel` enables the .NET-native local model adapter and points at the saved model artifact.
 - `DefenseEngine:CommunityBlocklist`
 - `DefenseEngine:PeerSync`
 - `DefenseEngine:Queue`

--- a/RedisBlocklistMiddlewareApp.Tests/LocalTrainedModelAdapterTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/LocalTrainedModelAdapterTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class LocalTrainedModelAdapterTests
+{
+    [Fact]
+    public async Task LocalTrainedModelAdapter_ReturnsMaliciousAssessment_ForTrainedMaliciousSample()
+    {
+        using var harness = LocalModelHarness.Create();
+        var artifacts = harness.Train("2026.03.15", threshold: 0.60f);
+        var adapter = harness.CreateAdapter(artifacts.ModelPath, requiredModelVersion: "2026.03.15", threshold: 0.60f);
+
+        var assessment = await adapter.AssessAsync(CreateMaliciousContext(), CancellationToken.None);
+
+        Assert.NotNull(assessment);
+        Assert.Equal("MALICIOUS_BOT", assessment!.Classification);
+        Assert.True(assessment.IsBot);
+        Assert.Equal(35, assessment.ScoreAdjustment);
+        Assert.Contains("local_model:malicious", assessment.Signals);
+        Assert.Contains("2026.03.15", assessment.Summary);
+    }
+
+    [Fact]
+    public async Task LocalTrainedModelAdapter_ReturnsNull_WhenDisabled()
+    {
+        using var harness = LocalModelHarness.Create();
+        var artifacts = harness.Train("2026.03.15");
+        var adapter = harness.CreateAdapter(artifacts.ModelPath, enabled: false);
+
+        var assessment = await adapter.AssessAsync(CreateMaliciousContext(), CancellationToken.None);
+
+        Assert.Null(assessment);
+    }
+
+    [Fact]
+    public void LocalTrainedModelTrainer_WritesMetadataWithRequestedVersion()
+    {
+        using var harness = LocalModelHarness.Create();
+
+        var artifacts = harness.Train("2026.03.15", threshold: 0.65f);
+
+        Assert.True(File.Exists(artifacts.ModelPath));
+        Assert.True(File.Exists(artifacts.MetadataPath));
+        Assert.Equal("2026.03.15", artifacts.Metadata.ModelVersion);
+        Assert.Equal(0.65f, artifacts.Metadata.MaliciousProbabilityThreshold);
+        Assert.Equal(LocalModelFeatureEngineering.SchemaVersion, artifacts.Metadata.SchemaVersion);
+        Assert.True(artifacts.Metadata.TrainingExampleCount >= 6);
+    }
+
+    private static ThreatAssessmentContext CreateMaliciousContext()
+    {
+        return new ThreatAssessmentContext(
+            "198.51.100.99",
+            "GET",
+            "/graphql/export",
+            "?page=1&take=5000",
+            "python-requests/2.31",
+            [
+                "known_bad_user_agent:python-requests",
+                "suspicious_path:/graphql",
+                "missing_accept_language",
+                "generic_accept_any",
+                "long_query_string"
+            ],
+            4,
+            170,
+            20);
+    }
+
+    private sealed class LocalModelHarness : IDisposable
+    {
+        private readonly string _rootPath;
+
+        private LocalModelHarness(string rootPath)
+        {
+            _rootPath = rootPath;
+        }
+
+        public static LocalModelHarness Create()
+        {
+            var rootPath = Path.Combine(Path.GetTempPath(), "ai-scraping-defense-model-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(rootPath);
+            return new LocalModelHarness(rootPath);
+        }
+
+        public LocalTrainedModelArtifacts Train(string modelVersion, float threshold = 0.75f)
+        {
+            var trainer = new LocalTrainedModelTrainer(seed: 1);
+            return trainer.TrainAndSave(CreateTrainingDocuments(), Path.Combine(_rootPath, "local-bot-detector.zip"), modelVersion, threshold);
+        }
+
+        public LocalTrainedModelAdapter CreateAdapter(
+            string modelPath,
+            bool enabled = true,
+            string requiredModelVersion = "",
+            float threshold = 0.75f)
+        {
+            return new LocalTrainedModelAdapter(
+                Options.Create(new DefenseEngineOptions
+                {
+                    Escalation = new EscalationOptions
+                    {
+                        LocalTrainedModel = new LocalTrainedModelOptions
+                        {
+                            Enabled = enabled,
+                            ModelPath = modelPath,
+                            RequiredModelVersion = requiredModelVersion,
+                            MaliciousProbabilityThreshold = threshold,
+                            MaliciousScoreAdjustment = 35,
+                            BenignScoreAdjustment = -10
+                        }
+                    }
+                }),
+                new TestHostEnvironment(_rootPath),
+                NullLogger<LocalTrainedModelAdapter>.Instance);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_rootPath))
+            {
+                Directory.Delete(_rootPath, recursive: true);
+            }
+        }
+
+        private static IReadOnlyList<LocalModelTrainingDocument> CreateTrainingDocuments()
+        {
+            return
+            [
+                new LocalModelTrainingDocument(true, "GET", "/graphql", "?page=1&take=5000", "python-requests/2.31", ["known_bad_user_agent:python-requests", "suspicious_path:/graphql", "missing_accept_language", "generic_accept_any", "long_query_string"], 4),
+                new LocalModelTrainingDocument(true, "GET", "/.env", string.Empty, "curl/8.6.0", ["suspicious_path:/.env", "missing_accept_language", "generic_accept_any"], 3),
+                new LocalModelTrainingDocument(true, "POST", "/wp-login", "?attempt=1", "Scrapy/2.0", ["known_bad_user_agent:Scrapy", "suspicious_path:/wp-login", "missing_accept_language"], 5),
+                new LocalModelTrainingDocument(false, "GET", "/pricing", string.Empty, "Mozilla/5.0", [], 1),
+                new LocalModelTrainingDocument(false, "GET", "/docs", "?page=2", "Mozilla/5.0", [], 1),
+                new LocalModelTrainingDocument(false, "GET", "/blog/post", string.Empty, "Mozilla/5.0", [], 2),
+                new LocalModelTrainingDocument(false, "GET", "/robots.txt", string.Empty, "Mozilla/5.0 (compatible; SearchBot)", [], 1)
+            ];
+        }
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public TestHostEnvironment(string contentRootPath)
+        {
+            ContentRootPath = contentRootPath;
+        }
+
+        public string EnvironmentName { get; set; } = "Development";
+
+        public string ApplicationName { get; set; } = "RedisBlocklistMiddlewareApp.Tests";
+
+        public string ContentRootPath { get; set; }
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -155,6 +155,13 @@ builder.Services
         options.Escalation.HttpReputation.ApiKey = options.Escalation.HttpReputation.ApiKey.Trim();
         options.Escalation.HttpReputation.TimeoutSeconds = Math.Max(1, options.Escalation.HttpReputation.TimeoutSeconds);
 
+        options.Escalation.LocalTrainedModel.ModelPath = options.Escalation.LocalTrainedModel.ModelPath.Trim();
+        options.Escalation.LocalTrainedModel.MetadataPath = options.Escalation.LocalTrainedModel.MetadataPath.Trim();
+        options.Escalation.LocalTrainedModel.RequiredModelVersion =
+            options.Escalation.LocalTrainedModel.RequiredModelVersion.Trim();
+        options.Escalation.LocalTrainedModel.MaliciousProbabilityThreshold =
+            Math.Clamp(options.Escalation.LocalTrainedModel.MaliciousProbabilityThreshold, 0.5f, 0.99f);
+
         options.Escalation.OpenAiCompatibleModel.Endpoint = options.Escalation.OpenAiCompatibleModel.Endpoint.Trim();
         options.Escalation.OpenAiCompatibleModel.ApiKey = options.Escalation.OpenAiCompatibleModel.ApiKey.Trim();
         options.Escalation.OpenAiCompatibleModel.Model = options.Escalation.OpenAiCompatibleModel.Model.Trim();
@@ -252,6 +259,7 @@ builder.Services.AddSingleton<ITarpitPageService, TarpitPageService>();
 builder.Services.AddSingleton<IClientIpResolver, ClientIpResolver>();
 builder.Services.AddSingleton<IThreatReputationProvider, ConfiguredRangeReputationProvider>();
 builder.Services.AddSingleton<IThreatReputationProvider, HttpReputationProvider>();
+builder.Services.AddSingleton<IThreatModelAdapter, LocalTrainedModelAdapter>();
 builder.Services.AddSingleton<IThreatModelAdapter, OpenAiCompatibleModelAdapter>();
 builder.Services.AddSingleton<IThreatAssessmentService, ThreatAssessmentService>();
 builder.Services.AddSingleton<ICommunityBlocklistFeedClient, HttpCommunityBlocklistFeedClient>();

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -118,6 +118,15 @@
         "TimeoutSeconds": 10,
         "MaliciousScoreAdjustment": 35
       },
+      "LocalTrainedModel": {
+        "Enabled": false,
+        "ModelPath": "models/local-bot-detector.zip",
+        "MetadataPath": "",
+        "RequiredModelVersion": "",
+        "MaliciousProbabilityThreshold": 0.75,
+        "MaliciousScoreAdjustment": 35,
+        "BenignScoreAdjustment": -10
+      },
       "OpenAiCompatibleModel": {
         "Enabled": false,
         "Endpoint": "",

--- a/anti-scraping-defense-iis.sln
+++ b/anti-scraping-defense-iis.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiScrapingDefense.TarpitApi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiScrapingDefense.IntegrationTests", "AiScrapingDefense.IntegrationTests\AiScrapingDefense.IntegrationTests.csproj", "{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiScrapingDefense.ModelTrainer", "AiScrapingDefense.ModelTrainer\AiScrapingDefense.ModelTrainer.csproj", "{925F524D-0B0A-43CE-96E2-177908A6CECD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,18 @@ Global
 		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Release|x64.Build.0 = Release|Any CPU
 		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Release|x86.ActiveCfg = Release|Any CPU
 		{ABCE4D47-C19A-4DB2-91B5-5AAE9C4F9B75}.Release|x86.Build.0 = Release|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Debug|x64.Build.0 = Debug|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Debug|x86.Build.0 = Debug|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Release|x64.ActiveCfg = Release|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Release|x64.Build.0 = Release|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Release|x86.ActiveCfg = Release|Any CPU
+		{925F524D-0B0A-43CE-96E2-177908A6CECD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ This documentation index is for the current .NET implementation in this reposito
 - [Parity Matrix](parity_matrix.md)
 - [Post-v1 Parity Roadmap](dotnet_parity_roadmap.md)
 - [API References](api_references.md)
+- [Local Model Training](local_model_training.md)
 - [Release Blockers](release_blockers.md)
 - [Release Checklist](release_checklist.md)
 - [Release Artifacts](release_artifacts.md)

--- a/docs/local_model_training.md
+++ b/docs/local_model_training.md
@@ -1,0 +1,76 @@
+# Local Model Training
+
+The escalation engine can load a local trained model artifact for self-contained scoring inside the .NET runtime.
+
+## Runtime Configuration
+
+Enable the local model adapter under `DefenseEngine:Escalation:LocalTrainedModel`:
+
+- `Enabled`
+- `ModelPath`
+- `MetadataPath`
+- `RequiredModelVersion`
+- `MaliciousProbabilityThreshold`
+- `MaliciousScoreAdjustment`
+- `BenignScoreAdjustment`
+
+If `MetadataPath` is left empty, the runtime looks for `<ModelPath>.metadata.json`.
+
+## Training Input Format
+
+The trainer consumes JSON Lines (`.jsonl`). Each line is one labeled example:
+
+```json
+{"label":true,"method":"GET","path":"/graphql","query_string":"?page=1&take=5000","user_agent":"python-requests/2.31","signals":["known_bad_user_agent:python-requests","suspicious_path:/graphql","missing_accept_language","generic_accept_any","long_query_string"],"frequency":4}
+```
+
+Required fields:
+
+- `label`
+- `method`
+- `path`
+- `query_string`
+- `user_agent`
+- `signals`
+- `frequency`
+
+## Training Command
+
+Run the bundled trainer:
+
+```bash
+dotnet run --project AiScrapingDefense.ModelTrainer -- \
+  --input data/local-model-training.jsonl \
+  --output models/local-bot-detector.zip \
+  --version 2026.03.15 \
+  --threshold 0.75
+```
+
+This writes:
+
+- the model archive to the requested `--output` path
+- metadata to `<output>.metadata.json`
+
+The metadata file records:
+
+- schema version
+- model version
+- algorithm
+- training timestamp
+- malicious threshold
+- training example count
+- feature-column list
+
+## Loading Behavior
+
+When enabled, the runtime loads the model lazily on first use, validates the metadata schema, and optionally enforces `RequiredModelVersion`.
+
+## Current Scope
+
+This commercial-v1 path provides:
+
+- .NET-native local model inference
+- a .NET-native trainer CLI
+- explicit model metadata and version checking
+
+The older project’s more opinionated log/feedback dataset-building path is still tracked separately in issue `#64`.

--- a/docs/parity_matrix.md
+++ b/docs/parity_matrix.md
@@ -19,7 +19,7 @@ Status legend:
 | Peer sync | Implemented | Timed imports, authenticated exports, and `ObserveOnly`/`BlockList` trust modes are implemented. | Add richer trust scoring and coordination. |
 | PostgreSQL-backed Markov tarpit | Implemented | The tarpit can load a Markov corpus from PostgreSQL and falls back safely when no snapshot exists. | Expand deeper decoy modes. See issue `#55`. |
 | Advanced tarpit decoys | Partial | Current tarpit modes cover deterministic HTML, archive, and API-catalog variants. | Port rotating archives and JavaScript ZIP honeypots. See issue `#55`. |
-| Reputation providers and classifier hooks | Partial | Configured ranges, HTTP reputation, and OpenAI-compatible model adapters exist. | Port trained ML lifecycle and richer provider orchestration. See issue `#54`. |
+| Reputation providers and classifier hooks | Implemented | Configured ranges, HTTP reputation, .NET-native local trained models, and OpenAI-compatible model adapters exist. | Add richer dataset-building and retraining ergonomics. See issue `#64`. |
 | Alerting and operator/community reporting | Partial | Confirmed malicious intake events can dispatch generic webhook alerts, SMTP alerts, and configurable community reports with durable delivery visibility. | Slack-specific alert channel parity still remains. See issue `#60`. |
 | Structured telemetry export | Implemented | Prometheus metrics, OTLP trace export, packaged scrape/alert config, and a bundled Grafana dashboard are included. | Tune thresholds and dashboard panels against production traffic after deployment. |
 | Independent multi-service deployment | Deferred | v1 intentionally ships as a single deployable ASP.NET Core runtime. | Split into independently deployed roles only when operations justify it. |


### PR DESCRIPTION
## Summary
- add a .NET-native local trained model adapter and trainer CLI using ML.NET
- add model artifact metadata, version checks, runtime configuration, and docs
- cover the trained-model path with unit tests and track the remaining dataset-builder gap in #64

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln

closes #54
