### PR TITLE
Define tarpit content strategy baseline

### DIFF
--- a/docs/dotnet_parity_roadmap.md
+++ b/docs/dotnet_parity_roadmap.md
@@ -21,6 +21,6 @@ Commercial v1 is defined in [commercial_scope.md](commercial_scope.md). This roa
 
 1. Promote the project-level split into optional independent runtime deployments when production constraints justify it (see [runtime_topologies.md](runtime_topologies.md)).
 2. Add richer escalation scoring, reputation providers, and optional LLM adapters (see [escalation_scoring_provider_baseline.md](escalation_scoring_provider_baseline.md)).
-3. Expand the tarpit content strategy with streaming/archive rotation and deeper content sources.
+3. Expand the tarpit content strategy with streaming/archive rotation and deeper content sources (see [tarpit_content_strategy_baseline.md](tarpit_content_strategy_baseline.md)).
 4. Add richer community-blocklist trust policy, reporting, and peer coordination.
 5. Add structured metrics, traces, and richer operator telemetry export.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ This documentation index is for the current .NET implementation in this reposito
 - [Parity Matrix](parity_matrix.md)
 - [Post-v1 Parity Roadmap](dotnet_parity_roadmap.md)
 - [Escalation Scoring and Provider Baseline](escalation_scoring_provider_baseline.md)
+- [Tarpit Content Strategy Baseline](tarpit_content_strategy_baseline.md)
 - [Runtime Topologies](runtime_topologies.md)
 - [Release Blockers](release_blockers.md)
 

--- a/docs/tarpit_content_strategy_baseline.md
+++ b/docs/tarpit_content_strategy_baseline.md
@@ -1,0 +1,43 @@
+# Tarpit Content Strategy Baseline
+
+This document defines the post-v1 baseline for expanding tarpit content strategy beyond current deterministic variants and PostgreSQL-backed Markov content.
+
+## Objectives
+
+- increase crawl-wasting depth while preserving deterministic operator controls
+- add richer content-generation sources and render variants
+- improve streaming and archive-rotation behavior for large tarpit corpora
+- document storage/runtime implications and safe operational defaults
+
+## Scope
+
+### Content sources and variants
+
+- support layered content sources (deterministic templates, Markov, curated archives)
+- add configurable render modes by route or policy profile
+- retain explicit controls for allowed content classes and response size limits
+
+### Streaming and archive rotation
+
+- define bounded streaming response policies
+- define archive retention and rotation windows with storage caps
+- provide fallback behavior when archive sources are unavailable
+
+### Operator controls
+
+- expose selected tarpit mode and source metadata in operator events
+- support runtime toggles for conservative and aggressive tarpit profiles
+- preserve deterministic mode for predictable investigations and tests
+
+## Validation Requirements
+
+- tests for each tarpit mode and source selection path
+- tests for archive rotation and missing-source fallback behavior
+- tests for bounded response size/time guarantees
+- deployment checks for storage and PostgreSQL impact
+
+## Operational Guidance
+
+- start with deterministic mode and add richer sources incrementally
+- enforce explicit CPU, memory, and response-time budgets
+- monitor operator metrics for generation latency and fallback rates


### PR DESCRIPTION
## Summary
- add a post-v1 baseline for deeper tarpit content strategy and mode controls
- define streaming/archive-rotation expectations and fallback behavior
- link the baseline from parity roadmap and docs index

## Validation
- docs-only change
- pre-commit config file is not present in this repository

Closes #73