### PR TITLE
Define escalation scoring/provider baseline

### DIFF
--- a/docs/dotnet_parity_roadmap.md
+++ b/docs/dotnet_parity_roadmap.md
@@ -20,7 +20,7 @@ Commercial v1 is defined in [commercial_scope.md](commercial_scope.md). This roa
 ## Post-v1 Parity Queue
 
 1. Promote the project-level split into optional independent runtime deployments when production constraints justify it (see [runtime_topologies.md](runtime_topologies.md)).
-2. Add richer escalation scoring, reputation providers, and optional LLM adapters.
+2. Add richer escalation scoring, reputation providers, and optional LLM adapters (see [escalation_scoring_provider_baseline.md](escalation_scoring_provider_baseline.md)).
 3. Expand the tarpit content strategy with streaming/archive rotation and deeper content sources.
 4. Add richer community-blocklist trust policy, reporting, and peer coordination.
 5. Add structured metrics, traces, and richer operator telemetry export.

--- a/docs/escalation_scoring_provider_baseline.md
+++ b/docs/escalation_scoring_provider_baseline.md
@@ -1,0 +1,43 @@
+# Escalation Scoring and Provider Baseline
+
+This document defines the post-v1 baseline for expanding escalation scoring, abuse-intelligence provider coverage, and optional model adapters.
+
+## Objectives
+
+- improve score composition with clearer operator-visible rationale
+- support additional reputation and abuse-intelligence providers
+- keep model adapters optional so default deployments stay lightweight
+- preserve deterministic fallback behavior when optional dependencies are disabled
+
+## Scope
+
+### Provider expansion
+
+- add normalized provider adapters behind existing service abstractions
+- define per-provider timeout, retry, and disable controls
+- record provider contribution metadata for operator visibility
+
+### Score composition
+
+- define weighted score components with stable ranges
+- expose component-level rationale in operator-facing event data
+- support policy thresholds for action levels (observe, challenge, block, tarpit)
+
+### Optional model adapters
+
+- support OpenAI-compatible and local model adapters as optional integrations
+- require explicit configuration to enable model-assisted enrichment
+- guarantee non-model fallback remains fully supported
+
+## Validation Requirements
+
+- unit tests for each scoring component and provider adapter boundary
+- integration tests for mixed provider availability and timeout paths
+- explicit tests for model-disabled and model-enabled configurations
+- operator API assertions for score rationale visibility
+
+## Operational Guidance
+
+- default deployments should run without external model dependencies
+- enable provider/model integrations incrementally with rollback controls
+- monitor provider latency and error rates before increasing scoring weight

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ This documentation index is for the current .NET implementation in this reposito
 - [Commercial v1 Scope](commercial_scope.md)
 - [Parity Matrix](parity_matrix.md)
 - [Post-v1 Parity Roadmap](dotnet_parity_roadmap.md)
+- [Escalation Scoring and Provider Baseline](escalation_scoring_provider_baseline.md)
 - [Runtime Topologies](runtime_topologies.md)
 - [Release Blockers](release_blockers.md)
 


### PR DESCRIPTION
## Summary
- add a baseline document for post-v1 escalation scoring expansion
- define provider-adapter, score-composition, and optional model-adapter expectations
- link the baseline from the parity roadmap and docs index

## Validation
- docs-only change
-  is not present in this repository

Closes #72