### PR TITLE
Fix .NET prerelease release semantics

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -30,13 +30,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          prerelease=false
           if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
             version="${GITHUB_REF_NAME#v}"
+            if [[ "${version}" == *-* ]]; then
+              prerelease=true
+            fi
           else
             version="0.0.0-ci.${GITHUB_RUN_NUMBER}"
           fi
 
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
 
       - name: Build macOS Packages
         shell: bash
@@ -95,11 +100,23 @@ jobs:
             artifacts/macos-installer/output/*.sha256
           if-no-files-found: error
 
-      - name: Publish macOS Installers To GitHub Release
-        if: github.ref_type == 'tag'
+      - name: Publish Stable macOS Installers To GitHub Release
+        if: github.ref_type == 'tag' && steps.version.outputs.prerelease != 'true'
         uses: softprops/action-gh-release@v2
         with:
           files: |
             artifacts/macos-installer/output/*.pkg
             artifacts/macos-installer/output/*.sha256
           generate_release_notes: true
+          make_latest: true
+
+      - name: Publish Prerelease macOS Installers To GitHub Release
+        if: github.ref_type == 'tag' && steps.version.outputs.prerelease == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/macos-installer/output/*.pkg
+            artifacts/macos-installer/output/*.sha256
+          generate_release_notes: true
+          prerelease: true
+          make_latest: false

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -39,14 +39,19 @@ jobs:
         id: version
         shell: pwsh
         run: |
+          $prerelease = 'false'
           if ($env:GITHUB_REF_TYPE -eq 'tag' -and $env:GITHUB_REF_NAME.StartsWith('v')) {
             $version = $env:GITHUB_REF_NAME.Substring(1)
+            if ($version.Contains('-')) {
+              $prerelease = 'true'
+            }
           }
           else {
             $version = "0.0.0-ci.$env:GITHUB_RUN_NUMBER"
           }
 
           "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding ascii
+          "prerelease=$prerelease" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding ascii
 
       - name: Build Windows Installer
         shell: pwsh
@@ -120,11 +125,23 @@ jobs:
             artifacts/installer/output/*.sha256
           if-no-files-found: error
 
-      - name: Publish Installer To GitHub Release
-        if: github.ref_type == 'tag'
+      - name: Publish Stable Installer To GitHub Release
+        if: github.ref_type == 'tag' && steps.version.outputs.prerelease != 'true'
         uses: softprops/action-gh-release@v2
         with:
           files: |
             artifacts/installer/output/*.exe
             artifacts/installer/output/*.sha256
           generate_release_notes: true
+          make_latest: true
+
+      - name: Publish Prerelease Installer To GitHub Release
+        if: github.ref_type == 'tag' && steps.version.outputs.prerelease == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/installer/output/*.exe
+            artifacts/installer/output/*.sha256
+          generate_release_notes: true
+          prerelease: true
+          make_latest: false

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ In `Production`, startup now fails fast if Redis still points at a loopback endp
 
 ## Status
 
-The project now has an explicit commercial-v1 target, but release readiness still depends on closing the remaining items in [docs/release_blockers.md](docs/release_blockers.md) and the post-v1 parity queue in [docs/dotnet_parity_roadmap.md](docs/dotnet_parity_roadmap.md).
+Commercial v1 is shipped and the blocker queue in [docs/release_blockers.md](docs/release_blockers.md) is closed. The remaining roadmap in [docs/dotnet_parity_roadmap.md](docs/dotnet_parity_roadmap.md) is post-v1 work rather than a release gate.
 
 ## Packaging
 

--- a/docs/release_artifacts.md
+++ b/docs/release_artifacts.md
@@ -38,6 +38,11 @@ For a prerelease tag such as `v1.4.2-rc.1`, the workflow publishes only:
 - `ghcr.io/<owner>/ai-scraping-defense-iis:v1.4.2-rc.1`
 - `ghcr.io/<owner>/ai-scraping-defense-iis:1.4.2-rc.1`
 
+GitHub Release metadata follows the same rule:
+
+- stable tags publish a normal release and may update the `latest` release marker
+- prerelease tags publish a GitHub prerelease and must not become `latest`
+
 This keeps prereleases from mutating `latest` or the rolling minor tag.
 
 ## Release Metadata


### PR DESCRIPTION
## Summary\n- mark RC tags as GitHub prereleases in the Windows and macOS installer workflows\n- keep stable tags eligible for latest while RC tags stay off the latest release marker\n- align README and release artifact docs with the shipped v1 status and tag policy\n\n## Validation\n- dotnet build anti-scraping-defense-iis.sln\n- dotnet test anti-scraping-defense-iis.sln\n- docker build -t ai-scraping-defense-dotnet:release-check .\n- docker compose -f compose.yaml -f compose.observability.yaml config\n- sha256sum -c on the downloaded v1.0.1-rc.4 Windows installer asset\n- gh release edit v1.0.1-rc.4 --prerelease