### PR TITLE
Add IIS operator tuning recommendations

### DIFF
--- a/AiScrapingDefense.Contracts/Models/DefenseModels.cs
+++ b/AiScrapingDefense.Contracts/Models/DefenseModels.cs
@@ -42,6 +42,22 @@ public sealed record DefenseEventMetrics(
     long ObservedCount,
     DateTimeOffset? LatestDecisionAtUtc);
 
+public sealed record OperatorRecommendation(
+    string Id,
+    string Category,
+    string Severity,
+    string Title,
+    string Summary,
+    string Rationale,
+    string CurrentValue,
+    string SuggestedValue,
+    IReadOnlyList<string> Evidence);
+
+public sealed record OperatorRecommendationSnapshot(
+    DateTimeOffset GeneratedAtUtc,
+    int RecentDecisionCount,
+    IReadOnlyList<OperatorRecommendation> Recommendations);
+
 public sealed record RequestSignalEvaluation(
     bool BlockImmediately,
     string BlockReason,

--- a/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
@@ -133,6 +133,7 @@ public sealed class ManagementEndpointTests
         Assert.Equal("/defense/dashboard", endpoints["dashboard"]);
         Assert.Equal("/defense/events", endpoints["events"]);
         Assert.Equal("/defense/metrics", endpoints["metrics"]);
+        Assert.Equal("/defense/recommendations", endpoints["recommendations"]);
     }
 
     [Fact]
@@ -278,6 +279,7 @@ public sealed class ManagementEndpointTests
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/dashboard/session");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/events");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/metrics");
+        Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/recommendations");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/intake-deliveries");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/intake-delivery-metrics");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/blocklist");
@@ -295,6 +297,7 @@ public sealed class ManagementEndpointTests
         Assert.Contains("/defense/dashboard/session", html);
         Assert.Contains("/defense/events", html);
         Assert.Contains("/defense/metrics", html);
+        Assert.Contains("/defense/recommendations", html);
         Assert.Contains("/defense/intake-deliveries", html);
         Assert.Contains("/defense/intake-delivery-metrics", html);
         Assert.Contains("/defense/blocklist", html);
@@ -399,6 +402,7 @@ public sealed class ManagementEndpointTests
         builder.Services.AddSingleton<ApiKeyEndpointFilter>();
         builder.Services.AddSingleton<IntakeApiKeyEndpointFilter>();
         builder.Services.AddSingleton<PeerApiKeyEndpointFilter>();
+        builder.Services.AddSingleton<IOperatorRecommendationService, OperatorRecommendationService>();
         builder.Services.AddSingleton<IOperatorDashboardPageService, OperatorDashboardPageService>();
         builder.Services.AddSingleton<IDefenseEventStore, TestDefenseEventStore>();
         builder.Services.AddSingleton<IIntakeDeliveryStore, TestIntakeDeliveryStore>();
@@ -406,6 +410,7 @@ public sealed class ManagementEndpointTests
         builder.Services.AddSingleton<IWebhookEventInbox, TestWebhookEventInbox>();
         builder.Services.AddSingleton<IPeerSyncStatusStore, TestPeerSyncStatusStore>();
         builder.Services.AddSingleton<ICommunityBlocklistSyncStatusStore, TestCommunityBlocklistSyncStatusStore>();
+        builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddSingleton(Options.Create(CreateOptions()));
         return builder.Build();
     }

--- a/RedisBlocklistMiddlewareApp.Tests/OperatorRecommendationServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/OperatorRecommendationServiceTests.cs
@@ -61,7 +61,8 @@ public sealed class OperatorRecommendationServiceTests
 
         Assert.Contains(snapshot.Recommendations, item => item.Id == "lower-block-threshold");
         Assert.Contains(snapshot.Recommendations, item => item.Id == "lower-frequency-threshold");
-        Assert.Contains(snapshot.Recommendations, item => item.Id == "review-hot-path");
+        var hotPathRecommendation = Assert.Single(snapshot.Recommendations, item => item.Id == "review-hot-path");
+        Assert.Equal("Not evaluated", hotPathRecommendation.CurrentValue);
     }
 
     private static OperatorRecommendationService CreateService(

--- a/RedisBlocklistMiddlewareApp.Tests/OperatorRecommendationServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/OperatorRecommendationServiceTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class OperatorRecommendationServiceTests
+{
+    [Fact]
+    public void GetRecommendations_SuggestsRaisingBlockThreshold_WhenBlockRateIsVeryHigh()
+    {
+        var observedAtUtc = DateTimeOffset.UtcNow;
+        var decisions = Enumerable.Range(0, 20)
+            .Select(index => new DefenseDecision(
+                $"198.51.100.{index}",
+                index < 15 ? "blocked" : "observed",
+                index < 15 ? 75 : 30,
+                1,
+                "/docs",
+                ["signal"],
+                "summary",
+                observedAtUtc,
+                observedAtUtc))
+            .ToArray();
+        var service = CreateService(decisions, options =>
+        {
+            options.Escalation.Containment.BlockScoreThreshold = 60;
+        });
+
+        var snapshot = service.GetRecommendations();
+
+        var recommendation = Assert.Single(snapshot.Recommendations, item => item.Id == "raise-block-threshold");
+        Assert.Contains("Increase block score threshold to 65", recommendation.SuggestedValue, StringComparison.Ordinal);
+        Assert.Contains("outright block", recommendation.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetRecommendations_SuggestsLoweringThresholds_WhenRiskyTrafficStaysNonBlocking()
+    {
+        var observedAtUtc = DateTimeOffset.UtcNow;
+        var decisions = Enumerable.Range(0, 24)
+            .Select(index => new DefenseDecision(
+                $"198.51.100.{index}",
+                index < 3 ? "blocked" : "observed",
+                index < 3 ? 90 : 55,
+                index < 10 ? 8 : 2,
+                "/search",
+                ["signal"],
+                "summary",
+                observedAtUtc,
+                observedAtUtc))
+            .ToArray();
+        var service = CreateService(decisions, options =>
+        {
+            options.Escalation.Containment.BlockScoreThreshold = 60;
+            options.Escalation.Containment.FrequencyBlockThreshold = 8;
+        });
+
+        var snapshot = service.GetRecommendations();
+
+        Assert.Contains(snapshot.Recommendations, item => item.Id == "lower-block-threshold");
+        Assert.Contains(snapshot.Recommendations, item => item.Id == "lower-frequency-threshold");
+        Assert.Contains(snapshot.Recommendations, item => item.Id == "review-hot-path");
+    }
+
+    private static OperatorRecommendationService CreateService(
+        IReadOnlyList<DefenseDecision> decisions,
+        Action<DefenseEngineOptions>? configure = null)
+    {
+        var options = new DefenseEngineOptions
+        {
+            Escalation = new EscalationOptions
+            {
+                Containment = new ContainmentPolicyOptions
+                {
+                    BlockScoreThreshold = 60,
+                    FrequencyBlockThreshold = 8
+                }
+            }
+        };
+        configure?.Invoke(options);
+
+        return new OperatorRecommendationService(
+            new TestDefenseEventStore(decisions),
+            Options.Create(options),
+            TimeProvider.System);
+    }
+
+    private sealed class TestDefenseEventStore : IDefenseEventStore
+    {
+        private readonly IReadOnlyList<DefenseDecision> _decisions;
+
+        public TestDefenseEventStore(IReadOnlyList<DefenseDecision> decisions)
+        {
+            _decisions = decisions;
+        }
+
+        public void Add(DefenseDecision decision)
+        {
+        }
+
+        public IReadOnlyList<DefenseDecision> GetRecent(int count)
+        {
+            return _decisions.Take(count).ToArray();
+        }
+
+        public DefenseEventMetrics GetMetrics()
+        {
+            return new DefenseEventMetrics(_decisions.Count, _decisions.Count(item => item.Action == "blocked"), _decisions.Count(item => item.Action == "observed"), _decisions.LastOrDefault()?.DecidedAtUtc);
+        }
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -317,6 +317,7 @@ builder.Services.AddSingleton<ManagementAuthenticationService>();
 builder.Services.AddSingleton<ApiKeyEndpointFilter>();
 builder.Services.AddSingleton<IntakeApiKeyEndpointFilter>();
 builder.Services.AddSingleton<PeerApiKeyEndpointFilter>();
+builder.Services.AddSingleton<IOperatorRecommendationService, OperatorRecommendationService>();
 builder.Services.AddSingleton<IOperatorDashboardPageService, OperatorDashboardPageService>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IWebhookEventInbox, SqliteWebhookEventInbox>();
@@ -437,6 +438,7 @@ public partial class Program
             endpoints["dashboard"] = "/defense/dashboard";
             endpoints["events"] = "/defense/events";
             endpoints["metrics"] = "/defense/metrics";
+            endpoints["recommendations"] = "/defense/recommendations";
         }
 
         if (ShouldExposeIntakeEndpoints(runtimeOptions))
@@ -516,6 +518,12 @@ public partial class Program
             IDefenseEventStore store) =>
         {
             return Results.Ok(store.GetMetrics());
+        });
+
+        management.MapGet("/recommendations", (
+            IOperatorRecommendationService recommendationService) =>
+        {
+            return Results.Ok(recommendationService.GetRecommendations());
         });
 
         management.MapGet("/intake-deliveries", (

--- a/RedisBlocklistMiddlewareApp/Services/IOperatorRecommendationService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IOperatorRecommendationService.cs
@@ -1,0 +1,8 @@
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public interface IOperatorRecommendationService
+{
+    OperatorRecommendationSnapshot GetRecommendations();
+}

--- a/RedisBlocklistMiddlewareApp/Services/OperatorDashboardPageService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/OperatorDashboardPageService.cs
@@ -2,14 +2,14 @@ namespace RedisBlocklistMiddlewareApp.Services;
 
 public interface IOperatorDashboardPageService
 {
-    string Render();
+  string Render();
 }
 
 public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
 {
-    public string Render()
-    {
-        return """
+  public string Render()
+  {
+    return """
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -372,7 +372,7 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
               <button class="secondary" id="refreshButton" type="button">Refresh now</button>
             </div>
           </form>
-          <p class="inline-note">The browser session uses a server-issued cookie after the initial sign-in. The dashboard then reads the same `/defense/*` management endpoints as any other operator client.</p>
+          <p class="inline-note">The browser session uses a server-issued cookie after the initial sign-in. The dashboard then reads the same `/defense/*` management endpoints as any other operator client, including `/defense/recommendations` for advisory tuning suggestions.</p>
         </aside>
       </div>
       <div class="status-bar">
@@ -440,6 +440,15 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
 
       <aside class="panel">
         <div class="status-bar">
+          <h2>Recommendations</h2>
+          <span class="inline-note">Advisory only — generated from recent decisions.</span>
+        </div>
+        <div id="recommendationsList" class="status-card">
+          <h3>Operator guidance</h3>
+          <p class="mono">Sign in to load tuning recommendations.</p>
+        </div>
+        <div style="height:12px"></div>
+        <div class="status-bar">
           <h2>Control actions</h2>
           <span class="inline-note">Lookup, block, and unblock IPs.</span>
         </div>
@@ -498,6 +507,7 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
     const sessionCopy = document.getElementById("sessionCopy");
     const errorBanner = document.getElementById("errorBanner");
     const eventsTableBody = document.getElementById("eventsTableBody");
+    const recommendationsList = document.getElementById("recommendationsList");
     const blocklistResult = document.getElementById("blocklistResult");
     const ipInput = document.getElementById("ipInput");
     const reasonInput = document.getElementById("reasonInput");
@@ -554,6 +564,7 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
         await Promise.all([
           refreshMetrics(),
           refreshEvents(),
+          refreshRecommendations(),
           refreshStatuses()
         ]);
 
@@ -612,6 +623,34 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
             <td>${formatDate(event.observedAtUtc)}</td>
           </tr>`;
       }).join("");
+    }
+
+    async function refreshRecommendations() {
+      const snapshot = await fetchJson("/defense/recommendations");
+      const recommendations = snapshot.recommendations || [];
+
+      if (!recommendations.length) {
+        recommendationsList.innerHTML = `
+          <h3>Operator guidance</h3>
+          <p class="mono">No changes suggested from the last ${number(snapshot.recentDecisionCount)} decisions.</p>`;
+        return;
+      }
+
+      recommendationsList.innerHTML = `
+        <h3>Operator guidance</h3>
+        <p class="inline-note">Generated ${formatDate(snapshot.generatedAtUtc)} from ${number(snapshot.recentDecisionCount)} recent decisions.</p>
+        ${recommendations.map(recommendation => `
+          <section>
+            <div class="action-row">
+              <span class="chip">${escapeHtml(recommendation.category)}</span>
+              <span class="chip ${recommendation.severity === "medium" || recommendation.severity === "high" ? "blocked" : "observed"}">${escapeHtml(recommendation.severity)}</span>
+            </div>
+            <p><strong>${escapeHtml(recommendation.title)}</strong></p>
+            <p>${escapeHtml(recommendation.summary)}</p>
+            <p class="inline-note">${escapeHtml(recommendation.rationale)}</p>
+            <p class="mono">Current: ${escapeHtml(recommendation.currentValue)}</p>
+            <p class="mono">Suggested: ${escapeHtml(recommendation.suggestedValue)}</p>
+          </section>`).join("<hr style=\"border:0;border-top:1px solid var(--line);margin:12px 0\">")}`;
     }
 
     async function refreshStatuses() {
@@ -725,6 +764,7 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
       document.getElementById("metricObserved").textContent = "0";
       document.getElementById("metricLatest").textContent = "none";
       eventsTableBody.innerHTML = '<tr><td colspan="6" class="empty">Sign in to load recent defense decisions.</td></tr>';
+      recommendationsList.innerHTML = '<h3>Operator guidance</h3><p class="mono">Sign in to load tuning recommendations.</p>';
       document.getElementById("intakeStatusCopy").textContent = "Waiting for session.";
       document.getElementById("communityStatusCopy").textContent = "Waiting for session.";
       document.getElementById("peerStatusCopy").textContent = "Waiting for session.";
@@ -794,5 +834,5 @@ public sealed class OperatorDashboardPageService : IOperatorDashboardPageService
 </body>
 </html>
 """;
-    }
+  }
 }

--- a/RedisBlocklistMiddlewareApp/Services/OperatorRecommendationService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/OperatorRecommendationService.cs
@@ -1,0 +1,169 @@
+using Microsoft.Extensions.Options;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+
+namespace RedisBlocklistMiddlewareApp.Services;
+
+public sealed class OperatorRecommendationService : IOperatorRecommendationService
+{
+    private readonly IDefenseEventStore _store;
+    private readonly DefenseEngineOptions _options;
+    private readonly TimeProvider _timeProvider;
+
+    public OperatorRecommendationService(
+        IDefenseEventStore store,
+        IOptions<DefenseEngineOptions> options,
+        TimeProvider timeProvider)
+    {
+        _store = store;
+        _options = options.Value;
+        _timeProvider = timeProvider;
+    }
+
+    public OperatorRecommendationSnapshot GetRecommendations()
+    {
+        var recentDecisions = _store.GetRecent(100);
+        var recommendations = new List<OperatorRecommendation>();
+
+        if (recentDecisions.Count > 0)
+        {
+            AddBlockThresholdRecommendations(recentDecisions, recommendations);
+            AddFrequencyThresholdRecommendation(recentDecisions, recommendations);
+            AddHotPathRecommendation(recentDecisions, recommendations);
+        }
+
+        return new OperatorRecommendationSnapshot(
+            _timeProvider.GetUtcNow(),
+            recentDecisions.Count,
+            recommendations);
+    }
+
+    private void AddBlockThresholdRecommendations(
+        IReadOnlyList<DefenseDecision> recentDecisions,
+        ICollection<OperatorRecommendation> recommendations)
+    {
+        var blockedCount = recentDecisions.Count(IsBlocked);
+        var blockedRate = blockedCount / (double)recentDecisions.Count;
+        var blockThreshold = _options.Escalation.Containment.BlockScoreThreshold;
+        var nearBlockObservedCount = recentDecisions.Count(decision =>
+            !IsBlocked(decision) &&
+            decision.Score >= Math.Max(0, blockThreshold - 10));
+
+        if (recentDecisions.Count >= 20 && blockedRate >= 0.65d)
+        {
+            var suggestedThreshold = Math.Min(100, blockThreshold + 5);
+            if (suggestedThreshold > blockThreshold)
+            {
+                recommendations.Add(new OperatorRecommendation(
+                    "raise-block-threshold",
+                    "containment",
+                    "medium",
+                    "Raise the queued-analysis block threshold",
+                    $"{blockedCount} of the last {recentDecisions.Count} decisions ended in an outright block.",
+                    "A very high block rate can indicate that the current containment threshold is too aggressive for mixed traffic.",
+                    $"Block score threshold = {blockThreshold}",
+                    $"Increase block score threshold to {suggestedThreshold}",
+                    [
+                        $"Blocked-rate sample: {blockedRate:P0}",
+                        $"Current containment block threshold: {blockThreshold}"
+                    ]));
+            }
+        }
+
+        if (recentDecisions.Count >= 20 && blockedRate <= 0.15d && nearBlockObservedCount >= 5)
+        {
+            var suggestedThreshold = Math.Max(10, blockThreshold - 5);
+            if (suggestedThreshold < blockThreshold)
+            {
+                recommendations.Add(new OperatorRecommendation(
+                    "lower-block-threshold",
+                    "containment",
+                    "medium",
+                    "Lower the queued-analysis block threshold",
+                    $"{nearBlockObservedCount} recent decisions scored near the block threshold but remained non-blocking.",
+                    "The current threshold may be letting obviously risky requests stay in challenge or observe-only states for too long.",
+                    $"Block score threshold = {blockThreshold}",
+                    $"Decrease block score threshold to {suggestedThreshold}",
+                    [
+                        $"Blocked-rate sample: {blockedRate:P0}",
+                        $"Near-block non-blocking decisions: {nearBlockObservedCount}"
+                    ]));
+            }
+        }
+    }
+
+    private void AddFrequencyThresholdRecommendation(
+        IReadOnlyList<DefenseDecision> recentDecisions,
+        ICollection<OperatorRecommendation> recommendations)
+    {
+        var highFrequencyObservedCount = recentDecisions.Count(decision =>
+            !IsBlocked(decision) &&
+            decision.Frequency >= _options.Escalation.Containment.FrequencyBlockThreshold);
+
+        if (highFrequencyObservedCount < 5)
+        {
+            return;
+        }
+
+        var currentThreshold = _options.Escalation.Containment.FrequencyBlockThreshold;
+        var suggestedThreshold = Math.Max(1, currentThreshold - 1);
+        if (suggestedThreshold == currentThreshold)
+        {
+            return;
+        }
+
+        recommendations.Add(new OperatorRecommendation(
+            "lower-frequency-threshold",
+            "containment",
+            "low",
+            "Lower the frequency block threshold",
+            $"{highFrequencyObservedCount} recent decisions reached the current frequency threshold without being blocked.",
+            "This pattern suggests the queue is still seeing repeated bursts from the same sources after the configured frequency threshold is met.",
+            $"Frequency block threshold = {currentThreshold}",
+            $"Decrease frequency block threshold to {suggestedThreshold}",
+            [
+                $"Observed high-frequency non-blocking decisions: {highFrequencyObservedCount}",
+                $"Current containment frequency threshold: {currentThreshold}"
+            ]));
+    }
+
+    private static void AddHotPathRecommendation(
+        IReadOnlyList<DefenseDecision> recentDecisions,
+        ICollection<OperatorRecommendation> recommendations)
+    {
+        if (recentDecisions.Count < 15)
+        {
+            return;
+        }
+
+        var dominantPath = recentDecisions
+            .Where(decision => !string.IsNullOrWhiteSpace(decision.Path))
+            .GroupBy(decision => decision.Path, StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(group => group.Count())
+            .FirstOrDefault();
+
+        if (dominantPath is null || dominantPath.Count() < Math.Max(5, (int)Math.Ceiling(recentDecisions.Count * 0.4d)))
+        {
+            return;
+        }
+
+        recommendations.Add(new OperatorRecommendation(
+            "review-hot-path",
+            "traffic-shaping",
+            "low",
+            "Review the busiest defended path",
+            $"The path {dominantPath.Key} accounts for {dominantPath.Count()} of the last {recentDecisions.Count} decisions.",
+            "A single dominant route can usually be tuned more safely with a targeted rule or allowlist than with a stack-wide threshold change.",
+            "No targeted path rule recorded",
+            $"Review a dedicated rule or allowlist policy for {dominantPath.Key}",
+            [
+                $"Dominant path sample: {dominantPath.Key}",
+                $"Recent decision share: {(dominantPath.Count() / (double)recentDecisions.Count):P0}"
+            ]));
+    }
+
+    private static bool IsBlocked(DefenseDecision decision)
+    {
+        return string.Equals(decision.Action, "blocked", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/RedisBlocklistMiddlewareApp/Services/OperatorRecommendationService.cs
+++ b/RedisBlocklistMiddlewareApp/Services/OperatorRecommendationService.cs
@@ -142,7 +142,14 @@ public sealed class OperatorRecommendationService : IOperatorRecommendationServi
             .OrderByDescending(group => group.Count())
             .FirstOrDefault();
 
-        if (dominantPath is null || dominantPath.Count() < Math.Max(5, (int)Math.Ceiling(recentDecisions.Count * 0.4d)))
+        if (dominantPath is null)
+        {
+            return;
+        }
+
+        var dominantPathCount = dominantPath.Count();
+        var threshold = Math.Max(5, (int)Math.Ceiling(recentDecisions.Count * 0.4d));
+        if (dominantPathCount < threshold)
         {
             return;
         }
@@ -152,13 +159,13 @@ public sealed class OperatorRecommendationService : IOperatorRecommendationServi
             "traffic-shaping",
             "low",
             "Review the busiest defended path",
-            $"The path {dominantPath.Key} accounts for {dominantPath.Count()} of the last {recentDecisions.Count} decisions.",
+            $"The path {dominantPath.Key} accounts for {dominantPathCount} of the last {recentDecisions.Count} decisions.",
             "A single dominant route can usually be tuned more safely with a targeted rule or allowlist than with a stack-wide threshold change.",
-            "No targeted path rule recorded",
+            "Not evaluated",
             $"Review a dedicated rule or allowlist policy for {dominantPath.Key}",
             [
                 $"Dominant path sample: {dominantPath.Key}",
-                $"Recent decision share: {(dominantPath.Count() / (double)recentDecisions.Count):P0}"
+                $"Recent decision share: {(dominantPathCount / (double)recentDecisions.Count):P0}"
             ]));
     }
 


### PR DESCRIPTION
## Summary
- add an operator recommendation service that derives advisory threshold and traffic-shaping suggestions from recent defense decisions
- expose authenticated `/defense/recommendations` management API output and surface it in the operator dashboard
- add tests for recommendation generation and management endpoint exposure

Closes #101

## Testing
- dotnet test anti-scraping-defense-iis.sln --nologo