### PR TITLE
Upgrade .NET tests to xUnit v3

### DIFF
--- a/AiScrapingDefense.IntegrationTests/AiScrapingDefense.IntegrationTests.csproj
+++ b/AiScrapingDefense.IntegrationTests/AiScrapingDefense.IntegrationTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Npgsql" Version="10.0.2" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="Testcontainers.Redis" Version="4.11.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 

--- a/AiScrapingDefense.IntegrationTests/DefenseStackFixture.cs
+++ b/AiScrapingDefense.IntegrationTests/DefenseStackFixture.cs
@@ -32,14 +32,14 @@ public sealed class DefenseStackFixture : IAsyncLifetime
 
     public string IntakeApiKey => "integration-intake-key";
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _redisContainer.StartAsync();
         await _postgresContainer.StartAsync();
         await InitializeMarkovSchemaAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _postgresContainer.DisposeAsync();
         await _redisContainer.DisposeAsync();

--- a/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj
+++ b/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- replace deprecated  package references with  in both .NET test projects
- update the integration test fixture to the xUnit v3 async lifetime signatures
- verify the solution no longer reports deprecated test packages

## Testing
- dotnet list anti-scraping-defense-iis.sln package --deprecated
- dotnet test anti-scraping-defense-iis.sln --nologo

Closes #110