### PR TITLE
Define optional split-runtime topology baseline

### DIFF
--- a/docs/commercial_scope.md
+++ b/docs/commercial_scope.md
@@ -28,6 +28,8 @@ Explicitly deferred from v1:
 - separate runtime deployments for `EdgeGateway`, `EscalationEngine`, and `TarpitApi`
 - SQL Server support
 
+Deferred split-runtime work is tracked in [runtime_topologies.md](runtime_topologies.md).
+
 ## Supported Deployment Model
 
 Commercial v1 supports these deployment modes:
@@ -41,6 +43,7 @@ Commercial v1 does not yet claim:
 - multi-node relational consistency
 - full-fidelity multi-node coordination beyond the shipped peer-sync exchange model
 - complete operator UI parity with the upstream project
+- independent runtime deployment as the default topology (single deployable remains the supported baseline)
 
 ## Database Strategy
 

--- a/docs/dotnet_parity_roadmap.md
+++ b/docs/dotnet_parity_roadmap.md
@@ -19,7 +19,7 @@ Commercial v1 is defined in [commercial_scope.md](commercial_scope.md). This roa
 
 ## Post-v1 Parity Queue
 
-1. Promote the project-level split into optional independent runtime deployments when production constraints justify it.
+1. Promote the project-level split into optional independent runtime deployments when production constraints justify it (see [runtime_topologies.md](runtime_topologies.md)).
 2. Add richer escalation scoring, reputation providers, and optional LLM adapters.
 3. Expand the tarpit content strategy with streaming/archive rotation and deeper content sources.
 4. Add richer community-blocklist trust policy, reporting, and peer coordination.

--- a/docs/iis_deployment_guide.md
+++ b/docs/iis_deployment_guide.md
@@ -8,6 +8,8 @@ This guide covers deploying the current .NET stack to Windows Server IIS with AS
 - Use Redis for operational state.
 - Optionally enable PostgreSQL-backed Markov tarpit content.
 - Enable management/intake/peer endpoints only when API keys are configured.
+- Keep single deployable mode as the default production topology.
+- Support optional split-runtime topology when operational constraints justify it.
 
 ## Prerequisites
 
@@ -53,6 +55,16 @@ Optional but commonly used:
 - `DefenseEngine:Networking:ClientIpResolutionMode=TrustedProxy`
 - `DefenseEngine:Networking:TrustedProxies` (when using proxy/CDN headers)
 
+Optional split-runtime settings (post-v1 topology):
+
+- `DefenseEngine:Topology:Mode=Split`
+- `DefenseEngine:Services:EscalationEngine:BaseUrl`
+- `DefenseEngine:Services:EscalationEngine:ApiKey`
+- `DefenseEngine:Services:TarpitApi:BaseUrl`
+- `DefenseEngine:Services:TarpitApi:ApiKey`
+
+If split-runtime settings are omitted, deployment remains in single deployable mode.
+
 ## 4) File-System Permissions
 
 Grant the IIS app pool identity least-privilege access to:
@@ -81,6 +93,15 @@ After site start/recycle:
 - Set explicit trusted proxies if forwarded headers are enabled.
 - Monitor `/health`, `/defense/metrics`, and Windows/IIS logs.
 
+## 7) Split Runtime Validation (Optional)
+
+When `DefenseEngine:Topology:Mode=Split` is enabled:
+
+1. Verify `EscalationEngine` and `TarpitApi` health endpoints are reachable from `EdgeGateway`.
+2. Verify service-to-service API keys are required and validated.
+3. Run an end-to-end suspicious request to confirm remote escalation and tarpit behavior.
+4. Intentionally stop one downstream runtime and verify graceful degradation with observable error telemetry.
+
 ## Troubleshooting
 
 - `500` at startup: verify Hosting Bundle/runtime mismatch and appsettings syntax.
@@ -88,4 +109,4 @@ After site start/recycle:
 - Redis health failures: verify connection string, TLS requirements, and firewall.
 - Missing management/intake/peer routes: confirm related API keys are configured.
 
-For endpoint contracts, see `api_references.md`. For release-time operational checks, see `operator_runbook.md` and `release_checklist.md`.
+For endpoint contracts, see `api_references.md`. For topology contract details, see `runtime_topologies.md`. For release-time operational checks, see `operator_runbook.md` and `release_checklist.md`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ This documentation index is for the current .NET implementation in this reposito
 - [Commercial v1 Scope](commercial_scope.md)
 - [Parity Matrix](parity_matrix.md)
 - [Post-v1 Parity Roadmap](dotnet_parity_roadmap.md)
+- [Runtime Topologies](runtime_topologies.md)
 - [Release Blockers](release_blockers.md)
 
 ## Operations and release

--- a/docs/runtime_topologies.md
+++ b/docs/runtime_topologies.md
@@ -1,0 +1,88 @@
+# Runtime Topologies
+
+This document defines supported runtime topology modes for the .NET stack and establishes the contract for optional split deployments.
+
+## Goals
+
+- preserve the current single deployable mode as the default production path
+- define clear runtime boundaries for `EdgeGateway`, `EscalationEngine`, and `TarpitApi`
+- provide configuration contracts that allow operators to split runtimes incrementally
+- define validation checks for both single-node and split deployments
+
+## Supported Modes
+
+### Mode A: Single Deployable (default)
+
+- One ASP.NET Core deployment hosts the full defense pipeline.
+- Internal service calls remain in-process.
+- Redis remains required for hot operational state.
+- SQLite remains the default durable event store.
+
+This mode is the commercial v1 baseline and remains supported after split-runtime enablement.
+
+### Mode B: Optional Split Runtime (post-v1)
+
+- `EdgeGateway` runs as the ingress-facing process.
+- `EscalationEngine` runs as a separate process with provider/model dependencies.
+- `TarpitApi` runs as a separate process focused on tarpit response generation.
+- Contracts between runtimes are authenticated service-to-service HTTP calls.
+
+Split-runtime mode is optional and should be enabled only when production topology, isolation, or scaling requirements justify it.
+
+## Runtime Boundaries
+
+### EdgeGateway boundary
+
+- accepts inbound traffic and applies request-inspection policy
+- performs blocklist checks and tarpit/allow routing decisions
+- forwards analysis payloads to `EscalationEngine` when split mode is enabled
+- calls `TarpitApi` for tarpit response generation when split mode is enabled
+
+### EscalationEngine boundary
+
+- accepts authenticated analysis intake from `EdgeGateway`
+- applies scoring, enrichment, and optional model/provider adapters
+- writes audit and webhook inbox records through shared persistence policy
+- emits operator-visible events/metrics
+
+### TarpitApi boundary
+
+- accepts authenticated tarpit render requests from `EdgeGateway`
+- generates deterministic or Markov-backed tarpit responses
+- enforces rendering/time budgets to avoid control-plane contention
+
+## Configuration Contract
+
+When split mode is enabled, configure explicit service endpoints and service keys:
+
+- `DefenseEngine__Topology__Mode=Split`
+- `DefenseEngine__Services__EscalationEngine__BaseUrl`
+- `DefenseEngine__Services__EscalationEngine__ApiKey`
+- `DefenseEngine__Services__TarpitApi__BaseUrl`
+- `DefenseEngine__Services__TarpitApi__ApiKey`
+
+When these settings are missing, the platform must continue operating in single deployable mode (`DefenseEngine__Topology__Mode=Single` or default).
+
+## Validation Checklist
+
+### Single Deployable validation
+
+1. `GET /health` reports healthy.
+2. `GET /` returns endpoint advertisement payload.
+3. `POST /analyze` works with configured intake key.
+4. Tarpit route responds and logs expected metadata.
+
+### Split Runtime validation
+
+1. `EdgeGateway` health endpoint is healthy.
+2. `EscalationEngine` health endpoint is healthy and rejects missing/invalid service key.
+3. `TarpitApi` health endpoint is healthy and rejects missing/invalid service key.
+4. End-to-end suspicious request flow reaches escalation and tarpit via remote calls.
+5. Failure of one downstream runtime degrades safely (deny-by-policy or bounded fallback) and is visible in metrics/logs.
+
+## Operator Guidance
+
+- Start with Mode A unless a clear isolation/scaling requirement exists.
+- Move to Mode B one boundary at a time (`EscalationEngine` first, then `TarpitApi`).
+- Keep the same API-key hygiene and trusted-proxy controls used in single-node mode.
+- Run release-checklist validation after each topology transition.


### PR DESCRIPTION
## Summary
- add a dedicated runtime topology contract for single-deployable and optional split-runtime modes
- document runtime boundaries and service-to-service configuration keys for split mode
- update commercial scope, parity roadmap, deployment guide, and docs index to reference the topology baseline

## Validation
- docs-only change; reviewed rendered markdown and link targets
- pre-commit unavailable in this repo ( is not present)

Closes #71