### PR TITLE
Add rotating tarpit ZIP decoys

### DIFF
--- a/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
+++ b/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
@@ -297,11 +297,23 @@ public sealed class TarpitOptions
 
     public string Seed { get; set; } = "ai-scraping-defense-dotnet";
 
+    public string ArchiveDirectory { get; set; } = "data/tarpit-archives";
+
     public int LinkCount { get; set; } = 6;
 
     public int ParagraphCount { get; set; } = 5;
 
     public int ResponseDelayMilliseconds { get; set; } = 200;
+
+    public int ArchiveRotationMinutes { get; set; } = 60;
+
+    public int MaximumArchivesToKeep { get; set; } = 5;
+
+    public int JavaScriptDecoyFileCount { get; set; } = 12;
+
+    public int MinJavaScriptDecoyFileSizeKb { get; set; } = 5;
+
+    public int MaxJavaScriptDecoyFileSizeKb { get; set; } = 24;
 
     public string[] Modes { get; set; } =
     [

--- a/AiScrapingDefense.IntegrationTests/TarpitArtifactFlowTests.cs
+++ b/AiScrapingDefense.IntegrationTests/TarpitArtifactFlowTests.cs
@@ -1,0 +1,30 @@
+using System.IO.Compression;
+using System.Net;
+
+namespace AiScrapingDefense.IntegrationTests;
+
+[Collection(EndToEndCollection.Name)]
+public sealed class TarpitArtifactFlowTests
+{
+    private readonly DefenseStackFixture _fixture;
+
+    public TarpitArtifactFlowTests(DefenseStackFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task TarpitArchiveRoute_ReturnsZipDecoyArtifact()
+    {
+        await using var host = await _fixture.CreateHostAsync();
+        var response = await host.Client.GetAsync("/anti-scrape-tarpit/reference/manual/archive/assets.zip");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/zip", response.Content.Headers.ContentType?.MediaType);
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+
+        using var archive = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+        Assert.NotEmpty(archive.Entries);
+        Assert.All(archive.Entries, entry => Assert.EndsWith(".js", entry.FullName, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/AiScrapingDefense.TarpitApi/Services/ITarpitArtifactService.cs
+++ b/AiScrapingDefense.TarpitApi/Services/ITarpitArtifactService.cs
@@ -1,0 +1,11 @@
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface ITarpitArtifactService
+{
+    Task<TarpitArtifact?> TryGetArtifactAsync(string path, CancellationToken cancellationToken);
+}
+
+public sealed record TarpitArtifact(
+    string FileName,
+    string ContentType,
+    byte[] Content);

--- a/AiScrapingDefense.TarpitApi/Services/TarpitArtifactService.cs
+++ b/AiScrapingDefense.TarpitApi/Services/TarpitArtifactService.cs
@@ -1,0 +1,192 @@
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class TarpitArtifactService : ITarpitArtifactService
+{
+    private static readonly string[] FilePrefixes =
+    [
+        "analytics_bundle",
+        "vendor_lib",
+        "core_framework",
+        "ui_component_pack",
+        "runtime_utils",
+        "shared_modules",
+        "feature_flags_data",
+        "auth_client_sdk"
+    ];
+
+    private static readonly string[] FileSuffixes =
+    [
+        "_min",
+        "_pack",
+        "_bundle",
+        "_core",
+        string.Empty
+    ];
+
+    private readonly TarpitOptions _options;
+    private readonly IHostEnvironment _environment;
+    private readonly TimeProvider _timeProvider;
+    private readonly object _gate = new();
+
+    public TarpitArtifactService(
+        IOptions<DefenseEngineOptions> options,
+        IHostEnvironment environment,
+        TimeProvider timeProvider)
+    {
+        _options = options.Value.Tarpit;
+        _environment = environment;
+        _timeProvider = timeProvider;
+    }
+
+    public Task<TarpitArtifact?> TryGetArtifactAsync(string path, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!path.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult<TarpitArtifact?>(null);
+        }
+
+        var archiveDirectory = ResolveArchiveDirectory();
+        Directory.CreateDirectory(archiveDirectory);
+
+        var slug = SanitizeSlug(Path.GetFileNameWithoutExtension(path));
+        var bucket = _timeProvider.GetUtcNow().ToUnixTimeSeconds() / Math.Max(60, _options.ArchiveRotationMinutes * 60);
+        var archiveFileName = $"{slug}_{bucket}.zip";
+        var archivePath = Path.Combine(archiveDirectory, archiveFileName);
+        byte[] content;
+
+        lock (_gate)
+        {
+            if (!File.Exists(archivePath))
+            {
+                content = BuildArchive(slug, bucket);
+                File.WriteAllBytes(archivePath, content);
+                CleanupOldArchives(archiveDirectory);
+            }
+            else
+            {
+                content = File.ReadAllBytes(archivePath);
+            }
+        }
+
+        return Task.FromResult<TarpitArtifact?>(new TarpitArtifact(
+            archiveFileName,
+            "application/zip",
+            content));
+    }
+
+    private byte[] BuildArchive(string slug, long bucket)
+    {
+        var random = new Random(GetSeed(slug, bucket));
+        using var memoryStream = new MemoryStream();
+        using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            for (var index = 0; index < Math.Max(1, _options.JavaScriptDecoyFileCount); index++)
+            {
+                var entry = archive.CreateEntry(BuildEntryName(random), CompressionLevel.SmallestSize);
+                using var writer = new StreamWriter(entry.Open(), Encoding.UTF8, leaveOpen: false);
+                writer.Write(BuildJavaScriptPayload(slug, bucket, random, index));
+            }
+        }
+
+        return memoryStream.ToArray();
+    }
+
+    private string BuildEntryName(Random random)
+    {
+        var prefix = FilePrefixes[random.Next(FilePrefixes.Length)];
+        var suffix = FileSuffixes[random.Next(FileSuffixes.Length)];
+        var hash = random.NextInt64().ToString("x8");
+        return $"{prefix}{suffix}.{hash}.js";
+    }
+
+    private string BuildJavaScriptPayload(string slug, long bucket, Random random, int index)
+    {
+        var targetBytes = random.Next(
+            Math.Max(1, _options.MinJavaScriptDecoyFileSizeKb) * 1024,
+            Math.Max(Math.Max(1, _options.MinJavaScriptDecoyFileSizeKb) * 1024 + 1, _options.MaxJavaScriptDecoyFileSizeKb * 1024));
+        var builder = new StringBuilder();
+        builder.AppendLine($"// synthetic decoy archive {slug}");
+        builder.AppendLine($"// rotation bucket {bucket}");
+        builder.AppendLine($"// entry {index}");
+        builder.AppendLine("(function(){");
+
+        for (var i = 0; i < 12; i++)
+        {
+            builder.Append("  const ");
+            builder.Append(RandomIdentifier(random));
+            builder.Append(" = ");
+            builder.Append('"');
+            builder.Append(RandomAscii(random, 24));
+            builder.AppendLine("\";");
+        }
+
+        builder.Append("  function ");
+        builder.Append(RandomIdentifier(random));
+        builder.AppendLine("(){ return true; }");
+        builder.AppendLine("})();");
+        builder.Append("/*");
+
+        while (Encoding.UTF8.GetByteCount(builder.ToString()) < targetBytes)
+        {
+            builder.Append(RandomAscii(random, 96));
+        }
+
+        builder.AppendLine("*/");
+        return builder.ToString();
+    }
+
+    private void CleanupOldArchives(string archiveDirectory)
+    {
+        var archives = new DirectoryInfo(archiveDirectory)
+            .GetFiles("*.zip")
+            .OrderByDescending(file => file.LastWriteTimeUtc)
+            .ToArray();
+
+        foreach (var archive in archives.Skip(Math.Max(1, _options.MaximumArchivesToKeep)))
+        {
+            archive.Delete();
+        }
+    }
+
+    private string ResolveArchiveDirectory()
+    {
+        return Path.IsPathRooted(_options.ArchiveDirectory)
+            ? _options.ArchiveDirectory
+            : Path.Combine(_environment.ContentRootPath, _options.ArchiveDirectory);
+    }
+
+    private int GetSeed(string slug, long bucket)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{_options.Seed}|{slug}|{bucket}"));
+        return BitConverter.ToInt32(bytes, 0);
+    }
+
+    private static string SanitizeSlug(string slug)
+    {
+        var cleaned = new string(slug
+            .Where(ch => char.IsLetterOrDigit(ch) || ch is '-' or '_')
+            .ToArray());
+        return string.IsNullOrWhiteSpace(cleaned) ? "assets" : cleaned;
+    }
+
+    private static string RandomIdentifier(Random random)
+    {
+        const string alphabet = "abcdefghijklmnopqrstuvwxyz";
+        return string.Concat(Enumerable.Range(0, 10).Select(_ => alphabet[random.Next(alphabet.Length)]));
+    }
+
+    private static string RandomAscii(Random random, int length)
+    {
+        const string alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ ;:,.-";
+        return string.Concat(Enumerable.Range(0, length).Select(_ => alphabet[random.Next(alphabet.Length)]));
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A tagged release workflow that publishes signed GHCR images with provenance (`.github/workflows/release-images.yml`).
 * A containerized integration-test project covering suspicious request handling, management blocklist operations, webhook intake, and PostgreSQL-backed tarpit rendering.
 * A .NET-native local trained-model path plus trainer CLI for the escalation engine (`AiScrapingDefense.ModelTrainer`, `DefenseEngine:Escalation:LocalTrainedModel`).
+* Rotating ZIP decoy archives with deterministic fake JavaScript payloads in the tarpit path.
 * Prometheus/OTLP observability options and runtime instrumentation for defense decisions, tarpit responses, webhook intake, and sync activity.
 * Queue depth and capacity telemetry for queued suspicious-request pressure monitoring.
 * Release documentation for parity, operator operations, and release validation.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - Configurable outbound community reporting for processed intake events.
 - Optional community blocklist feed sync with authenticated status surfaced under `/defense/community-blocklist/status`.
 - Optional peer sync with explicit `ObserveOnly` and `BlockList` trust modes plus authenticated signal export at `/peer-sync/signals`.
-- Optional PostgreSQL-backed Markov tarpit content with deterministic render variants.
+- Optional PostgreSQL-backed Markov tarpit content with deterministic render variants and rotating ZIP decoy archives.
 
 ## Commercial v1 Scope
 
@@ -127,6 +127,8 @@ Key areas:
 - `DefenseEngine:PeerSync`
 - `DefenseEngine:Queue`
 - `DefenseEngine:Tarpit`
+  - `ArchiveDirectory`, `ArchiveRotationMinutes`, and `MaximumArchivesToKeep` control rotating ZIP decoy retention.
+  - `JavaScriptDecoyFileCount`, `MinJavaScriptDecoyFileSizeKb`, and `MaxJavaScriptDecoyFileSizeKb` control generated JavaScript archive contents.
 - `DefenseEngine:Observability`
 
 For direct edge deployments, leave `DefenseEngine:Networking:ClientIpResolutionMode` as `Direct`. If the app is behind a reverse proxy or CDN, switch it to `TrustedProxy` and populate `DefenseEngine:Networking:TrustedProxies` with the proxy IPs you explicitly trust.

--- a/RedisBlocklistMiddlewareApp.Tests/TarpitArtifactServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/TarpitArtifactServiceTests.cs
@@ -1,0 +1,135 @@
+using System.IO.Compression;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class TarpitArtifactServiceTests
+{
+    [Fact]
+    public async Task TryGetArtifactAsync_ReturnsDeterministicZip_ForSameRotationBucket()
+    {
+        using var harness = TarpitArtifactHarness.Create();
+        var service = harness.CreateService();
+
+        var first = await service.TryGetArtifactAsync("manual/archive/assets.zip", CancellationToken.None);
+        var second = await service.TryGetArtifactAsync("manual/archive/assets.zip", CancellationToken.None);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal(first!.FileName, second!.FileName);
+        Assert.Equal(first.Content, second.Content);
+
+        using var archive = new ZipArchive(new MemoryStream(first.Content), ZipArchiveMode.Read);
+        Assert.NotEmpty(archive.Entries);
+        Assert.All(archive.Entries, entry => Assert.EndsWith(".js", entry.FullName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task TryGetArtifactAsync_CleansUpOldArchives_WhenRotationAdvances()
+    {
+        using var harness = TarpitArtifactHarness.Create();
+        var service = harness.CreateService(maximumArchivesToKeep: 2, archiveRotationMinutes: 1);
+
+        await service.TryGetArtifactAsync("manual/archive/assets.zip", CancellationToken.None);
+        harness.AdvanceMinutes(1);
+        await service.TryGetArtifactAsync("manual/archive/assets.zip", CancellationToken.None);
+        harness.AdvanceMinutes(1);
+        await service.TryGetArtifactAsync("manual/archive/assets.zip", CancellationToken.None);
+
+        var archives = Directory.GetFiles(harness.ArchiveDirectory, "*.zip");
+        Assert.Equal(2, archives.Length);
+    }
+
+    private sealed class TarpitArtifactHarness : IDisposable
+    {
+        private readonly string _rootPath;
+        private readonly TestTimeProvider _timeProvider;
+
+        private TarpitArtifactHarness(string rootPath, TestTimeProvider timeProvider)
+        {
+            _rootPath = rootPath;
+            _timeProvider = timeProvider;
+        }
+
+        public string ArchiveDirectory => Path.Combine(_rootPath, "archives");
+
+        public static TarpitArtifactHarness Create()
+        {
+            var rootPath = Path.Combine(Path.GetTempPath(), "ai-scraping-defense-artifact-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(rootPath);
+            return new TarpitArtifactHarness(rootPath, new TestTimeProvider(DateTimeOffset.Parse("2026-03-15T12:00:00Z")));
+        }
+
+        public TarpitArtifactService CreateService(int maximumArchivesToKeep = 5, int archiveRotationMinutes = 60)
+        {
+            return new TarpitArtifactService(
+                Options.Create(new DefenseEngineOptions
+                {
+                    Tarpit = new TarpitOptions
+                    {
+                        ArchiveDirectory = "archives",
+                        MaximumArchivesToKeep = maximumArchivesToKeep,
+                        ArchiveRotationMinutes = archiveRotationMinutes,
+                        JavaScriptDecoyFileCount = 3,
+                        MinJavaScriptDecoyFileSizeKb = 1,
+                        MaxJavaScriptDecoyFileSizeKb = 1
+                    }
+                }),
+                new TestHostEnvironment(_rootPath),
+                _timeProvider);
+        }
+
+        public void AdvanceMinutes(int minutes)
+        {
+            _timeProvider.Advance(TimeSpan.FromMinutes(minutes));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_rootPath))
+            {
+                Directory.Delete(_rootPath, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public TestHostEnvironment(string contentRootPath)
+        {
+            ContentRootPath = contentRootPath;
+        }
+
+        public string EnvironmentName { get; set; } = "Development";
+
+        public string ApplicationName { get; set; } = "RedisBlocklistMiddlewareApp.Tests";
+
+        public string ContentRootPath { get; set; }
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private sealed class TestTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+
+        public TestTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return _utcNow;
+        }
+
+        public void Advance(TimeSpan by)
+        {
+            _utcNow = _utcNow.Add(by);
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -37,6 +37,15 @@ builder.Services
         }
 
         options.Tarpit.PathPrefix = options.Tarpit.PathPrefix.TrimEnd('/');
+        options.Tarpit.ArchiveDirectory = string.IsNullOrWhiteSpace(options.Tarpit.ArchiveDirectory)
+            ? "data/tarpit-archives"
+            : options.Tarpit.ArchiveDirectory.Trim();
+        options.Tarpit.ArchiveRotationMinutes = Math.Max(1, options.Tarpit.ArchiveRotationMinutes);
+        options.Tarpit.MaximumArchivesToKeep = Math.Max(1, options.Tarpit.MaximumArchivesToKeep);
+        options.Tarpit.JavaScriptDecoyFileCount = Math.Max(1, options.Tarpit.JavaScriptDecoyFileCount);
+        options.Tarpit.MinJavaScriptDecoyFileSizeKb = Math.Max(1, options.Tarpit.MinJavaScriptDecoyFileSizeKb);
+        options.Tarpit.MaxJavaScriptDecoyFileSizeKb =
+            Math.Max(options.Tarpit.MinJavaScriptDecoyFileSizeKb, options.Tarpit.MaxJavaScriptDecoyFileSizeKb);
         options.Tarpit.Modes = options.Tarpit.Modes
             .Where(mode => !string.IsNullOrWhiteSpace(mode))
             .Select(mode => mode.Trim())
@@ -256,6 +265,7 @@ builder.Services.AddSingleton<ISuspiciousRequestQueue, SuspiciousRequestQueue>()
 builder.Services.AddSingleton<IRequestSignalEvaluator, RequestSignalEvaluator>();
 builder.Services.AddSingleton<ITarpitMarkovStore, PostgresTarpitMarkovStore>();
 builder.Services.AddSingleton<ITarpitPageService, TarpitPageService>();
+builder.Services.AddSingleton<ITarpitArtifactService, TarpitArtifactService>();
 builder.Services.AddSingleton<IClientIpResolver, ClientIpResolver>();
 builder.Services.AddSingleton<IThreatReputationProvider, ConfiguredRangeReputationProvider>();
 builder.Services.AddSingleton<IThreatReputationProvider, HttpReputationProvider>();
@@ -273,6 +283,7 @@ builder.Services.AddSingleton<ApiKeyEndpointFilter>();
 builder.Services.AddSingleton<IntakeApiKeyEndpointFilter>();
 builder.Services.AddSingleton<PeerApiKeyEndpointFilter>();
 builder.Services.AddSingleton<IOperatorDashboardPageService, OperatorDashboardPageService>();
+builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IWebhookEventInbox, SqliteWebhookEventInbox>();
 builder.Services.AddSingleton<IIntakeAlertDispatcher, IntakeAlertDispatcher>();
 builder.Services.AddSingleton<ICommunityReporter, CommunityReporter>();
@@ -341,6 +352,7 @@ app.MapGet(tarpitRoutePattern, async (
     HttpContext context,
     string? path,
     ITarpitPageService tarpitPageService,
+    ITarpitArtifactService tarpitArtifactService,
     IClientIpResolver clientIpResolver,
     DefenseTelemetry telemetry,
     IOptions<DefenseEngineOptions> options,
@@ -354,7 +366,15 @@ app.MapGet(tarpitRoutePattern, async (
     }
 
     var clientIp = clientIpResolver.Resolve(context) ?? "unknown";
-    var content = tarpitPageService.GeneratePage(path ?? string.Empty, clientIp);
+    var normalizedPath = path ?? string.Empty;
+    var artifact = await tarpitArtifactService.TryGetArtifactAsync(normalizedPath, cancellationToken);
+    if (artifact is not null)
+    {
+        telemetry.RecordTarpitRender();
+        return Results.File(artifact.Content, artifact.ContentType, artifact.FileName);
+    }
+
+    var content = tarpitPageService.GeneratePage(normalizedPath, clientIp);
     telemetry.RecordTarpitRender();
     return Results.Content(content, "text/html");
 });

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -162,9 +162,15 @@
     "Tarpit": {
       "PathPrefix": "/anti-scrape-tarpit",
       "Seed": "ai-scraping-defense-dotnet",
+      "ArchiveDirectory": "data/tarpit-archives",
       "LinkCount": 6,
       "ParagraphCount": 5,
       "ResponseDelayMilliseconds": 200,
+      "ArchiveRotationMinutes": 60,
+      "MaximumArchivesToKeep": 5,
+      "JavaScriptDecoyFileCount": 12,
+      "MinJavaScriptDecoyFileSizeKb": 5,
+      "MaxJavaScriptDecoyFileSizeKb": 24,
       "Modes": [
         "Standard",
         "ArchiveIndex",

--- a/docs/operator_runbook.md
+++ b/docs/operator_runbook.md
@@ -189,3 +189,4 @@ See [observability_pack.md](observability_pack.md) for the packaged monitoring a
 - missing real client IPs: proxy/CDN trust mode is not configured correctly
 - intake delivery failures: inspect `/defense/intake-deliveries` for failed webhook, SMTP, or community-report attempts
 - empty Markov tarpit output changes: PostgreSQL corpus is empty or unavailable, so synthetic fallback content is being used
+- ZIP decoy archive churn looks wrong: inspect `DefenseEngine:Tarpit:ArchiveDirectory` and the archive-retention settings

--- a/docs/parity_matrix.md
+++ b/docs/parity_matrix.md
@@ -18,11 +18,11 @@ Status legend:
 | Community blocklist sync | Implemented | Feed sync, status reporting, import tracking, and outbound community reporting for intake events are in place. | Add richer trust policies and provider-specific controls as needed. |
 | Peer sync | Implemented | Timed imports, authenticated exports, and `ObserveOnly`/`BlockList` trust modes are implemented. | Add richer trust scoring and coordination. |
 | PostgreSQL-backed Markov tarpit | Implemented | The tarpit can load a Markov corpus from PostgreSQL and falls back safely when no snapshot exists. | Expand deeper decoy modes. See issue `#55`. |
-| Advanced tarpit decoys | Partial | Current tarpit modes cover deterministic HTML, archive, and API-catalog variants. | Port rotating archives and JavaScript ZIP honeypots. See issue `#55`. |
+| Advanced tarpit decoys | Implemented | The tarpit now serves rotating ZIP decoy archives with deterministic fake JavaScript payloads in addition to deterministic HTML modes. | Expand artifact families only when they add measurable crawler cost. |
 | Reputation providers and classifier hooks | Implemented | Configured ranges, HTTP reputation, .NET-native local trained models, and OpenAI-compatible model adapters exist. | Add richer dataset-building and retraining ergonomics. See issue `#64`. |
 | Alerting and operator/community reporting | Partial | Confirmed malicious intake events can dispatch generic webhook alerts, SMTP alerts, and configurable community reports with durable delivery visibility. | Slack-specific alert channel parity still remains. See issue `#60`. |
 | Structured telemetry export | Implemented | Prometheus metrics, OTLP trace export, packaged scrape/alert config, and a bundled Grafana dashboard are included. | Tune thresholds and dashboard panels against production traffic after deployment. |
 | Independent multi-service deployment | Deferred | v1 intentionally ships as a single deployable ASP.NET Core runtime. | Split into independently deployed roles only when operations justify it. |
 | SQL Server support | Deferred | Redis + SQLite + PostgreSQL are the supported data stores for v1. | Revisit only if customer demand justifies the extra provider surface. |
 
-Commercial v1 is feature-complete enough to package and validate, but fuller upstream parity still depends on closing issues `#54`, `#55`, and `#60`.
+Commercial v1 is feature-complete enough to package and validate, but fuller upstream parity still depends on closing issues `#60` and `#64`.


### PR DESCRIPTION
## Summary
- add deterministic rotating ZIP decoy generation for tarpit archive paths
- expose tarpit artifact settings and wire ZIP responses into the tarpit endpoint
- cover artifact generation and route behavior with unit and integration tests

Closes #55

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln