### PR TITLE
Add decision memory and operator feedback hooks

### DIFF
--- a/AiScrapingDefense.Contracts/Models/DefenseModels.cs
+++ b/AiScrapingDefense.Contracts/Models/DefenseModels.cs
@@ -21,7 +21,8 @@ public sealed record DefenseDecision(
     string Summary,
     DateTimeOffset ObservedAtUtc,
     DateTimeOffset DecidedAtUtc,
-    DefenseScoreBreakdown? Breakdown = null);
+    DefenseScoreBreakdown? Breakdown = null,
+    long Id = 0);
 
 public sealed record DefenseScoreBreakdown(
     int BaseSignalScore,
@@ -57,6 +58,16 @@ public sealed record OperatorRecommendationSnapshot(
     DateTimeOffset GeneratedAtUtc,
     int RecentDecisionCount,
     IReadOnlyList<OperatorRecommendation> Recommendations);
+
+public sealed record DefenseDecisionFeedback(
+    long Id,
+    long DecisionId,
+    string IpAddress,
+    string OriginalAction,
+    string UpdatedAction,
+    string Reason,
+    string Actor,
+    DateTimeOffset CreatedAtUtc);
 
 public sealed record RequestSignalEvaluation(
     bool BlockImmediately,

--- a/AiScrapingDefense.Contracts/Models/OperatorDashboardModels.cs
+++ b/AiScrapingDefense.Contracts/Models/OperatorDashboardModels.cs
@@ -1,3 +1,9 @@
 namespace RedisBlocklistMiddlewareApp.Models;
 
 public sealed record DashboardSessionLoginRequest(string ApiKey);
+
+public sealed record DefenseDecisionFeedbackCreateRequest(
+    long DecisionId,
+    string UpdatedAction,
+    string Reason,
+    string? Actor);

--- a/RedisBlocklistMiddlewareApp.Tests/DefenseEventStoreFeedbackTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/DefenseEventStoreFeedbackTests.cs
@@ -1,0 +1,123 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.Data.Sqlite;
+using RedisBlocklistMiddlewareApp.Configuration;
+using RedisBlocklistMiddlewareApp.Models;
+using RedisBlocklistMiddlewareApp.Services;
+
+namespace RedisBlocklistMiddlewareApp.Tests;
+
+public sealed class DefenseEventStoreFeedbackTests
+{
+    [Fact]
+    public void SqliteDefenseEventStore_PersistsDecisionIdsAndFeedbackRecords()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "ai-scraping-defense-feedback-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        try
+        {
+            var store = CreateStore(tempDirectory);
+            var now = DateTimeOffset.UtcNow;
+
+            store.Add(new DefenseDecision(
+                "198.51.100.10",
+                "challenged",
+                35,
+                2,
+                "/docs",
+                ["signal"],
+                "summary",
+                now,
+                now));
+
+            var decision = Assert.Single(store.GetRecent(10));
+            Assert.True(decision.Id > 0);
+
+            var persisted = store.GetById(decision.Id);
+            Assert.NotNull(persisted);
+            Assert.Equal("198.51.100.10", persisted!.IpAddress);
+
+            var feedback = store.AddFeedback(new DefenseDecisionFeedback(
+                0,
+                decision.Id,
+                decision.IpAddress,
+                decision.Action,
+                "blocked",
+                "confirmed malicious after review",
+                "operator@example",
+                now.AddMinutes(1)));
+
+            Assert.True(feedback.Id > 0);
+
+            var recentFeedback = Assert.Single(store.GetRecentFeedback(10));
+            Assert.Equal(decision.Id, recentFeedback.DecisionId);
+            Assert.Equal("challenged", recentFeedback.OriginalAction);
+            Assert.Equal("blocked", recentFeedback.UpdatedAction);
+            Assert.Equal("operator@example", recentFeedback.Actor);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SqliteDefenseEventStore_RejectsFeedbackForUnknownDecision()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), "ai-scraping-defense-feedback-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        try
+        {
+            var store = CreateStore(tempDirectory);
+            var now = DateTimeOffset.UtcNow;
+
+            Assert.Throws<SqliteException>(() => store.AddFeedback(new DefenseDecisionFeedback(
+                0,
+                999,
+                "198.51.100.99",
+                "observed",
+                "blocked",
+                "invalid decision reference",
+                "management_api_key",
+                now)));
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    private static SqliteDefenseEventStore CreateStore(string rootPath)
+    {
+        var options = Options.Create(new DefenseEngineOptions
+        {
+            Audit = new AuditOptions
+            {
+                DatabasePath = "data/defense-events.db",
+                MaxRecentEvents = 100
+            }
+        });
+
+        return new SqliteDefenseEventStore(options, new TestHostEnvironment(rootPath));
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public TestHostEnvironment(string contentRootPath)
+        {
+            ContentRootPath = contentRootPath;
+            ContentRootFileProvider = new PhysicalFileProvider(contentRootPath);
+        }
+
+        public string EnvironmentName { get; set; } = "Development";
+
+        public string ApplicationName { get; set; } = "RedisBlocklistMiddlewareApp.Tests";
+
+        public string ContentRootPath { get; set; }
+
+        public IFileProvider ContentRootFileProvider { get; set; }
+    }
+}

--- a/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
@@ -134,6 +134,7 @@ public sealed class ManagementEndpointTests
         Assert.Equal("/defense/events", endpoints["events"]);
         Assert.Equal("/defense/metrics", endpoints["metrics"]);
         Assert.Equal("/defense/recommendations", endpoints["recommendations"]);
+        Assert.Equal("/defense/feedback", endpoints["feedback"]);
     }
 
     [Fact]
@@ -250,6 +251,44 @@ public sealed class ManagementEndpointTests
     }
 
     [Fact]
+    public void GetFeedbackAuthenticatedActor_ReturnsApiKeySource_WhenHeaderPresent()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = "test-management-key";
+
+        var actor = Program.GetFeedbackAuthenticatedActor(httpContext, CreateOptions());
+
+        Assert.Equal("management_api_key", actor);
+    }
+
+    [Fact]
+    public void GetFeedbackAuthenticatedActor_ReturnsDashboardSession_WhenCookiePresent()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.Cookie = $"{ManagementAuthenticationService.SessionCookieName}=session-value";
+
+        var actor = Program.GetFeedbackAuthenticatedActor(httpContext, CreateOptions());
+
+        Assert.Equal("dashboard_session", actor);
+    }
+
+    [Fact]
+    public void BuildFeedbackReason_AppendsOperatorLabel_WhenProvided()
+    {
+        var reason = Program.BuildFeedbackReason("confirmed malicious after review", "operator@example");
+
+        Assert.Equal("confirmed malicious after review (operator: operator@example)", reason);
+    }
+
+    [Fact]
+    public void BuildFeedbackReason_UsesBaseReason_WhenOperatorLabelMissing()
+    {
+        var reason = Program.BuildFeedbackReason("confirmed malicious after review", "   ");
+
+        Assert.Equal("confirmed malicious after review", reason);
+    }
+
+    [Fact]
     public void MapManagementEndpoints_DoesNotRegisterDefenseEvents_WhenManagementApiKeyIsMissing()
     {
         var app = CreateApp();
@@ -280,6 +319,7 @@ public sealed class ManagementEndpointTests
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/events");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/metrics");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/recommendations");
+        Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/feedback");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/intake-deliveries");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/intake-delivery-metrics");
         Assert.Contains(endpoints, endpoint => endpoint.RoutePattern.RawText == "/defense/blocklist");
@@ -488,13 +528,34 @@ public sealed class ManagementEndpointTests
 
     private sealed class TestDefenseEventStore : IDefenseEventStore
     {
+        private readonly List<DefenseDecision> _decisions = [];
+        private readonly List<DefenseDecisionFeedback> _feedback = [];
+
         public void Add(Models.DefenseDecision decision)
         {
+            _decisions.Add(decision);
         }
 
         public IReadOnlyList<Models.DefenseDecision> GetRecent(int count)
         {
-            return [];
+            return _decisions.Take(count).ToArray();
+        }
+
+        public DefenseDecision? GetById(long id)
+        {
+            return _decisions.FirstOrDefault(decision => decision.Id == id);
+        }
+
+        public DefenseDecisionFeedback AddFeedback(DefenseDecisionFeedback feedback)
+        {
+            var persisted = feedback with { Id = _feedback.Count + 1 };
+            _feedback.Add(persisted);
+            return persisted;
+        }
+
+        public IReadOnlyList<DefenseDecisionFeedback> GetRecentFeedback(int count)
+        {
+            return _feedback.Take(count).ToArray();
         }
 
         public Models.DefenseEventMetrics GetMetrics()
@@ -519,6 +580,21 @@ public sealed class ManagementEndpointTests
         public IReadOnlyList<DefenseDecision> GetRecent(int count)
         {
             return _decisions.Take(count).ToArray();
+        }
+
+        public DefenseDecision? GetById(long id)
+        {
+            return _decisions.FirstOrDefault(decision => decision.Id == id);
+        }
+
+        public DefenseDecisionFeedback AddFeedback(DefenseDecisionFeedback feedback)
+        {
+            return feedback with { Id = 1 };
+        }
+
+        public IReadOnlyList<DefenseDecisionFeedback> GetRecentFeedback(int count)
+        {
+            return [];
         }
 
         public DefenseEventMetrics GetMetrics()

--- a/RedisBlocklistMiddlewareApp.Tests/OperatorRecommendationServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/OperatorRecommendationServiceTests.cs
@@ -106,6 +106,21 @@ public sealed class OperatorRecommendationServiceTests
             return _decisions.Take(count).ToArray();
         }
 
+        public DefenseDecision? GetById(long id)
+        {
+            return _decisions.FirstOrDefault(decision => decision.Id == id);
+        }
+
+        public DefenseDecisionFeedback AddFeedback(DefenseDecisionFeedback feedback)
+        {
+            return feedback with { Id = 1 };
+        }
+
+        public IReadOnlyList<DefenseDecisionFeedback> GetRecentFeedback(int count)
+        {
+            return [];
+        }
+
         public DefenseEventMetrics GetMetrics()
         {
             return new DefenseEventMetrics(_decisions.Count, _decisions.Count(item => item.Action == "blocked"), _decisions.Count(item => item.Action == "observed"), _decisions.LastOrDefault()?.DecidedAtUtc);

--- a/RedisBlocklistMiddlewareApp.Tests/PeerSyncRunnerTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/PeerSyncRunnerTests.cs
@@ -237,6 +237,8 @@ public sealed class PeerSyncRunnerTests
     {
         public List<DefenseDecision> Decisions { get; } = [];
 
+        public List<DefenseDecisionFeedback> Feedback { get; } = [];
+
         public void Add(DefenseDecision decision)
         {
             Decisions.Add(decision);
@@ -245,6 +247,23 @@ public sealed class PeerSyncRunnerTests
         public IReadOnlyList<DefenseDecision> GetRecent(int count)
         {
             return Decisions.Take(count).ToArray();
+        }
+
+        public DefenseDecision? GetById(long id)
+        {
+            return Decisions.FirstOrDefault(decision => decision.Id == id);
+        }
+
+        public DefenseDecisionFeedback AddFeedback(DefenseDecisionFeedback feedback)
+        {
+            var persisted = feedback with { Id = Feedback.Count + 1 };
+            Feedback.Add(persisted);
+            return persisted;
+        }
+
+        public IReadOnlyList<DefenseDecisionFeedback> GetRecentFeedback(int count)
+        {
+            return Feedback.Take(count).ToArray();
         }
 
         public DefenseEventMetrics GetMetrics()

--- a/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareTests.cs
@@ -379,6 +379,8 @@ public sealed class RedisBlocklistMiddlewareTests
     {
         public List<DefenseDecision> Decisions { get; } = [];
 
+        public List<DefenseDecisionFeedback> Feedback { get; } = [];
+
         public void Add(DefenseDecision decision)
         {
             Decisions.Add(decision);
@@ -387,6 +389,23 @@ public sealed class RedisBlocklistMiddlewareTests
         public IReadOnlyList<DefenseDecision> GetRecent(int count)
         {
             return Decisions.Take(count).ToArray();
+        }
+
+        public DefenseDecision? GetById(long id)
+        {
+            return Decisions.FirstOrDefault(decision => decision.Id == id);
+        }
+
+        public DefenseDecisionFeedback AddFeedback(DefenseDecisionFeedback feedback)
+        {
+            var persisted = feedback with { Id = Feedback.Count + 1 };
+            Feedback.Add(persisted);
+            return persisted;
+        }
+
+        public IReadOnlyList<DefenseDecisionFeedback> GetRecentFeedback(int count)
+        {
+            return Feedback.Take(count).ToArray();
         }
 
         public DefenseEventMetrics GetMetrics()

--- a/RedisBlocklistMiddlewareApp.Tests/WebhookIntakeProcessingServiceTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/WebhookIntakeProcessingServiceTests.cs
@@ -153,6 +153,8 @@ public sealed class WebhookIntakeProcessingServiceTests
     {
         public List<DefenseDecision> Decisions { get; } = [];
 
+        public List<DefenseDecisionFeedback> Feedback { get; } = [];
+
         public void Add(DefenseDecision decision)
         {
             Decisions.Add(decision);
@@ -161,6 +163,23 @@ public sealed class WebhookIntakeProcessingServiceTests
         public IReadOnlyList<DefenseDecision> GetRecent(int count)
         {
             return Decisions.Take(count).ToArray();
+        }
+
+        public DefenseDecision? GetById(long id)
+        {
+            return Decisions.FirstOrDefault(decision => decision.Id == id);
+        }
+
+        public DefenseDecisionFeedback AddFeedback(DefenseDecisionFeedback feedback)
+        {
+            var persisted = feedback with { Id = Feedback.Count + 1 };
+            Feedback.Add(persisted);
+            return persisted;
+        }
+
+        public IReadOnlyList<DefenseDecisionFeedback> GetRecentFeedback(int count)
+        {
+            return Feedback.Take(count).ToArray();
         }
 
         public DefenseEventMetrics GetMetrics()

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -439,6 +439,7 @@ public partial class Program
             endpoints["events"] = "/defense/events";
             endpoints["metrics"] = "/defense/metrics";
             endpoints["recommendations"] = "/defense/recommendations";
+            endpoints["feedback"] = "/defense/feedback";
         }
 
         if (ShouldExposeIntakeEndpoints(runtimeOptions))
@@ -524,6 +525,13 @@ public partial class Program
             IOperatorRecommendationService recommendationService) =>
         {
             return Results.Ok(recommendationService.GetRecommendations());
+        });
+
+        management.MapGet("/feedback", (
+            IDefenseEventStore store,
+            int count = 50) =>
+        {
+            return Results.Ok(store.GetRecentFeedback(count));
         });
 
         management.MapGet("/intake-deliveries", (
@@ -617,6 +625,59 @@ public partial class Program
                 ip = normalizedIp,
                 blocked = false
             });
+        });
+
+        management.MapPost("/feedback", async (
+            DefenseDecisionFeedbackCreateRequest request,
+            HttpContext httpContext,
+            IDefenseEventStore store,
+            IBlocklistService blocklistService,
+            CancellationToken cancellationToken) =>
+        {
+            if (request.DecisionId <= 0)
+            {
+                return Results.BadRequest(new { error = "decisionId must be a positive integer." });
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Reason))
+            {
+                return Results.BadRequest(new { error = "reason is required." });
+            }
+
+            if (!TryNormalizeManagedAction(request.UpdatedAction, out var updatedAction))
+            {
+                return Results.BadRequest(new { error = "updatedAction must be one of observed, challenged, tarpitted, throttled, or blocked." });
+            }
+
+            var decision = store.GetById(request.DecisionId);
+            if (decision is null)
+            {
+                return Results.NotFound(new { error = "The referenced defense decision could not be found." });
+            }
+
+            var authenticatedActor = GetFeedbackAuthenticatedActor(httpContext, runtimeOptions);
+            var persistedReason = BuildFeedbackReason(request.Reason, request.Actor);
+
+            var feedback = store.AddFeedback(new DefenseDecisionFeedback(
+                0,
+                decision.Id,
+                decision.IpAddress,
+                decision.Action,
+                updatedAction,
+                persistedReason,
+                authenticatedActor,
+                DateTimeOffset.UtcNow));
+
+            if (string.Equals(updatedAction, ContainmentActions.Blocked, StringComparison.OrdinalIgnoreCase))
+            {
+                await blocklistService.BlockAsync(
+                    decision.IpAddress,
+                    "operator_feedback_override",
+                    ["operator_feedback_override"],
+                    cancellationToken);
+            }
+
+            return Results.Accepted("/defense/feedback?count=50", feedback);
         });
     }
 
@@ -752,6 +813,33 @@ public partial class Program
         return true;
     }
 
+    public static string GetFeedbackAuthenticatedActor(
+        HttpContext httpContext,
+        DefenseEngineOptions runtimeOptions)
+    {
+        if (httpContext.Request.Headers.ContainsKey(runtimeOptions.Management.ApiKeyHeaderName))
+        {
+            return "management_api_key";
+        }
+
+        if (httpContext.Request.Cookies.ContainsKey(ManagementAuthenticationService.SessionCookieName))
+        {
+            return "dashboard_session";
+        }
+
+        return "management_endpoint";
+    }
+
+    public static string BuildFeedbackReason(string reason, string? actor)
+    {
+        var trimmedReason = reason.Trim();
+        var trimmedActor = actor?.Trim() ?? string.Empty;
+
+        return string.IsNullOrWhiteSpace(trimmedActor)
+            ? trimmedReason
+            : $"{trimmedReason} (operator: {trimmedActor})";
+    }
+
     private static string NormalizeObservabilityPath(string path)
     {
         return NormalizeRoutePrefix(
@@ -773,5 +861,43 @@ public partial class Program
         return candidate.Length > 1
             ? candidate.TrimEnd('/')
             : "/";
+    }
+
+    private static bool TryNormalizeManagedAction(string? value, out string normalized)
+    {
+        normalized = string.Empty;
+        var candidate = value?.Trim() ?? string.Empty;
+
+        if (string.Equals(candidate, ContainmentActions.Observed, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = ContainmentActions.Observed;
+            return true;
+        }
+
+        if (string.Equals(candidate, ContainmentActions.Challenged, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = ContainmentActions.Challenged;
+            return true;
+        }
+
+        if (string.Equals(candidate, ContainmentActions.Tarpitted, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = ContainmentActions.Tarpitted;
+            return true;
+        }
+
+        if (string.Equals(candidate, ContainmentActions.Throttled, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = ContainmentActions.Throttled;
+            return true;
+        }
+
+        if (string.Equals(candidate, ContainmentActions.Blocked, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = ContainmentActions.Blocked;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/RedisBlocklistMiddlewareApp/Services/IDefenseEventStore.cs
+++ b/RedisBlocklistMiddlewareApp/Services/IDefenseEventStore.cs
@@ -8,5 +8,11 @@ public interface IDefenseEventStore
 
     IReadOnlyList<DefenseDecision> GetRecent(int count);
 
+    DefenseDecision? GetById(long id);
+
+    DefenseDecisionFeedback AddFeedback(DefenseDecisionFeedback feedback);
+
+    IReadOnlyList<DefenseDecisionFeedback> GetRecentFeedback(int count);
+
     DefenseEventMetrics GetMetrics();
 }

--- a/RedisBlocklistMiddlewareApp/Services/SqliteDefenseEventStore.cs
+++ b/RedisBlocklistMiddlewareApp/Services/SqliteDefenseEventStore.cs
@@ -82,8 +82,8 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
                 "$breakdownJson",
                 decision.Breakdown is null ? DBNull.Value : JsonSerializer.Serialize(decision.Breakdown));
             command.Parameters.AddWithValue("$summary", decision.Summary);
-            command.Parameters.AddWithValue("$observedAtUtc", decision.ObservedAtUtc.UtcDateTime.ToString("O"));
-            command.Parameters.AddWithValue("$decidedAtUtc", decision.DecidedAtUtc.UtcDateTime.ToString("O"));
+            command.Parameters.AddWithValue("$observedAtUtc", decision.ObservedAtUtc.ToString("O"));
+            command.Parameters.AddWithValue("$decidedAtUtc", decision.DecidedAtUtc.ToString("O"));
             command.ExecuteNonQuery();
 
             using var summaryCommand = connection.CreateCommand();
@@ -102,7 +102,7 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
                 WHERE summary_key = 1;
                 """;
             summaryCommand.Parameters.AddWithValue("$action", decision.Action);
-            summaryCommand.Parameters.AddWithValue("$decidedAtUtc", decision.DecidedAtUtc.UtcDateTime.ToString("O"));
+            summaryCommand.Parameters.AddWithValue("$decidedAtUtc", decision.DecidedAtUtc.ToString("O"));
             summaryCommand.ExecuteNonQuery();
         }
     }
@@ -119,6 +119,7 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
             command.CommandText =
                 """
                 SELECT
+                    id,
                     ip_address,
                     action,
                     score,
@@ -139,18 +140,160 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
             while (reader.Read())
             {
                 results.Add(new DefenseDecision(
-                    reader.GetString(0),
                     reader.GetString(1),
-                    reader.GetInt32(2),
-                    reader.GetInt64(3),
-                    reader.GetString(4),
-                    JsonSerializer.Deserialize<string[]>(reader.GetString(5)) ?? [],
-                    reader.GetString(7),
-                    DateTimeOffset.Parse(reader.GetString(8)),
+                    reader.GetString(2),
+                    reader.GetInt32(3),
+                    reader.GetInt64(4),
+                    reader.GetString(5),
+                    JsonSerializer.Deserialize<string[]>(reader.GetString(6)) ?? [],
+                    reader.GetString(8),
                     DateTimeOffset.Parse(reader.GetString(9)),
-                    reader.IsDBNull(6)
+                    DateTimeOffset.Parse(reader.GetString(10)),
+                    reader.IsDBNull(7)
                         ? null
-                        : JsonSerializer.Deserialize<DefenseScoreBreakdown>(reader.GetString(6))));
+                        : JsonSerializer.Deserialize<DefenseScoreBreakdown>(reader.GetString(7)),
+                    reader.GetInt64(0)));
+            }
+        }
+
+        return results;
+    }
+
+    public DefenseDecision? GetById(long id)
+    {
+        if (id <= 0)
+        {
+            return null;
+        }
+
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                SELECT
+                    id,
+                    ip_address,
+                    action,
+                    score,
+                    frequency,
+                    path,
+                    signals_json,
+                    breakdown_json,
+                    summary,
+                    observed_at_utc,
+                    decided_at_utc
+                FROM defense_events
+                WHERE id = $id;
+                """;
+            command.Parameters.AddWithValue("$id", id);
+
+            using var reader = command.ExecuteReader();
+            if (!reader.Read())
+            {
+                return null;
+            }
+
+            return new DefenseDecision(
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetInt32(3),
+                reader.GetInt64(4),
+                reader.GetString(5),
+                JsonSerializer.Deserialize<string[]>(reader.GetString(6)) ?? [],
+                reader.GetString(8),
+                DateTimeOffset.Parse(reader.GetString(9)),
+                DateTimeOffset.Parse(reader.GetString(10)),
+                reader.IsDBNull(7)
+                    ? null
+                    : JsonSerializer.Deserialize<DefenseScoreBreakdown>(reader.GetString(7)),
+                reader.GetInt64(0));
+        }
+    }
+
+    public DefenseDecisionFeedback AddFeedback(DefenseDecisionFeedback feedback)
+    {
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                INSERT INTO defense_feedback
+                (
+                    decision_id,
+                    ip_address,
+                    original_action,
+                    updated_action,
+                    reason,
+                    actor,
+                    created_at_utc
+                )
+                VALUES
+                (
+                    $decisionId,
+                    $ipAddress,
+                    $originalAction,
+                    $updatedAction,
+                    $reason,
+                    $actor,
+                    $createdAtUtc
+                );
+
+                SELECT last_insert_rowid();
+                """;
+            command.Parameters.AddWithValue("$decisionId", feedback.DecisionId);
+            command.Parameters.AddWithValue("$ipAddress", feedback.IpAddress);
+            command.Parameters.AddWithValue("$originalAction", feedback.OriginalAction);
+            command.Parameters.AddWithValue("$updatedAction", feedback.UpdatedAction);
+            command.Parameters.AddWithValue("$reason", feedback.Reason);
+            command.Parameters.AddWithValue("$actor", feedback.Actor);
+            command.Parameters.AddWithValue("$createdAtUtc", feedback.CreatedAtUtc.ToString("O"));
+
+            var id = (long)(command.ExecuteScalar() ?? 0L);
+            return feedback with { Id = id };
+        }
+    }
+
+    public IReadOnlyList<DefenseDecisionFeedback> GetRecentFeedback(int count)
+    {
+        var safeCount = Math.Clamp(count, 1, _maxRecentEvents);
+        var results = new List<DefenseDecisionFeedback>(safeCount);
+
+        lock (_gate)
+        {
+            using var connection = OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                """
+                SELECT
+                    id,
+                    decision_id,
+                    ip_address,
+                    original_action,
+                    updated_action,
+                    reason,
+                    actor,
+                    created_at_utc
+                FROM defense_feedback
+                ORDER BY created_at_utc DESC, id DESC
+                LIMIT $limit;
+                """;
+            command.Parameters.AddWithValue("$limit", safeCount);
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                results.Add(new DefenseDecisionFeedback(
+                    reader.GetInt64(0),
+                    reader.GetInt64(1),
+                    reader.GetString(2),
+                    reader.GetString(3),
+                    reader.GetString(4),
+                    reader.GetString(5),
+                    reader.GetString(6),
+                    DateTimeOffset.Parse(reader.GetString(7))));
             }
         }
 
@@ -215,6 +358,22 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
                 CREATE INDEX IF NOT EXISTS idx_defense_events_decided_at
                     ON defense_events (decided_at_utc DESC, id DESC);
 
+                CREATE TABLE IF NOT EXISTS defense_feedback
+                (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    decision_id INTEGER NOT NULL,
+                    ip_address TEXT NOT NULL,
+                    original_action TEXT NOT NULL,
+                    updated_action TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    actor TEXT NOT NULL,
+                    created_at_utc TEXT NOT NULL,
+                    FOREIGN KEY (decision_id) REFERENCES defense_events (id)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_defense_feedback_created_at
+                    ON defense_feedback (created_at_utc DESC, id DESC);
+
                 CREATE TABLE IF NOT EXISTS defense_event_summary
                 (
                     summary_key INTEGER PRIMARY KEY CHECK (summary_key = 1),
@@ -270,6 +429,11 @@ public sealed class SqliteDefenseEventStore : IDefenseEventStore
     {
         var connection = new SqliteConnection(_connectionString);
         connection.Open();
+
+        using var pragmaCommand = connection.CreateCommand();
+        pragmaCommand.CommandText = "PRAGMA foreign_keys = ON;";
+        pragmaCommand.ExecuteNonQuery();
+
         return connection;
     }
 


### PR DESCRIPTION
## Summary
- persist durable decision identifiers and operator feedback records in the defense event store
- add authenticated management endpoints for listing and submitting operator feedback on prior decisions
- cover feedback persistence and endpoint discovery with regression tests

## Testing
- dotnet test anti-scraping-defense-iis.sln --nologo

Closes #103