### PR TITLE
Add local model dataset builders

### DIFF
--- a/AiScrapingDefense.EscalationEngine/Services/LocalModelDatasetBuilder.cs
+++ b/AiScrapingDefense.EscalationEngine/Services/LocalModelDatasetBuilder.cs
@@ -1,0 +1,444 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using RedisBlocklistMiddlewareApp.Configuration;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class LocalModelDatasetBuilder
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly string[] KnownBenignUserAgentMarkers =
+    [
+        "Mozilla/",
+        "Chrome/",
+        "Safari/",
+        "Firefox/",
+        "Edg/",
+        "OPR/",
+        "SearchBot",
+        "Googlebot",
+        "bingbot",
+        "DuckDuckBot"
+    ];
+
+    private readonly HeuristicOptions _heuristics;
+    private readonly TimeSpan _frequencyWindow;
+    private readonly TimeSpan _feedbackMatchTolerance;
+
+    public LocalModelDatasetBuilder(
+        HeuristicOptions? heuristics = null,
+        TimeSpan? frequencyWindow = null,
+        TimeSpan? feedbackMatchTolerance = null)
+    {
+        _heuristics = heuristics ?? new HeuristicOptions();
+        _frequencyWindow = frequencyWindow ?? TimeSpan.FromMinutes(5);
+        _feedbackMatchTolerance = feedbackMatchTolerance ?? TimeSpan.FromMinutes(5);
+    }
+
+    public LocalModelDatasetBuildResult Build(
+        IEnumerable<LocalModelDatasetSourceRecord> sourceRecords,
+        IEnumerable<LocalModelFeedbackRecord>? feedbackRecords = null)
+    {
+        var orderedRecords = sourceRecords
+            .Where(record => !string.IsNullOrWhiteSpace(record.Method) && !string.IsNullOrWhiteSpace(record.Path))
+            .OrderBy(record => record.TimestampUtc)
+            .ToArray();
+        var feedback = feedbackRecords?.ToArray() ?? [];
+        var windows = new Dictionary<string, Queue<DateTimeOffset>>(StringComparer.Ordinal);
+        var documents = new List<LocalModelTrainingDocument>(orderedRecords.Length);
+        var feedbackLabels = 0;
+        var heuristicLabels = 0;
+        var skippedRecords = 0;
+
+        foreach (var record in orderedRecords)
+        {
+            var frequency = record.Frequency ?? CalculateFrequency(record, windows);
+            var signals = EvaluateSignals(record);
+            var label = FindFeedbackLabel(record, feedback);
+
+            if (label is not null)
+            {
+                feedbackLabels++;
+            }
+            else
+            {
+                label = InferLabel(record, signals);
+                if (label is not null)
+                {
+                    heuristicLabels++;
+                }
+            }
+
+            if (label is null)
+            {
+                skippedRecords++;
+                continue;
+            }
+
+            documents.Add(new LocalModelTrainingDocument(
+                label.Value,
+                record.Method.Trim().ToUpperInvariant(),
+                NormalizePath(record.Path),
+                NormalizeQueryString(record.QueryString),
+                record.UserAgent?.Trim() ?? string.Empty,
+                signals,
+                frequency));
+        }
+
+        return new LocalModelDatasetBuildResult(documents, feedbackLabels, heuristicLabels, skippedRecords);
+    }
+
+    public IReadOnlyList<LocalModelDatasetSourceRecord> LoadRequestRecordsFromJsonl(string inputPath)
+    {
+        var records = new List<LocalModelDatasetSourceRecord>();
+        foreach (var line in File.ReadLines(inputPath))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var record = JsonSerializer.Deserialize<LocalModelDatasetSourceRecord>(line, JsonOptions)
+                ?? throw new InvalidOperationException("Request export input contained an invalid JSON line.");
+            records.Add(record);
+        }
+
+        return records;
+    }
+
+    public IReadOnlyList<LocalModelFeedbackRecord> LoadFeedbackRecordsFromJsonl(string inputPath)
+    {
+        var records = new List<LocalModelFeedbackRecord>();
+        foreach (var line in File.ReadLines(inputPath))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var record = JsonSerializer.Deserialize<LocalModelFeedbackRecord>(line, JsonOptions)
+                ?? throw new InvalidOperationException("Feedback input contained an invalid JSON line.");
+            records.Add(record);
+        }
+
+        return records;
+    }
+
+    public IReadOnlyList<LocalModelDatasetSourceRecord> LoadRequestRecordsFromW3cLog(string inputPath)
+    {
+        var results = new List<LocalModelDatasetSourceRecord>();
+        Dictionary<int, string>? fieldMap = null;
+
+        foreach (var rawLine in File.ReadLines(inputPath))
+        {
+            if (string.IsNullOrWhiteSpace(rawLine))
+            {
+                continue;
+            }
+
+            if (rawLine.StartsWith("#Fields:", StringComparison.Ordinal))
+            {
+                var fields = rawLine["#Fields:".Length..]
+                    .Trim()
+                    .Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                fieldMap = fields
+                    .Select((field, index) => new KeyValuePair<int, string>(index, field))
+                    .ToDictionary(pair => pair.Key, pair => pair.Value);
+                continue;
+            }
+
+            if (rawLine.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (fieldMap is null)
+            {
+                throw new InvalidOperationException("W3C log input must contain a #Fields directive before request lines.");
+            }
+
+            var parts = rawLine.Split(' ');
+            if (parts.Length != fieldMap.Count)
+            {
+                continue;
+            }
+
+            var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var pair in fieldMap)
+            {
+                values[fieldMap[pair.Key]] = NormalizeLogValue(parts[pair.Key]);
+            }
+
+            if (!values.TryGetValue("date", out var dateValue) ||
+                !values.TryGetValue("time", out var timeValue) ||
+                string.IsNullOrWhiteSpace(dateValue) ||
+                string.IsNullOrWhiteSpace(timeValue))
+            {
+                continue;
+            }
+
+            if (!DateTimeOffset.TryParseExact(
+                    $"{dateValue} {timeValue}",
+                    "yyyy-MM-dd HH:mm:ss",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var timestampUtc))
+            {
+                continue;
+            }
+
+            results.Add(new LocalModelDatasetSourceRecord(
+                timestampUtc,
+                values.GetValueOrDefault("c-ip") ?? string.Empty,
+                values.GetValueOrDefault("cs-method") ?? "GET",
+                values.GetValueOrDefault("cs-uri-stem") ?? "/",
+                NormalizeQueryString(values.GetValueOrDefault("cs-uri-query")),
+                DecodeLogToken(values.GetValueOrDefault("cs(User-Agent)")),
+                DecodeLogToken(values.GetValueOrDefault("cs(Accept)")),
+                DecodeLogToken(values.GetValueOrDefault("cs(Accept-Language)")),
+                null));
+        }
+
+        return results;
+    }
+
+    public void WriteDocumentsAsJsonl(IEnumerable<LocalModelTrainingDocument> documents, string outputPath)
+    {
+        var directory = Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var writer = new StreamWriter(outputPath, append: false);
+        foreach (var document in documents)
+        {
+            writer.WriteLine(JsonSerializer.Serialize(document));
+        }
+    }
+
+    private long CalculateFrequency(
+        LocalModelDatasetSourceRecord record,
+        IDictionary<string, Queue<DateTimeOffset>> windows)
+    {
+        if (!windows.TryGetValue(record.IpAddress, out var window))
+        {
+            window = new Queue<DateTimeOffset>();
+            windows[record.IpAddress] = window;
+        }
+
+        while (window.Count > 0 && record.TimestampUtc - window.Peek() > _frequencyWindow)
+        {
+            window.Dequeue();
+        }
+
+        window.Enqueue(record.TimestampUtc);
+        return window.Count;
+    }
+
+    private IReadOnlyList<string> EvaluateSignals(LocalModelDatasetSourceRecord record)
+    {
+        var signals = new List<string>();
+        var userAgent = record.UserAgent ?? string.Empty;
+        var path = NormalizePath(record.Path);
+        var acceptLanguage = record.AcceptLanguage ?? string.Empty;
+        var accept = record.Accept ?? string.Empty;
+        var queryString = NormalizeQueryString(record.QueryString);
+
+        if (!string.IsNullOrWhiteSpace(userAgent))
+        {
+            foreach (var knownBadUserAgent in _heuristics.KnownBadUserAgents)
+            {
+                if (userAgent.Contains(knownBadUserAgent, StringComparison.OrdinalIgnoreCase))
+                {
+                    signals.Add($"known_bad_user_agent:{knownBadUserAgent}");
+                    break;
+                }
+            }
+        }
+        else if (_heuristics.CheckEmptyUserAgent)
+        {
+            signals.Add("empty_user_agent");
+        }
+
+        if (_heuristics.CheckMissingAcceptLanguage && string.IsNullOrWhiteSpace(acceptLanguage))
+        {
+            signals.Add("missing_accept_language");
+        }
+
+        if (_heuristics.CheckGenericAcceptHeader && string.Equals(accept, "*/*", StringComparison.Ordinal))
+        {
+            signals.Add("generic_accept_any");
+        }
+
+        foreach (var suspiciousPath in _heuristics.SuspiciousPathSubstrings)
+        {
+            if (path.Contains(suspiciousPath, StringComparison.OrdinalIgnoreCase))
+            {
+                signals.Add($"suspicious_path:{suspiciousPath}");
+                break;
+            }
+        }
+
+        if (queryString.Length > 200)
+        {
+            signals.Add("long_query_string");
+        }
+
+        return signals;
+    }
+
+    private bool? FindFeedbackLabel(
+        LocalModelDatasetSourceRecord record,
+        IReadOnlyList<LocalModelFeedbackRecord> feedbackRecords)
+    {
+        LocalModelFeedbackRecord? match = null;
+        var matchScore = -1;
+
+        foreach (var feedbackRecord in feedbackRecords)
+        {
+            if (!string.Equals(feedbackRecord.IpAddress, record.IpAddress, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var score = 1;
+
+            if (!string.IsNullOrWhiteSpace(feedbackRecord.Path))
+            {
+                if (!string.Equals(NormalizePath(feedbackRecord.Path), NormalizePath(record.Path), StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                score++;
+            }
+
+            if (!string.IsNullOrWhiteSpace(feedbackRecord.UserAgent))
+            {
+                if (!string.Equals(feedbackRecord.UserAgent, record.UserAgent, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                score++;
+            }
+
+            if (feedbackRecord.ObservedAtUtc is not null)
+            {
+                if ((record.TimestampUtc - feedbackRecord.ObservedAtUtc.Value).Duration() > _feedbackMatchTolerance)
+                {
+                    continue;
+                }
+
+                score++;
+            }
+
+            if (score > matchScore)
+            {
+                match = feedbackRecord;
+                matchScore = score;
+            }
+        }
+
+        return match?.Label;
+    }
+
+    private bool? InferLabel(LocalModelDatasetSourceRecord record, IReadOnlyList<string> signals)
+    {
+        if (signals.Any(signal => signal.StartsWith("known_bad_user_agent:", StringComparison.Ordinal)))
+        {
+            return true;
+        }
+
+        if (signals.Count >= 2 &&
+            signals.Any(signal => signal.StartsWith("suspicious_path:", StringComparison.Ordinal)))
+        {
+            return true;
+        }
+
+        if (signals.Contains("empty_user_agent", StringComparer.Ordinal) &&
+            signals.Contains("generic_accept_any", StringComparer.Ordinal))
+        {
+            return true;
+        }
+
+        if (signals.Count == 0)
+        {
+            var userAgent = record.UserAgent ?? string.Empty;
+            if (KnownBenignUserAgentMarkers.Any(marker => userAgent.Contains(marker, StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+        }
+
+        return null;
+    }
+
+    private static string NormalizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return "/";
+        }
+
+        var trimmed = path.Trim();
+        return trimmed.StartsWith("/", StringComparison.Ordinal) ? trimmed : $"/{trimmed}";
+    }
+
+    private static string NormalizeQueryString(string? queryString)
+    {
+        if (string.IsNullOrWhiteSpace(queryString))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = queryString.Trim();
+        if (trimmed == "-")
+        {
+            return string.Empty;
+        }
+
+        return trimmed.StartsWith("?", StringComparison.Ordinal) ? trimmed : $"?{trimmed}";
+    }
+
+    private static string? NormalizeLogValue(string value)
+    {
+        return value == "-" ? null : value;
+    }
+
+    private static string? DecodeLogToken(string? value)
+    {
+        return value?.Replace("+", " ", StringComparison.Ordinal);
+    }
+}
+
+public sealed record LocalModelDatasetSourceRecord(
+    [property: JsonPropertyName("timestamp_utc")] DateTimeOffset TimestampUtc,
+    [property: JsonPropertyName("ip_address")] string IpAddress,
+    [property: JsonPropertyName("method")] string Method,
+    [property: JsonPropertyName("path")] string Path,
+    [property: JsonPropertyName("query_string")] string? QueryString,
+    [property: JsonPropertyName("user_agent")] string? UserAgent,
+    [property: JsonPropertyName("accept")] string? Accept,
+    [property: JsonPropertyName("accept_language")] string? AcceptLanguage,
+    [property: JsonPropertyName("frequency")] long? Frequency);
+
+public sealed record LocalModelFeedbackRecord(
+    [property: JsonPropertyName("label")] bool Label,
+    [property: JsonPropertyName("ip_address")] string IpAddress,
+    [property: JsonPropertyName("path")] string? Path,
+    [property: JsonPropertyName("user_agent")] string? UserAgent,
+    [property: JsonPropertyName("observed_at_utc")] DateTimeOffset? ObservedAtUtc,
+    [property: JsonPropertyName("note")] string? Note);
+
+public sealed record LocalModelDatasetBuildResult(
+    IReadOnlyList<LocalModelTrainingDocument> Documents,
+    int FeedbackLabelsApplied,
+    int HeuristicLabelsApplied,
+    int SkippedRecords);

--- a/AiScrapingDefense.ModelTrainer/Program.cs
+++ b/AiScrapingDefense.ModelTrainer/Program.cs
@@ -1,40 +1,114 @@
 using System.Text.Json;
 using RedisBlocklistMiddlewareApp.Services;
 
-var arguments = ParseArguments(args);
-if (!arguments.TryGetValue("--input", out var inputPath) ||
-    !arguments.TryGetValue("--output", out var outputPath) ||
-    !arguments.TryGetValue("--version", out var modelVersion))
+var exitCode = Execute(args);
+return exitCode;
+
+static int Execute(string[] args)
 {
-    WriteUsage();
-    return 1;
+    var commandArguments = args;
+    var command = "train";
+
+    if (args.Length > 0 &&
+        !args[0].StartsWith("--", StringComparison.Ordinal) &&
+        (string.Equals(args[0], "train", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(args[0], "build-dataset", StringComparison.OrdinalIgnoreCase)))
+    {
+        command = args[0].ToLowerInvariant();
+        commandArguments = args[1..];
+    }
+
+    var arguments = ParseArguments(commandArguments);
+    return command switch
+    {
+        "build-dataset" => ExecuteBuildDataset(arguments),
+        _ => ExecuteTrain(arguments)
+    };
 }
 
-var threshold = 0.75f;
-if (arguments.TryGetValue("--threshold", out var thresholdValue) &&
-    !float.TryParse(thresholdValue, out threshold))
+static int ExecuteTrain(IReadOnlyDictionary<string, string> arguments)
 {
-    Console.Error.WriteLine("The --threshold value must be a floating-point number.");
-    return 1;
+    if (!arguments.TryGetValue("--input", out var inputPath) ||
+        !arguments.TryGetValue("--output", out var outputPath) ||
+        !arguments.TryGetValue("--version", out var modelVersion))
+    {
+        WriteUsage();
+        return 1;
+    }
+
+    var threshold = 0.75f;
+    if (arguments.TryGetValue("--threshold", out var thresholdValue) &&
+        !float.TryParse(thresholdValue, out threshold))
+    {
+        Console.Error.WriteLine("The --threshold value must be a floating-point number.");
+        return 1;
+    }
+
+    threshold = Math.Clamp(threshold, 0.5f, 0.99f);
+
+    if (!File.Exists(inputPath))
+    {
+        Console.Error.WriteLine($"Training input file '{inputPath}' was not found.");
+        return 1;
+    }
+
+    var documents = LoadTrainingDocuments(inputPath);
+    var trainer = new LocalTrainedModelTrainer();
+    var artifacts = trainer.TrainAndSave(documents, outputPath, modelVersion, threshold);
+
+    Console.WriteLine($"Model written to {artifacts.ModelPath}");
+    Console.WriteLine($"Metadata written to {artifacts.MetadataPath}");
+    Console.WriteLine($"Model version: {artifacts.Metadata.ModelVersion}");
+    Console.WriteLine($"Training examples: {artifacts.Metadata.TrainingExampleCount}");
+    return 0;
 }
 
-threshold = Math.Clamp(threshold, 0.5f, 0.99f);
-
-if (!File.Exists(inputPath))
+static int ExecuteBuildDataset(IReadOnlyDictionary<string, string> arguments)
 {
-    Console.Error.WriteLine($"Training input file '{inputPath}' was not found.");
-    return 1;
+    if (!arguments.TryGetValue("--input-format", out var inputFormat) ||
+        !arguments.TryGetValue("--input", out var inputPath) ||
+        !arguments.TryGetValue("--output", out var outputPath))
+    {
+        WriteUsage();
+        return 1;
+    }
+
+    if (!File.Exists(inputPath))
+    {
+        Console.Error.WriteLine($"Dataset input file '{inputPath}' was not found.");
+        return 1;
+    }
+
+    var builder = new LocalModelDatasetBuilder();
+    IReadOnlyList<LocalModelDatasetSourceRecord> sourceRecords = inputFormat.ToLowerInvariant() switch
+    {
+        "request-jsonl" => builder.LoadRequestRecordsFromJsonl(inputPath),
+        "w3c" => builder.LoadRequestRecordsFromW3cLog(inputPath),
+        _ => throw new InvalidOperationException("Unsupported --input-format. Use 'request-jsonl' or 'w3c'.")
+    };
+
+    IReadOnlyList<LocalModelFeedbackRecord>? feedbackRecords = null;
+    if (arguments.TryGetValue("--feedback", out var feedbackPath) && !string.IsNullOrWhiteSpace(feedbackPath))
+    {
+        if (!File.Exists(feedbackPath))
+        {
+            Console.Error.WriteLine($"Feedback file '{feedbackPath}' was not found.");
+            return 1;
+        }
+
+        feedbackRecords = builder.LoadFeedbackRecordsFromJsonl(feedbackPath);
+    }
+
+    var result = builder.Build(sourceRecords, feedbackRecords);
+    builder.WriteDocumentsAsJsonl(result.Documents, outputPath);
+
+    Console.WriteLine($"Dataset written to {outputPath}");
+    Console.WriteLine($"Training examples: {result.Documents.Count}");
+    Console.WriteLine($"Feedback labels applied: {result.FeedbackLabelsApplied}");
+    Console.WriteLine($"Heuristic labels applied: {result.HeuristicLabelsApplied}");
+    Console.WriteLine($"Skipped records: {result.SkippedRecords}");
+    return 0;
 }
-
-var documents = LoadDocuments(inputPath);
-var trainer = new LocalTrainedModelTrainer();
-var artifacts = trainer.TrainAndSave(documents, outputPath, modelVersion, threshold);
-
-Console.WriteLine($"Model written to {artifacts.ModelPath}");
-Console.WriteLine($"Metadata written to {artifacts.MetadataPath}");
-Console.WriteLine($"Model version: {artifacts.Metadata.ModelVersion}");
-Console.WriteLine($"Training examples: {artifacts.Metadata.TrainingExampleCount}");
-return 0;
 
 static Dictionary<string, string> ParseArguments(string[] args)
 {
@@ -60,7 +134,7 @@ static Dictionary<string, string> ParseArguments(string[] args)
     return results;
 }
 
-static IReadOnlyList<LocalModelTrainingDocument> LoadDocuments(string inputPath)
+static IReadOnlyList<LocalModelTrainingDocument> LoadTrainingDocuments(string inputPath)
 {
     var lines = File.ReadAllLines(inputPath)
         .Where(line => !string.IsNullOrWhiteSpace(line))
@@ -84,6 +158,9 @@ static IReadOnlyList<LocalModelTrainingDocument> LoadDocuments(string inputPath)
 static void WriteUsage()
 {
     Console.Error.WriteLine(
-        "Usage: dotnet run --project AiScrapingDefense.ModelTrainer -- " +
-        "--input <training.jsonl> --output <model.zip> --version <model-version> [--threshold 0.75]");
+        "Usage:\n" +
+        "  dotnet run --project AiScrapingDefense.ModelTrainer -- " +
+        "train --input <training.jsonl> --output <model.zip> --version <model-version> [--threshold 0.75]\n" +
+        "  dotnet run --project AiScrapingDefense.ModelTrainer -- " +
+        "build-dataset --input-format <request-jsonl|w3c> --input <requests-file> --output <training.jsonl> [--feedback <feedback.jsonl>]");
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A tagged release workflow that publishes signed GHCR images with provenance (`.github/workflows/release-images.yml`).
 * A containerized integration-test project covering suspicious request handling, management blocklist operations, webhook intake, and PostgreSQL-backed tarpit rendering.
 * A .NET-native local trained-model path plus trainer CLI for the escalation engine (`AiScrapingDefense.ModelTrainer`, `DefenseEngine:Escalation:LocalTrainedModel`).
+* A .NET-native dataset builder for local model retraining from W3C logs or request-export JSONL plus operator feedback overrides.
 * A first-class Slack Incoming Webhook alert channel for intake processing, with persisted delivery outcomes alongside webhook/SMTP/community reporting.
 * Rotating ZIP decoy archives with deterministic fake JavaScript payloads in the tarpit path.
 * Prometheus/OTLP observability options and runtime instrumentation for defense decisions, tarpit responses, webhook intake, and sync activity.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Queued suspicious-request analysis now persists a score breakdown with named con
 - an optional OpenAI-compatible classifier endpoint
 
 The default configuration keeps the external reputation/model hooks disabled. They are exposed under `DefenseEngine:Escalation` so production deployments can opt in without changing the rest of the request pipeline.
-See [docs/local_model_training.md](docs/local_model_training.md) for the local model artifact format and trainer CLI.
+See [docs/local_model_training.md](docs/local_model_training.md) for the local model artifact format, dataset-builder inputs, and trainer CLI.
 
 ## PostgreSQL Tarpit
 

--- a/RedisBlocklistMiddlewareApp.Tests/LocalModelDatasetBuilderTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/LocalModelDatasetBuilderTests.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class LocalModelDatasetBuilderTests
+{
+    [Fact]
+    public void Build_LoadsW3cLogsAndFeedback_IntoTrainingDocuments()
+    {
+        using var harness = DatasetHarness.Create();
+        var logPath = harness.WriteW3cLog(
+            """
+            #Version: 1.0
+            #Fields: date time c-ip cs-method cs-uri-stem cs-uri-query cs(User-Agent) cs(Accept) cs(Accept-Language)
+            2026-03-15 12:00:00 198.51.100.10 GET /graphql page=1&take=5000 python-requests/2.31 */* -
+            2026-03-15 12:01:00 198.51.100.20 GET /pricing - Mozilla/5.0 text/html en-US
+            2026-03-15 12:02:00 198.51.100.30 GET /docs/export - Mozilla/5.0 text/html en-US
+            """);
+        var feedbackPath = harness.WriteFeedbackJsonl(
+            new LocalModelFeedbackRecord(
+                true,
+                "198.51.100.30",
+                "/docs/export",
+                "Mozilla/5.0",
+                DateTimeOffset.Parse("2026-03-15T12:02:00Z"),
+                "operator review"));
+
+        var builder = new LocalModelDatasetBuilder();
+
+        var sourceRecords = builder.LoadRequestRecordsFromW3cLog(logPath);
+        var feedbackRecords = builder.LoadFeedbackRecordsFromJsonl(feedbackPath);
+        var result = builder.Build(sourceRecords, feedbackRecords);
+
+        Assert.Equal(3, result.Documents.Count);
+        Assert.Equal(1, result.FeedbackLabelsApplied);
+        Assert.Equal(2, result.HeuristicLabelsApplied);
+        Assert.Equal(0, result.SkippedRecords);
+
+        var malicious = Assert.Single(result.Documents, document => document.Path == "/graphql");
+        Assert.True(malicious.Label);
+        Assert.Contains("known_bad_user_agent:python-requests", malicious.Signals);
+
+        var benign = Assert.Single(result.Documents, document => document.Path == "/pricing");
+        Assert.False(benign.Label);
+
+        var feedbackDriven = Assert.Single(result.Documents, document => document.Path == "/docs/export");
+        Assert.True(feedbackDriven.Label);
+    }
+
+    [Fact]
+    public void Build_RequestJsonlDataset_ThenTrainModel_EndToEnd()
+    {
+        using var harness = DatasetHarness.Create();
+        var requestsPath = harness.WriteRequestJsonl(
+            new LocalModelDatasetSourceRecord(
+                DateTimeOffset.Parse("2026-03-15T12:00:00Z"),
+                "198.51.100.10",
+                "GET",
+                "/graphql",
+                "?page=1&take=5000",
+                "python-requests/2.31",
+                "*/*",
+                string.Empty,
+                4),
+            new LocalModelDatasetSourceRecord(
+                DateTimeOffset.Parse("2026-03-15T12:00:05Z"),
+                "198.51.100.11",
+                "POST",
+                "/wp-login",
+                "?attempt=1",
+                "Scrapy/2.0",
+                "*/*",
+                string.Empty,
+                5),
+            new LocalModelDatasetSourceRecord(
+                DateTimeOffset.Parse("2026-03-15T12:01:00Z"),
+                "198.51.100.20",
+                "GET",
+                "/pricing",
+                string.Empty,
+                "Mozilla/5.0",
+                "text/html",
+                "en-US",
+                1),
+            new LocalModelDatasetSourceRecord(
+                DateTimeOffset.Parse("2026-03-15T12:01:15Z"),
+                "198.51.100.21",
+                "GET",
+                "/docs",
+                "?page=2",
+                "Mozilla/5.0",
+                "text/html",
+                "en-US",
+                1));
+
+        var outputPath = Path.Combine(harness.RootPath, "training.jsonl");
+        var builder = new LocalModelDatasetBuilder();
+        var sourceRecords = builder.LoadRequestRecordsFromJsonl(requestsPath);
+        var buildResult = builder.Build(sourceRecords);
+        builder.WriteDocumentsAsJsonl(buildResult.Documents, outputPath);
+
+        var trainingDocuments = File.ReadAllLines(outputPath)
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .Select(line => JsonSerializer.Deserialize<LocalModelTrainingDocument>(line))
+            .Cast<LocalModelTrainingDocument>()
+            .ToArray();
+        var trainer = new LocalTrainedModelTrainer(seed: 1);
+        var artifacts = trainer.TrainAndSave(
+            trainingDocuments,
+            Path.Combine(harness.RootPath, "local-bot-detector.zip"),
+            "2026.03.15",
+            0.70f);
+
+        Assert.Equal(4, trainingDocuments.Length);
+        Assert.True(File.Exists(artifacts.ModelPath));
+        Assert.True(File.Exists(artifacts.MetadataPath));
+        Assert.Equal(4, artifacts.Metadata.TrainingExampleCount);
+    }
+
+    private sealed class DatasetHarness : IDisposable
+    {
+        private DatasetHarness(string rootPath)
+        {
+            RootPath = rootPath;
+        }
+
+        public string RootPath { get; }
+
+        public static DatasetHarness Create()
+        {
+            var rootPath = Path.Combine(Path.GetTempPath(), "ai-scraping-defense-dataset-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(rootPath);
+            return new DatasetHarness(rootPath);
+        }
+
+        public string WriteW3cLog(string content)
+        {
+            var path = Path.Combine(RootPath, "u_ex260315.log");
+            File.WriteAllText(path, content.ReplaceLineEndings(Environment.NewLine));
+            return path;
+        }
+
+        public string WriteFeedbackJsonl(params LocalModelFeedbackRecord[] records)
+        {
+            var path = Path.Combine(RootPath, "feedback.jsonl");
+            File.WriteAllLines(path, records.Select(record => JsonSerializer.Serialize(record)));
+            return path;
+        }
+
+        public string WriteRequestJsonl(params LocalModelDatasetSourceRecord[] records)
+        {
+            var path = Path.Combine(RootPath, "request-export.jsonl");
+            File.WriteAllLines(path, records.Select(record => JsonSerializer.Serialize(record)));
+            return path;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/docs/local_model_training.md
+++ b/docs/local_model_training.md
@@ -16,6 +16,51 @@ Enable the local model adapter under `DefenseEngine:Escalation:LocalTrainedModel
 
 If `MetadataPath` is left empty, the runtime looks for `<ModelPath>.metadata.json`.
 
+## Building a Dataset
+
+The bundled CLI can derive labeled training examples from either:
+
+- W3C request logs with a `#Fields:` header
+- request-export JSON Lines (`.jsonl`) files using the schema below
+
+Optional operator feedback can be folded into the dataset as JSON Lines overrides. Each feedback line can match on IP alone or more specifically on IP plus path, user agent, and observed timestamp.
+
+Request-export example:
+
+```json
+{"timestamp_utc":"2026-03-15T12:00:00Z","ip_address":"198.51.100.30","method":"GET","path":"/graphql","query_string":"?page=1&take=5000","user_agent":"python-requests/2.31","accept":"*/*","accept_language":"","frequency":4}
+```
+
+Feedback example:
+
+```json
+{"label":true,"ip_address":"198.51.100.30","path":"/graphql","user_agent":"python-requests/2.31","observed_at_utc":"2026-03-15T12:00:00Z","note":"confirmed scraper"}
+```
+
+Build a dataset from request-export JSONL:
+
+```bash
+dotnet run --project AiScrapingDefense.ModelTrainer -- \
+  build-dataset \
+  --input-format request-jsonl \
+  --input data/request-export.jsonl \
+  --feedback data/operator-feedback.jsonl \
+  --output data/local-model-training.jsonl
+```
+
+Build a dataset from a W3C log:
+
+```bash
+dotnet run --project AiScrapingDefense.ModelTrainer -- \
+  build-dataset \
+  --input-format w3c \
+  --input data/u_ex260315.log \
+  --feedback data/operator-feedback.jsonl \
+  --output data/local-model-training.jsonl
+```
+
+The builder applies operator feedback first and then fills the remaining dataset with high-confidence heuristic labels.
+
 ## Training Input Format
 
 The trainer consumes JSON Lines (`.jsonl`). Each line is one labeled example:
@@ -40,6 +85,7 @@ Run the bundled trainer:
 
 ```bash
 dotnet run --project AiScrapingDefense.ModelTrainer -- \
+  train \
   --input data/local-model-training.jsonl \
   --output models/local-bot-detector.zip \
   --version 2026.03.15 \
@@ -71,6 +117,5 @@ This commercial-v1 path provides:
 
 - .NET-native local model inference
 - a .NET-native trainer CLI
+- a .NET-native dataset builder for W3C logs or request-export JSONL plus operator feedback
 - explicit model metadata and version checking
-
-The older project’s more opinionated log/feedback dataset-building path is still tracked separately in issue `#64`.

--- a/docs/parity_matrix.md
+++ b/docs/parity_matrix.md
@@ -19,10 +19,10 @@ Status legend:
 | Peer sync | Implemented | Timed imports, authenticated exports, and `ObserveOnly`/`BlockList` trust modes are implemented. | Add richer trust scoring and coordination. |
 | PostgreSQL-backed Markov tarpit | Implemented | The tarpit can load a Markov corpus from PostgreSQL and falls back safely when no snapshot exists. | Expand deeper decoy modes. See issue `#55`. |
 | Advanced tarpit decoys | Implemented | The tarpit now serves rotating ZIP decoy archives with deterministic fake JavaScript payloads in addition to deterministic HTML modes. | Expand artifact families only when they add measurable crawler cost. |
-| Reputation providers and classifier hooks | Implemented | Configured ranges, HTTP reputation, .NET-native local trained models, and OpenAI-compatible model adapters exist. | Add richer dataset-building and retraining ergonomics. See issue `#64`. |
+| Reputation providers and classifier hooks | Implemented | Configured ranges, HTTP reputation, .NET-native local trained models, OpenAI-compatible model adapters, and a log/export dataset-builder path for local retraining exist. | Keep improving feature quality and retraining workflows against real operator feedback. |
 | Alerting and operator/community reporting | Implemented | Confirmed malicious intake events can dispatch generic webhook alerts, Slack Incoming Webhook alerts, SMTP alerts, and configurable community reports with durable delivery visibility. | Add provider-specific enrichments only when operators show real demand. |
 | Structured telemetry export | Implemented | Prometheus metrics, OTLP trace export, packaged scrape/alert config, and a bundled Grafana dashboard are included. | Tune thresholds and dashboard panels against production traffic after deployment. |
 | Independent multi-service deployment | Deferred | v1 intentionally ships as a single deployable ASP.NET Core runtime. | Split into independently deployed roles only when operations justify it. |
 | SQL Server support | Deferred | Redis + SQLite + PostgreSQL are the supported data stores for v1. | Revisit only if customer demand justifies the extra provider surface. |
 
-Commercial v1 is feature-complete enough to package and validate, but fuller upstream parity still depends on closing issue `#64`.
+Commercial v1 now covers the defined commercial parity scope. Additional work should be driven by measured operator demand rather than inherited backlog assumptions.


### PR DESCRIPTION
## Summary
- add a dataset-builder path for local model retraining from W3C logs or request-export JSONL
- support operator feedback overrides and emit training JSONL for the existing trainer
- document the builder workflow and cover dataset-build plus train flow with tests

Closes #64

## Validation
- dotnet build anti-scraping-defense-iis.sln
- dotnet test anti-scraping-defense-iis.sln