### PR TITLE
Fix unused imports and silent SMTP cleanup failure in IIS AI webhook

### DIFF
--- a/ai_service/ai_webhook.py
+++ b/ai_service/ai_webhook.py
@@ -2,9 +2,9 @@
 # Modified for Windows/IIS Compatibility
 # Receives webhook events, logs, blocklists via Redis, reports, and sends alerts.
 
-from fastapi import FastAPI, Request, HTTPException
-from pydantic import BaseModel, Field, ValidationError
-from typing import Dict, Any, Literal, Optional
+from fastapi import FastAPI, Request
+from pydantic import BaseModel, Field
+from typing import Any, Dict, Optional
 import datetime
 import pprint
 import os
@@ -379,8 +379,10 @@ Check logs in '{LOGS_DIR}' for more context.
         except Exception as e: log_error(f"Unexpected error sending email alert for IP {ip}", e); increment_metric("alerts_errors_smtp")
         finally:
             if smtp_conn:
-                try: smtp_conn.quit()
-                except Exception: pass # Ignore errors during quit
+                try:
+                    smtp_conn.quit()
+                except Exception as exc:
+                    logger.debug("SMTP quit failed during cleanup: %s", exc)
 
     try:
         # Run synchronous SMTP logic in a separate thread


### PR DESCRIPTION
Fixes #80.

## Summary
- remove unused imports from 
- replace the silent  during SMTP cleanup with a debug log
- keep the change isolated to the webhook service to avoid overlapping with other IIS fixes

## Validation
- 
- Run started:2026-03-18 21:45:11.758244+00:00

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 393
	Total lines skipped (#nosec): 0
	Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):