### PR TITLE
Define observability telemetry baseline

### DIFF
--- a/docs/dotnet_parity_roadmap.md
+++ b/docs/dotnet_parity_roadmap.md
@@ -23,4 +23,4 @@ Commercial v1 is defined in [commercial_scope.md](commercial_scope.md). This roa
 2. Add richer escalation scoring, reputation providers, and optional LLM adapters (see [escalation_scoring_provider_baseline.md](escalation_scoring_provider_baseline.md)).
 3. Expand the tarpit content strategy with streaming/archive rotation and deeper content sources (see [tarpit_content_strategy_baseline.md](tarpit_content_strategy_baseline.md)).
 4. Add richer community-blocklist trust policy, reporting, and peer coordination (see [community_blocklist_peer_coordination_baseline.md](community_blocklist_peer_coordination_baseline.md)).
-5. Add structured metrics, traces, and richer operator telemetry export.
+5. Add structured metrics, traces, and richer operator telemetry export (see [observability_telemetry_export_baseline.md](observability_telemetry_export_baseline.md)).

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ This documentation index is for the current .NET implementation in this reposito
 - [Escalation Scoring and Provider Baseline](escalation_scoring_provider_baseline.md)
 - [Tarpit Content Strategy Baseline](tarpit_content_strategy_baseline.md)
 - [Community Blocklist and Peer Coordination Baseline](community_blocklist_peer_coordination_baseline.md)
+- [Observability and Telemetry Export Baseline](observability_telemetry_export_baseline.md)
 - [Runtime Topologies](runtime_topologies.md)
 - [Release Blockers](release_blockers.md)
 

--- a/docs/observability_telemetry_export_baseline.md
+++ b/docs/observability_telemetry_export_baseline.md
@@ -1,0 +1,43 @@
+# Observability and Telemetry Export Baseline
+
+This document defines the post-v1 baseline for structured metrics, trace-friendly instrumentation, and richer operator telemetry export.
+
+## Objectives
+
+- publish structured application and defense metrics
+- add trace correlation across key request and defense workflows
+- improve operator-visible telemetry for diagnosis and auditability
+- validate telemetry behavior in packaged deployments
+
+## Scope
+
+### Structured metrics
+
+- define stable metric names, labels, and cardinality limits
+- publish request path, defense action, and error-class metrics
+- preserve low-overhead defaults for production safety
+
+### Trace instrumentation
+
+- instrument ingress, escalation, tarpit, management, and sync workflows
+- propagate correlation identifiers across internal boundaries
+- support standards-based export to tracing backends
+
+### Operator telemetry
+
+- include correlation IDs in operator event views
+- expose richer timeline fields for investigations
+- preserve API-first telemetry access patterns for dashboard consumers
+
+## Validation Requirements
+
+- unit/integration tests for metrics emission and label stability
+- tests for trace propagation across core workflow boundaries
+- packaged deployment checks for telemetry endpoint behavior
+- tests ensuring telemetry remains functional when optional backends are disabled
+
+## Operational Guidance
+
+- set explicit metric label and sampling guardrails before broad enablement
+- stage trace export rollouts to prevent ingestion overload
+- treat telemetry schema changes as versioned contract updates


### PR DESCRIPTION
## Summary
- add a post-v1 baseline for structured metrics, traces, and richer telemetry export
- define telemetry scope, validation expectations, and operational guardrails
- link the baseline from parity roadmap and docs index

## Validation
- docs-only change
- pre-commit config file is not present in this repository

Closes #75