### PR TITLE
Define multi-node durability baseline

### DIFF
--- a/docs/commercial_scope.md
+++ b/docs/commercial_scope.md
@@ -45,6 +45,8 @@ Commercial v1 does not yet claim:
 - complete operator UI parity with the upstream project
 - independent runtime deployment as the default topology (single deployable remains the supported baseline)
 
+Post-v1 multi-node durability and coordination work is tracked in [multi_node_durability_coordination_baseline.md](multi_node_durability_coordination_baseline.md).
+
 ## Database Strategy
 
 The storage model for commercial v1 is intentionally narrow:

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ This documentation index is for the current .NET implementation in this reposito
 - [Tarpit Content Strategy Baseline](tarpit_content_strategy_baseline.md)
 - [Community Blocklist and Peer Coordination Baseline](community_blocklist_peer_coordination_baseline.md)
 - [Observability and Telemetry Export Baseline](observability_telemetry_export_baseline.md)
+- [Multi-Node Durability and Coordination Baseline](multi_node_durability_coordination_baseline.md)
 - [Runtime Topologies](runtime_topologies.md)
 - [Release Blockers](release_blockers.md)
 

--- a/docs/multi_node_durability_coordination_baseline.md
+++ b/docs/multi_node_durability_coordination_baseline.md
@@ -1,0 +1,43 @@
+# Multi-Node Durability and Coordination Baseline
+
+This document defines the post-v1 baseline for supported multi-node durability and coordination behavior.
+
+## Objectives
+
+- define supported multi-node topologies and trust boundaries
+- close durability and consistency gaps for shared state and audit data
+- document coordination guarantees, conflict behavior, and failure modes
+- provide validation coverage for supported multi-node operation
+
+## Supported Topology Targets
+
+- active-active edge nodes with shared Redis and durable event storage
+- active-passive failover with deterministic role transition controls
+- bounded peer-coordination overlays with explicit trust configuration
+
+## Durability and Consistency Baseline
+
+- define authoritative stores for hot state vs. durable audit/event data
+- define write/read consistency expectations per data class
+- define replay/recovery behavior after partial failures
+- define idempotency requirements for cross-node signal processing
+
+## Coordination Guarantees
+
+- bounded eventual consistency for non-critical shared signals
+- explicit conflict resolution strategy for concurrent updates
+- deterministic behavior when peers are partitioned or stale
+- operator-visible state for replication lag and conflict events
+
+## Validation Requirements
+
+- integration tests for multi-node write/read and failover behavior
+- chaos-style tests for partition, stale-peer, and recovery scenarios
+- tests for idempotency and duplicate-signal handling across nodes
+- operator/API checks for lag, conflict, and recovery telemetry
+
+## Operational Guidance
+
+- start with single-node baseline and promote to multi-node with staged rollout
+- enforce explicit node identity, trust, and authentication controls
+- define runbook steps for failover, rejoin, and conflict remediation


### PR DESCRIPTION
## Summary
- add a post-v1 baseline for multi-node durability and coordination behavior
- define topology targets, consistency/coordination guarantees, and validation scope
- link the baseline from commercial scope and docs index

## Validation
- docs-only change
- pre-commit config file is not present in this repository

Closes #76