### PR TITLE
Add Slack intake alert channel

### DIFF
--- a/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
+++ b/AiScrapingDefense.Contracts/Configuration/DefenseEngineOptions.cs
@@ -342,6 +342,8 @@ public sealed class IntakeAlertingOptions
 {
     public GenericWebhookAlertOptions GenericWebhook { get; set; } = new();
 
+    public SlackAlertOptions Slack { get; set; } = new();
+
     public SmtpAlertOptions Smtp { get; set; } = new();
 }
 
@@ -373,6 +375,15 @@ public sealed class SmtpAlertOptions
     public string From { get; set; } = string.Empty;
 
     public string[] To { get; set; } = [];
+}
+
+public sealed class SlackAlertOptions
+{
+    public bool Enabled { get; set; }
+
+    public string WebhookUrl { get; set; } = string.Empty;
+
+    public int TimeoutSeconds { get; set; } = 10;
 }
 
 public sealed class CommunityReportingOptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A tagged release workflow that publishes signed GHCR images with provenance (`.github/workflows/release-images.yml`).
 * A containerized integration-test project covering suspicious request handling, management blocklist operations, webhook intake, and PostgreSQL-backed tarpit rendering.
 * A .NET-native local trained-model path plus trainer CLI for the escalation engine (`AiScrapingDefense.ModelTrainer`, `DefenseEngine:Escalation:LocalTrainedModel`).
+* A first-class Slack Incoming Webhook alert channel for intake processing, with persisted delivery outcomes alongside webhook/SMTP/community reporting.
 * Rotating ZIP decoy archives with deterministic fake JavaScript payloads in the tarpit path.
 * Prometheus/OTLP observability options and runtime instrumentation for defense decisions, tarpit responses, webhook intake, and sync activity.
 * Queue depth and capacity telemetry for queued suspicious-request pressure monitoring.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The current codebase now contains the first .NET-native defense slice inside [Re
 - Authenticated operator metrics and blocklist management endpoints under `/defense/*`.
 - A protected operator dashboard at `/defense/dashboard` backed by the same management API.
 - An authenticated `/analyze` webhook endpoint with durable SQLite-backed intake for confirmed malicious events.
-- Configurable webhook and SMTP alert dispatch for processed intake events.
+- Configurable webhook, Slack, and SMTP alert dispatch for processed intake events.
 - Configurable outbound community reporting for processed intake events.
 - Optional community blocklist feed sync with authenticated status surfaced under `/defense/community-blocklist/status`.
 - Optional peer sync with explicit `ObserveOnly` and `BlockList` trust modes plus authenticated signal export at `/peer-sync/signals`.
@@ -118,6 +118,7 @@ Key areas:
   - `DashboardSessionHours` controls the browser dashboard session lifetime after successful sign-in.
 - `DefenseEngine:Intake`
   - `Alerting:GenericWebhook` controls optional outbound webhook alerts for processed intake events.
+  - `Alerting:Slack` controls optional Slack Incoming Webhook alerts for processed intake events.
   - `Alerting:Smtp` controls optional operator email alerts for processed intake events.
   - `CommunityReporting` controls optional outbound reporting to providers like AbuseIPDB.
 - `DefenseEngine:Audit`

--- a/RedisBlocklistMiddlewareApp.Tests/IntakeAlertDispatcherTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/IntakeAlertDispatcherTests.cs
@@ -61,6 +61,65 @@ public sealed class IntakeAlertDispatcherTests
         Assert.Contains("network down", webhookResult.Detail);
     }
 
+    [Fact]
+    public async Task DispatchAsync_SendsSlackAlert_WithSlackFormattedPayload()
+    {
+        var handler = new RecordingHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK));
+        var options = CreateOptions();
+        options.Intake.Alerting.GenericWebhook.Enabled = false;
+        options.Intake.Alerting.Smtp.Enabled = false;
+        options.Intake.Alerting.Slack = new SlackAlertOptions
+        {
+            Enabled = true,
+            WebhookUrl = "https://hooks.slack.example.test/services/test",
+            TimeoutSeconds = 5
+        };
+        var dispatcher = new IntakeAlertDispatcher(
+            Options.Create(options),
+            new FakeHttpClientFactory(handler),
+            new RecordingSmtpAlertSender());
+
+        var results = await dispatcher.DispatchAsync(CreateEvent(), CancellationToken.None);
+
+        var slackResult = Assert.Single(results, record => record.Channel == IntakeDeliveryChannels.Slack);
+        Assert.Equal(IntakeDeliveryStatuses.Succeeded, slackResult.Status);
+        Assert.NotNull(handler.Request);
+        Assert.Equal(HttpMethod.Post, handler.Request!.Method);
+        Assert.Equal("https://hooks.slack.example.test/services/test", handler.Request.RequestUri!.ToString());
+
+        var requestJson = await handler.Request.Content!.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(requestJson);
+        var text = json.RootElement.GetProperty("text").GetString();
+        Assert.Contains("*AI Defense Alert*", text);
+        Assert.Contains("198.51.100.30", text);
+        Assert.True(json.RootElement.TryGetProperty("blocks", out var blocks));
+        Assert.NotEmpty(blocks.EnumerateArray());
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ReturnsFailedSlackRecord_WhenSlackCallThrows()
+    {
+        var options = CreateOptions();
+        options.Intake.Alerting.GenericWebhook.Enabled = false;
+        options.Intake.Alerting.Smtp.Enabled = false;
+        options.Intake.Alerting.Slack = new SlackAlertOptions
+        {
+            Enabled = true,
+            WebhookUrl = "https://hooks.slack.example.test/services/test",
+            TimeoutSeconds = 5
+        };
+        var dispatcher = new IntakeAlertDispatcher(
+            Options.Create(options),
+            new FakeHttpClientFactory(new ThrowingHttpMessageHandler(new HttpRequestException("slack down"))),
+            new RecordingSmtpAlertSender());
+
+        var results = await dispatcher.DispatchAsync(CreateEvent(), CancellationToken.None);
+
+        var slackResult = Assert.Single(results, record => record.Channel == IntakeDeliveryChannels.Slack);
+        Assert.Equal(IntakeDeliveryStatuses.Failed, slackResult.Status);
+        Assert.Contains("slack down", slackResult.Detail);
+    }
+
     private static DefenseEngineOptions CreateOptions()
     {
         return new DefenseEngineOptions

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -94,6 +94,9 @@ builder.Services
             options.Intake.Alerting.GenericWebhook.AuthorizationHeaderValue.Trim();
         options.Intake.Alerting.GenericWebhook.TimeoutSeconds =
             Math.Max(1, options.Intake.Alerting.GenericWebhook.TimeoutSeconds);
+        options.Intake.Alerting.Slack.WebhookUrl = options.Intake.Alerting.Slack.WebhookUrl.Trim();
+        options.Intake.Alerting.Slack.TimeoutSeconds =
+            Math.Max(1, options.Intake.Alerting.Slack.TimeoutSeconds);
         options.Intake.Alerting.Smtp.Host = options.Intake.Alerting.Smtp.Host.Trim();
         options.Intake.Alerting.Smtp.Port = Math.Max(1, options.Intake.Alerting.Smtp.Port);
         options.Intake.Alerting.Smtp.Username = options.Intake.Alerting.Smtp.Username.Trim();

--- a/RedisBlocklistMiddlewareApp/Services/IntakeAlertDispatcher.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IntakeAlertDispatcher.cs
@@ -27,11 +27,17 @@ public sealed class IntakeAlertDispatcher : IIntakeAlertDispatcher
         IntakeWebhookEvent webhookEvent,
         CancellationToken cancellationToken)
     {
-        var results = new List<IntakeDeliveryRecord>(2);
+        var results = new List<IntakeDeliveryRecord>(3);
         var webhookResult = await SendGenericWebhookAsync(webhookEvent, cancellationToken);
         if (webhookResult is not null)
         {
             results.Add(webhookResult);
+        }
+
+        var slackResult = await SendSlackAsync(webhookEvent, cancellationToken);
+        if (slackResult is not null)
+        {
+            results.Add(slackResult);
         }
 
         var smtpResult = await SendSmtpAsync(webhookEvent, cancellationToken);
@@ -106,6 +112,56 @@ public sealed class IntakeAlertDispatcher : IIntakeAlertDispatcher
         }
     }
 
+    private async Task<IntakeDeliveryRecord?> SendSlackAsync(
+        IntakeWebhookEvent webhookEvent,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.Slack;
+        if (!options.Enabled || string.IsNullOrWhiteSpace(options.WebhookUrl))
+        {
+            return null;
+        }
+
+        var attemptedAtUtc = DateTimeOffset.UtcNow;
+        try
+        {
+            using var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(Math.Max(1, options.TimeoutSeconds));
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, options.WebhookUrl)
+            {
+                Content = JsonContent.Create(BuildSlackPayload(webhookEvent))
+            };
+
+            using var response = await client.SendAsync(request, cancellationToken);
+            var detail = response.IsSuccessStatusCode
+                ? "Alert delivered successfully."
+                : $"Alert delivery failed with status {(int)response.StatusCode}.";
+
+            return new IntakeDeliveryRecord(
+                IntakeDeliveryTypes.Alert,
+                IntakeDeliveryChannels.Slack,
+                webhookEvent.Details.IpAddress,
+                webhookEvent.Reason,
+                options.WebhookUrl,
+                response.IsSuccessStatusCode ? IntakeDeliveryStatuses.Succeeded : IntakeDeliveryStatuses.Failed,
+                detail,
+                attemptedAtUtc);
+        }
+        catch (Exception ex)
+        {
+            return new IntakeDeliveryRecord(
+                IntakeDeliveryTypes.Alert,
+                IntakeDeliveryChannels.Slack,
+                webhookEvent.Details.IpAddress,
+                webhookEvent.Reason,
+                options.WebhookUrl,
+                IntakeDeliveryStatuses.Failed,
+                ex.Message,
+                attemptedAtUtc);
+        }
+    }
+
     private async Task<IntakeDeliveryRecord?> SendSmtpAsync(
         IntakeWebhookEvent webhookEvent,
         CancellationToken cancellationToken)
@@ -172,5 +228,70 @@ public sealed class IntakeAlertDispatcher : IIntakeAlertDispatcher
         builder.AppendLine($"Signals: {string.Join(", ", detail.Signals ?? [])}");
         return builder.ToString();
     }
-}
 
+    private static object BuildSlackPayload(IntakeWebhookEvent webhookEvent)
+    {
+        var detail = webhookEvent.Details;
+        var userAgent = string.IsNullOrWhiteSpace(detail.UserAgent) ? "N/A" : detail.UserAgent;
+        var method = string.IsNullOrWhiteSpace(detail.Method) ? "N/A" : detail.Method;
+        var path = string.IsNullOrWhiteSpace(detail.Path) ? "/" : detail.Path;
+        var queryString = string.IsNullOrWhiteSpace(detail.QueryString) ? string.Empty : detail.QueryString;
+        var signals = detail.Signals is { Count: > 0 } ? string.Join(", ", detail.Signals) : "None";
+        var pathDisplay = string.IsNullOrEmpty(queryString) ? path : $"{path}{queryString}";
+        var message = $":shield: *AI Defense Alert*\n" +
+                      $"> *Reason:* {webhookEvent.Reason}\n" +
+                      $"> *IP Address:* `{detail.IpAddress}`\n" +
+                      $"> *Method:* `{method}`\n" +
+                      $"> *Path:* `{pathDisplay}`\n" +
+                      $"> *User Agent:* `{userAgent}`\n" +
+                      $"> *Signals:* {signals}\n" +
+                      $"> *Timestamp (UTC):* {webhookEvent.TimestampUtc:O}";
+
+        return new
+        {
+            text = message,
+            blocks = new object[]
+            {
+                new
+                {
+                    type = "section",
+                    text = new
+                    {
+                        type = "mrkdwn",
+                        text = "*AI Defense Alert*\nConfirmed malicious traffic was processed by the intake pipeline."
+                    }
+                },
+                new
+                {
+                    type = "section",
+                    fields = new object[]
+                    {
+                        new { type = "mrkdwn", text = $"*Reason:*\n{EscapeSlack(webhookEvent.Reason)}" },
+                        new { type = "mrkdwn", text = $"*IP Address:*\n`{EscapeSlack(detail.IpAddress)}`" },
+                        new { type = "mrkdwn", text = $"*Method:*\n`{EscapeSlack(method)}`" },
+                        new { type = "mrkdwn", text = $"*Path:*\n`{EscapeSlack(pathDisplay)}`" },
+                        new { type = "mrkdwn", text = $"*User Agent:*\n`{EscapeSlack(userAgent)}`" },
+                        new { type = "mrkdwn", text = $"*Timestamp (UTC):*\n{webhookEvent.TimestampUtc:O}" }
+                    }
+                },
+                new
+                {
+                    type = "section",
+                    text = new
+                    {
+                        type = "mrkdwn",
+                        text = $"*Signals:*\n{EscapeSlack(signals)}"
+                    }
+                }
+            }
+        };
+    }
+
+    private static string EscapeSlack(string value)
+    {
+        return value
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal);
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/IntakeDeliveryConstants.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IntakeDeliveryConstants.cs
@@ -11,6 +11,8 @@ public static class IntakeDeliveryChannels
 {
     public const string GenericWebhook = "generic_webhook";
 
+    public const string Slack = "slack";
+
     public const string Smtp = "smtp";
 }
 
@@ -22,4 +24,3 @@ public static class IntakeDeliveryStatuses
 
     public const string Skipped = "skipped";
 }
-

--- a/RedisBlocklistMiddlewareApp/appsettings.json
+++ b/RedisBlocklistMiddlewareApp/appsettings.json
@@ -79,6 +79,11 @@
           "AuthorizationHeaderValue": "",
           "TimeoutSeconds": 10
         },
+        "Slack": {
+          "Enabled": false,
+          "WebhookUrl": "",
+          "TimeoutSeconds": 10
+        },
         "Smtp": {
           "Enabled": false,
           "Host": "",

--- a/docs/operator_runbook.md
+++ b/docs/operator_runbook.md
@@ -33,7 +33,7 @@ At minimum, set:
 - `DefenseEngine:Redis:ConnectionString`
 - `DefenseEngine:Management:ApiKey`
 - `DefenseEngine:Intake:ApiKey` if webhook intake is required
-- `DefenseEngine:Intake:Alerting:*` if webhook or SMTP alerts are required
+- `DefenseEngine:Intake:Alerting:*` if webhook, Slack, or SMTP alerts are required
 - `DefenseEngine:Intake:CommunityReporting:*` if outbound community reporting is required
 - `DefenseEngine:Audit:DatabasePath`
 - `DefenseEngine:Networking:ClientIpResolutionMode`
@@ -187,6 +187,6 @@ See [observability_pack.md](observability_pack.md) for the packaged monitoring a
 - `503 /health`: Redis is unreachable or misconfigured
 - startup failure in `Production`: loopback Redis or unsafe proxy config is still present
 - missing real client IPs: proxy/CDN trust mode is not configured correctly
-- intake delivery failures: inspect `/defense/intake-deliveries` for failed webhook, SMTP, or community-report attempts
+- intake delivery failures: inspect `/defense/intake-deliveries` for failed webhook, Slack, SMTP, or community-report attempts
 - empty Markov tarpit output changes: PostgreSQL corpus is empty or unavailable, so synthetic fallback content is being used
 - ZIP decoy archive churn looks wrong: inspect `DefenseEngine:Tarpit:ArchiveDirectory` and the archive-retention settings

--- a/docs/parity_matrix.md
+++ b/docs/parity_matrix.md
@@ -20,9 +20,9 @@ Status legend:
 | PostgreSQL-backed Markov tarpit | Implemented | The tarpit can load a Markov corpus from PostgreSQL and falls back safely when no snapshot exists. | Expand deeper decoy modes. See issue `#55`. |
 | Advanced tarpit decoys | Implemented | The tarpit now serves rotating ZIP decoy archives with deterministic fake JavaScript payloads in addition to deterministic HTML modes. | Expand artifact families only when they add measurable crawler cost. |
 | Reputation providers and classifier hooks | Implemented | Configured ranges, HTTP reputation, .NET-native local trained models, and OpenAI-compatible model adapters exist. | Add richer dataset-building and retraining ergonomics. See issue `#64`. |
-| Alerting and operator/community reporting | Partial | Confirmed malicious intake events can dispatch generic webhook alerts, SMTP alerts, and configurable community reports with durable delivery visibility. | Slack-specific alert channel parity still remains. See issue `#60`. |
+| Alerting and operator/community reporting | Implemented | Confirmed malicious intake events can dispatch generic webhook alerts, Slack Incoming Webhook alerts, SMTP alerts, and configurable community reports with durable delivery visibility. | Add provider-specific enrichments only when operators show real demand. |
 | Structured telemetry export | Implemented | Prometheus metrics, OTLP trace export, packaged scrape/alert config, and a bundled Grafana dashboard are included. | Tune thresholds and dashboard panels against production traffic after deployment. |
 | Independent multi-service deployment | Deferred | v1 intentionally ships as a single deployable ASP.NET Core runtime. | Split into independently deployed roles only when operations justify it. |
 | SQL Server support | Deferred | Redis + SQLite + PostgreSQL are the supported data stores for v1. | Revisit only if customer demand justifies the extra provider surface. |
 
-Commercial v1 is feature-complete enough to package and validate, but fuller upstream parity still depends on closing issues `#60` and `#64`.
+Commercial v1 is feature-complete enough to package and validate, but fuller upstream parity still depends on closing issue `#64`.


### PR DESCRIPTION
## Summary
- add a first-class Slack Incoming Webhook channel for intake alerting
- persist Slack delivery outcomes alongside existing alert/report records
- update docs and parity tracking for Slack alert support

Closes #60

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln