### PR TITLE
Define community blocklist/peer baseline

### DIFF
--- a/docs/community_blocklist_peer_coordination_baseline.md
+++ b/docs/community_blocklist_peer_coordination_baseline.md
@@ -1,0 +1,43 @@
+# Community Blocklist and Peer Coordination Baseline
+
+This document defines the post-v1 baseline for strengthening community blocklist trust policy and peer coordination behavior.
+
+## Objectives
+
+- improve source trust policy for imported blocklist and peer signals
+- strengthen deduplication, attribution, and reporting controls
+- improve peer trust scoring and coordination behavior in multi-node exchanges
+- increase operator visibility into accept/reject decisions
+
+## Scope
+
+### Source trust policy
+
+- define trust tiers for feed and peer sources
+- support explicit allowlist/denylist and weighted trust profiles
+- require signed/authenticated source metadata where available
+
+### Deduplication and reporting
+
+- define canonical identity keys and merge policy for duplicate signals
+- preserve source attribution and confidence when consolidating entries
+- provide operator-facing reports for accepted, downgraded, and rejected signals
+
+### Peer coordination
+
+- score peer sources on reliability, freshness, and historical quality
+- define bounded propagation policies to prevent feedback loops
+- define safe defaults when peer trust score is low or stale
+
+## Validation Requirements
+
+- tests for trust-tier policy and source classification paths
+- tests for deduplication merge and conflict resolution behavior
+- tests for peer-score changes and propagation guardrails
+- operator API tests for decision transparency fields
+
+## Operational Guidance
+
+- start with conservative trust profiles and expand intentionally
+- review rejection and downgrade trends before changing trust thresholds
+- keep peer coordination behavior observable and reversible

--- a/docs/dotnet_parity_roadmap.md
+++ b/docs/dotnet_parity_roadmap.md
@@ -22,5 +22,5 @@ Commercial v1 is defined in [commercial_scope.md](commercial_scope.md). This roa
 1. Promote the project-level split into optional independent runtime deployments when production constraints justify it (see [runtime_topologies.md](runtime_topologies.md)).
 2. Add richer escalation scoring, reputation providers, and optional LLM adapters (see [escalation_scoring_provider_baseline.md](escalation_scoring_provider_baseline.md)).
 3. Expand the tarpit content strategy with streaming/archive rotation and deeper content sources (see [tarpit_content_strategy_baseline.md](tarpit_content_strategy_baseline.md)).
-4. Add richer community-blocklist trust policy, reporting, and peer coordination.
+4. Add richer community-blocklist trust policy, reporting, and peer coordination (see [community_blocklist_peer_coordination_baseline.md](community_blocklist_peer_coordination_baseline.md)).
 5. Add structured metrics, traces, and richer operator telemetry export.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ This documentation index is for the current .NET implementation in this reposito
 - [Post-v1 Parity Roadmap](dotnet_parity_roadmap.md)
 - [Escalation Scoring and Provider Baseline](escalation_scoring_provider_baseline.md)
 - [Tarpit Content Strategy Baseline](tarpit_content_strategy_baseline.md)
+- [Community Blocklist and Peer Coordination Baseline](community_blocklist_peer_coordination_baseline.md)
 - [Runtime Topologies](runtime_topologies.md)
 - [Release Blockers](release_blockers.md)
 


### PR DESCRIPTION
## Summary
- add a post-v1 baseline for community blocklist trust policy and peer coordination
- define trust tiers, deduplication/reporting policy, and peer propagation guardrails
- link the baseline from parity roadmap and docs index

## Validation
- docs-only change
- pre-commit config file is not present in this repository

Closes #74