### PR TITLE
Clean up xUnit v3 cancellation warnings

### DIFF
--- a/AiScrapingDefense.IntegrationTests/EndToEndFlowTests.cs
+++ b/AiScrapingDefense.IntegrationTests/EndToEndFlowTests.cs
@@ -22,6 +22,7 @@ public sealed class EndToEndFlowTests
     [Fact]
     public async Task SuspiciousRequests_AreAnalyzed_AndEventuallyBlocked()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         await using var host = await _fixture.CreateHostAsync();
         var client = host.Client;
 
@@ -29,7 +30,7 @@ public sealed class EndToEndFlowTests
         suspiciousRequest.Headers.Add(HeaderDrivenClientIpResolver.HeaderName, "198.51.100.51");
         suspiciousRequest.Headers.UserAgent.ParseAdd("Mozilla/5.0");
         suspiciousRequest.Headers.Accept.ParseAdd("*/*");
-        var firstResponse = await client.SendAsync(suspiciousRequest);
+        var firstResponse = await client.SendAsync(suspiciousRequest, cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
         Assert.Equal("text/html", firstResponse.Content.Headers.ContentType?.MediaType);
@@ -38,26 +39,26 @@ public sealed class EndToEndFlowTests
         secondRequest.Headers.Add(HeaderDrivenClientIpResolver.HeaderName, "198.51.100.51");
         secondRequest.Headers.UserAgent.ParseAdd("Mozilla/5.0");
         secondRequest.Headers.Accept.ParseAdd("*/*");
-        var secondResponse = await client.SendAsync(secondRequest);
+        var secondResponse = await client.SendAsync(secondRequest, cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
 
         var blockedDecision = await WaitForAsync(async () =>
         {
-            var decisions = await GetEventsAsync(client);
+            var decisions = await GetEventsAsync(client, cancellationToken);
             return decisions.FirstOrDefault(decision => string.Equals(decision.Action, "blocked", StringComparison.OrdinalIgnoreCase));
-        });
+        }, cancellationToken);
 
         Assert.NotNull(blockedDecision);
 
-        var blockStatus = await GetBlockStatusAsync(client, blockedDecision!.IpAddress);
+        var blockStatus = await GetBlockStatusAsync(client, blockedDecision!.IpAddress, cancellationToken);
         Assert.True(blockStatus.Blocked);
 
         using var thirdRequest = new HttpRequestMessage(HttpMethod.Get, "/docs");
         thirdRequest.Headers.Add(HeaderDrivenClientIpResolver.HeaderName, "198.51.100.51");
         thirdRequest.Headers.UserAgent.ParseAdd("Mozilla/5.0");
         thirdRequest.Headers.Accept.ParseAdd("*/*");
-        var deniedResponse = await client.SendAsync(thirdRequest);
+        var deniedResponse = await client.SendAsync(thirdRequest, cancellationToken);
 
         Assert.Equal(HttpStatusCode.Forbidden, deniedResponse.StatusCode);
     }
@@ -65,30 +66,32 @@ public sealed class EndToEndFlowTests
     [Fact]
     public async Task ManualBlocklistEndpoints_Block_And_Unblock()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         await using var host = await _fixture.CreateHostAsync();
         var client = host.Client;
         const string ipAddress = "198.51.100.44";
 
         using var blockRequest = CreateManagementRequest(HttpMethod.Post, $"/defense/blocklist?ip={Uri.EscapeDataString(ipAddress)}&reason=manual_test");
-        var blockResponse = await client.SendAsync(blockRequest);
+        var blockResponse = await client.SendAsync(blockRequest, cancellationToken);
         Assert.True(
             blockResponse.StatusCode == HttpStatusCode.Accepted,
-            $"Expected Accepted but received {(int)blockResponse.StatusCode} {blockResponse.StatusCode}: {await blockResponse.Content.ReadAsStringAsync()}");
+            $"Expected Accepted but received {(int)blockResponse.StatusCode} {blockResponse.StatusCode}: {await blockResponse.Content.ReadAsStringAsync(cancellationToken)}");
 
-        var blockedStatus = await GetBlockStatusAsync(client, ipAddress);
+        var blockedStatus = await GetBlockStatusAsync(client, ipAddress, cancellationToken);
         Assert.True(blockedStatus.Blocked);
 
         using var unblockRequest = CreateManagementRequest(HttpMethod.Delete, $"/defense/blocklist?ip={Uri.EscapeDataString(ipAddress)}");
-        var unblockResponse = await client.SendAsync(unblockRequest);
+        var unblockResponse = await client.SendAsync(unblockRequest, cancellationToken);
         Assert.Equal(HttpStatusCode.OK, unblockResponse.StatusCode);
 
-        var unblockedStatus = await GetBlockStatusAsync(client, ipAddress);
+        var unblockedStatus = await GetBlockStatusAsync(client, ipAddress, cancellationToken);
         Assert.False(unblockedStatus.Blocked);
     }
 
     [Fact]
     public async Task WebhookIntake_BlocksIp_AndPersistsDecision()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         await using var host = await _fixture.CreateHostAsync();
         var client = host.Client;
         const string ipAddress = "198.51.100.77";
@@ -113,50 +116,51 @@ public sealed class EndToEndFlowTests
         };
         request.Headers.Add("X-Webhook-Key", _fixture.IntakeApiKey);
 
-        var response = await client.SendAsync(request);
+        var response = await client.SendAsync(request, cancellationToken);
         Assert.True(
             response.StatusCode == HttpStatusCode.Accepted,
-            $"Expected Accepted but received {(int)response.StatusCode} {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+            $"Expected Accepted but received {(int)response.StatusCode} {response.StatusCode}: {await response.Content.ReadAsStringAsync(cancellationToken)}");
 
         var blockStatus = await WaitForAsync(async () =>
         {
-            var status = await GetBlockStatusAsync(client, ipAddress);
+            var status = await GetBlockStatusAsync(client, ipAddress, cancellationToken);
             return status.Blocked ? status : null;
-        });
+        }, cancellationToken);
 
         Assert.NotNull(blockStatus);
 
-        var decisions = await GetEventsAsync(client);
+        var decisions = await GetEventsAsync(client, cancellationToken);
         Assert.Contains(decisions, decision => decision.IpAddress == ipAddress && decision.Signals.Contains("model_positive"));
     }
 
     [Fact]
     public async Task Tarpit_UsesPostgresMarkovCorpus_WhenEnabled()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         await using var host = await _fixture.CreateHostAsync();
         var client = host.Client;
 
-        var response = await client.GetAsync("/anti-scrape-tarpit/reference/manual");
-        var html = await response.Content.ReadAsStringAsync();
+        using var response = await client.GetAsync("/anti-scrape-tarpit/reference/manual", cancellationToken);
+        var html = await response.Content.ReadAsStringAsync(cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Contains("clockwork", html, StringComparison.OrdinalIgnoreCase);
     }
 
-    private async Task<IReadOnlyList<DefenseDecisionDto>> GetEventsAsync(HttpClient client)
+    private async Task<IReadOnlyList<DefenseDecisionDto>> GetEventsAsync(HttpClient client, CancellationToken cancellationToken)
     {
         using var request = CreateManagementRequest(HttpMethod.Get, "/defense/events?count=20");
-        var response = await client.SendAsync(request);
+        using var response = await client.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<IReadOnlyList<DefenseDecisionDto>>(JsonOptions) ?? [];
+        return await response.Content.ReadFromJsonAsync<IReadOnlyList<DefenseDecisionDto>>(JsonOptions, cancellationToken) ?? [];
     }
 
-    private async Task<BlockStatusDto> GetBlockStatusAsync(HttpClient client, string ipAddress)
+    private async Task<BlockStatusDto> GetBlockStatusAsync(HttpClient client, string ipAddress, CancellationToken cancellationToken)
     {
         using var request = CreateManagementRequest(HttpMethod.Get, $"/defense/blocklist?ip={Uri.EscapeDataString(ipAddress)}");
-        var response = await client.SendAsync(request);
+        using var response = await client.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
-        return (await response.Content.ReadFromJsonAsync<BlockStatusDto>(JsonOptions))!;
+        return (await response.Content.ReadFromJsonAsync<BlockStatusDto>(JsonOptions, cancellationToken))!;
     }
 
     private HttpRequestMessage CreateManagementRequest(HttpMethod method, string uri)
@@ -166,7 +170,7 @@ public sealed class EndToEndFlowTests
         return request;
     }
 
-    private static async Task<T?> WaitForAsync<T>(Func<Task<T?>> action)
+    private static async Task<T?> WaitForAsync<T>(Func<Task<T?>> action, CancellationToken cancellationToken)
         where T : class
     {
         var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
@@ -179,7 +183,7 @@ public sealed class EndToEndFlowTests
                 return result;
             }
 
-            await Task.Delay(200);
+            await Task.Delay(200, cancellationToken);
         }
 
         return null;

--- a/AiScrapingDefense.IntegrationTests/ObservabilityFlowTests.cs
+++ b/AiScrapingDefense.IntegrationTests/ObservabilityFlowTests.cs
@@ -15,6 +15,7 @@ public sealed class ObservabilityFlowTests
     [Fact]
     public async Task MetricsEndpoint_ExposesDefenseMetrics_WhenPrometheusIsEnabled()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         await using var host = await _fixture.CreateHostAsync(new Dictionary<string, string?>
         {
             ["DefenseEngine:Observability:EnablePrometheusEndpoint"] = "true"
@@ -26,35 +27,35 @@ public sealed class ObservabilityFlowTests
             suspiciousRequest.Headers.Add(HeaderDrivenClientIpResolver.HeaderName, "198.51.100.71");
             suspiciousRequest.Headers.UserAgent.ParseAdd("Mozilla/5.0");
             suspiciousRequest.Headers.Accept.ParseAdd("*/*");
-            var response = await client.SendAsync(suspiciousRequest);
+            var response = await client.SendAsync(suspiciousRequest, cancellationToken);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         var metricsBody = await WaitForMetricsAsync(client, body =>
             body.Contains("ai_scraping_defense_suspicious_requests_total", StringComparison.Ordinal) &&
             body.Contains("ai_scraping_defense_queue_depth", StringComparison.Ordinal) &&
-            body.Contains("ai_scraping_defense_queue_capacity", StringComparison.Ordinal));
+            body.Contains("ai_scraping_defense_queue_capacity", StringComparison.Ordinal), cancellationToken);
 
         Assert.NotNull(metricsBody);
     }
 
-    private static async Task<string?> WaitForMetricsAsync(HttpClient client, Func<string, bool> predicate)
+    private static async Task<string?> WaitForMetricsAsync(HttpClient client, Func<string, bool> predicate, CancellationToken cancellationToken)
     {
         var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
 
         while (DateTimeOffset.UtcNow < deadline)
         {
-            var response = await client.GetAsync("/metrics");
+            using var response = await client.GetAsync("/metrics", cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                var body = await response.Content.ReadAsStringAsync();
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
                 if (predicate(body))
                 {
                     return body;
                 }
             }
 
-            await Task.Delay(200);
+            await Task.Delay(200, cancellationToken);
         }
 
         return null;

--- a/AiScrapingDefense.IntegrationTests/TarpitArtifactFlowTests.cs
+++ b/AiScrapingDefense.IntegrationTests/TarpitArtifactFlowTests.cs
@@ -16,12 +16,13 @@ public sealed class TarpitArtifactFlowTests
     [Fact]
     public async Task TarpitArchiveRoute_ReturnsZipDecoyArtifact()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         await using var host = await _fixture.CreateHostAsync();
-        var response = await host.Client.GetAsync("/anti-scrape-tarpit/reference/manual/archive/assets.zip");
+        using var response = await host.Client.GetAsync("/anti-scrape-tarpit/reference/manual/archive/assets.zip", cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("application/zip", response.Content.Headers.ContentType?.MediaType);
-        var bytes = await response.Content.ReadAsByteArrayAsync();
+        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
 
         using var archive = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
         Assert.NotEmpty(archive.Entries);

--- a/RedisBlocklistMiddlewareApp.Tests/CommunityReporterTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/CommunityReporterTests.cs
@@ -12,12 +12,13 @@ public sealed class CommunityReporterTests
     [Fact]
     public async Task ReportAsync_PostsExpectedFormPayload()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var handler = new RecordingHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK));
         var reporter = new CommunityReporter(
             Options.Create(CreateOptions()),
             new FakeHttpClientFactory(handler));
 
-        var result = await reporter.ReportAsync(CreateEvent("AI scraper detected"), CancellationToken.None);
+        var result = await reporter.ReportAsync(CreateEvent("AI scraper detected"), cancellationToken);
 
         Assert.NotNull(result);
         Assert.Equal(IntakeDeliveryStatuses.Succeeded, result!.Status);
@@ -26,7 +27,7 @@ public sealed class CommunityReporterTests
 
         Assert.NotNull(handler.Request);
         Assert.Equal("integration-key", handler.Request!.Headers.GetValues("Key").Single());
-        var body = await handler.Request.Content!.ReadAsStringAsync();
+        var body = await handler.Request.Content!.ReadAsStringAsync(cancellationToken);
         Assert.Contains("ip=198.51.100.44", body);
         Assert.Contains("categories=19", body);
         Assert.Contains("AI+Defense+Stack+detection", body);
@@ -35,14 +36,15 @@ public sealed class CommunityReporterTests
     [Fact]
     public async Task ReportAsync_UsesDefaultCategoryWhenReasonDoesNotMatchKnownPatterns()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var handler = new RecordingHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK));
         var reporter = new CommunityReporter(
             Options.Create(CreateOptions()),
             new FakeHttpClientFactory(handler));
 
-        await reporter.ReportAsync(CreateEvent("manual review verdict"), CancellationToken.None);
+        await reporter.ReportAsync(CreateEvent("manual review verdict"), cancellationToken);
 
-        var body = await handler.Request!.Content!.ReadAsStringAsync();
+        var body = await handler.Request!.Content!.ReadAsStringAsync(cancellationToken);
         Assert.Contains("categories=18%2C20", body);
     }
 

--- a/RedisBlocklistMiddlewareApp.Tests/IntakeAlertDispatcherTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/IntakeAlertDispatcherTests.cs
@@ -14,6 +14,7 @@ public sealed class IntakeAlertDispatcherTests
     [Fact]
     public async Task DispatchAsync_SendsGenericWebhookAndSmtpAlerts()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var handler = new RecordingHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.Accepted));
         var smtpSender = new RecordingSmtpAlertSender();
         var dispatcher = new IntakeAlertDispatcher(
@@ -22,7 +23,7 @@ public sealed class IntakeAlertDispatcherTests
             smtpSender);
         var webhookEvent = CreateEvent();
 
-        var results = await dispatcher.DispatchAsync(webhookEvent, CancellationToken.None);
+        var results = await dispatcher.DispatchAsync(webhookEvent, cancellationToken);
 
         Assert.Equal(2, results.Count);
         Assert.Contains(results, record =>
@@ -35,7 +36,7 @@ public sealed class IntakeAlertDispatcherTests
         Assert.NotNull(handler.Request);
         Assert.Equal(HttpMethod.Post, handler.Request!.Method);
         Assert.Equal("Bearer test-token", handler.Request.Headers.Authorization!.ToString());
-        var requestJson = await handler.Request.Content!.ReadAsStringAsync();
+        var requestJson = await handler.Request.Content!.ReadAsStringAsync(cancellationToken);
         using var json = JsonDocument.Parse(requestJson);
         Assert.Equal("AI_DEFENSE_BLOCK", json.RootElement.GetProperty("alert_type").GetString());
         Assert.Equal("suspicious_activity_detected", json.RootElement.GetProperty("event_type").GetString());
@@ -49,12 +50,13 @@ public sealed class IntakeAlertDispatcherTests
     [Fact]
     public async Task DispatchAsync_ReturnsFailedWebhookRecord_WhenWebhookCallThrows()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var dispatcher = new IntakeAlertDispatcher(
             Options.Create(CreateOptions()),
             new FakeHttpClientFactory(new ThrowingHttpMessageHandler(new HttpRequestException("network down"))),
             new RecordingSmtpAlertSender());
 
-        var results = await dispatcher.DispatchAsync(CreateEvent(), CancellationToken.None);
+        var results = await dispatcher.DispatchAsync(CreateEvent(), cancellationToken);
 
         var webhookResult = Assert.Single(results, record => record.Channel == IntakeDeliveryChannels.GenericWebhook);
         Assert.Equal(IntakeDeliveryStatuses.Failed, webhookResult.Status);
@@ -64,6 +66,7 @@ public sealed class IntakeAlertDispatcherTests
     [Fact]
     public async Task DispatchAsync_SendsSlackAlert_WithSlackFormattedPayload()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var handler = new RecordingHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK));
         var options = CreateOptions();
         options.Intake.Alerting.GenericWebhook.Enabled = false;
@@ -79,7 +82,7 @@ public sealed class IntakeAlertDispatcherTests
             new FakeHttpClientFactory(handler),
             new RecordingSmtpAlertSender());
 
-        var results = await dispatcher.DispatchAsync(CreateEvent(), CancellationToken.None);
+        var results = await dispatcher.DispatchAsync(CreateEvent(), cancellationToken);
 
         var slackResult = Assert.Single(results, record => record.Channel == IntakeDeliveryChannels.Slack);
         Assert.Equal(IntakeDeliveryStatuses.Succeeded, slackResult.Status);
@@ -87,7 +90,7 @@ public sealed class IntakeAlertDispatcherTests
         Assert.Equal(HttpMethod.Post, handler.Request!.Method);
         Assert.Equal("https://hooks.slack.example.test/services/test", handler.Request.RequestUri!.ToString());
 
-        var requestJson = await handler.Request.Content!.ReadAsStringAsync();
+        var requestJson = await handler.Request.Content!.ReadAsStringAsync(cancellationToken);
         using var json = JsonDocument.Parse(requestJson);
         var text = json.RootElement.GetProperty("text").GetString();
         Assert.Contains("*AI Defense Alert*", text);
@@ -99,6 +102,7 @@ public sealed class IntakeAlertDispatcherTests
     [Fact]
     public async Task DispatchAsync_ReturnsFailedSlackRecord_WhenSlackCallThrows()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var options = CreateOptions();
         options.Intake.Alerting.GenericWebhook.Enabled = false;
         options.Intake.Alerting.Smtp.Enabled = false;
@@ -113,7 +117,7 @@ public sealed class IntakeAlertDispatcherTests
             new FakeHttpClientFactory(new ThrowingHttpMessageHandler(new HttpRequestException("slack down"))),
             new RecordingSmtpAlertSender());
 
-        var results = await dispatcher.DispatchAsync(CreateEvent(), CancellationToken.None);
+        var results = await dispatcher.DispatchAsync(CreateEvent(), cancellationToken);
 
         var slackResult = Assert.Single(results, record => record.Channel == IntakeDeliveryChannels.Slack);
         Assert.Equal(IntakeDeliveryStatuses.Failed, slackResult.Status);

--- a/RedisBlocklistMiddlewareApp.Tests/SuspiciousRequestQueueTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/SuspiciousRequestQueueTests.cs
@@ -10,19 +10,21 @@ public sealed class SuspiciousRequestQueueTests
     [Fact]
     public async Task QueueAsync_WaitsForCapacityInsteadOfDroppingOldestRequest()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var queue = CreateQueue(capacity: 1);
         var first = CreateRequest("198.51.100.1", "/first");
         var second = CreateRequest("198.51.100.2", "/second");
 
-        Assert.True(await queue.QueueAsync(first, CancellationToken.None));
+        Assert.True(await queue.QueueAsync(first, cancellationToken));
 
-        using var secondWriteCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        using var secondWriteCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        secondWriteCts.CancelAfter(TimeSpan.FromSeconds(2));
         var secondWriteTask = queue.QueueAsync(second, secondWriteCts.Token).AsTask();
 
-        await Task.Delay(100);
+        await Task.Delay(100, cancellationToken);
         Assert.False(secondWriteTask.IsCompleted);
 
-        var enumerator = queue.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+        var enumerator = queue.ReadAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
         Assert.True(await enumerator.MoveNextAsync());
         Assert.Equal("/first", enumerator.Current.Path);
 
@@ -37,16 +39,18 @@ public sealed class SuspiciousRequestQueueTests
     [Fact]
     public async Task QueueAsync_ReturnsFalseWhenWaitingWriterIsCancelled()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var queue = CreateQueue(capacity: 1);
 
-        Assert.True(await queue.QueueAsync(CreateRequest("198.51.100.1", "/first"), CancellationToken.None));
+        Assert.True(await queue.QueueAsync(CreateRequest("198.51.100.1", "/first"), cancellationToken));
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
         var queued = await queue.QueueAsync(CreateRequest("198.51.100.2", "/second"), cts.Token);
 
         Assert.False(queued);
 
-        var enumerator = queue.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+        var enumerator = queue.ReadAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
         Assert.True(await enumerator.MoveNextAsync());
         Assert.Equal("/first", enumerator.Current.Path);
         await enumerator.DisposeAsync();

--- a/RedisBlocklistMiddlewareApp.Tests/WebhookEventInboxTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/WebhookEventInboxTests.cs
@@ -12,13 +12,14 @@ public sealed class WebhookEventInboxTests
     [Fact]
     public async Task Inbox_PersistsQueuedEventsAcrossInstances()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         using var harness = SqliteInboxHarness.Create();
         var firstInbox = harness.CreateInbox();
 
-        await firstInbox.EnqueueAsync(CreateEvent("198.51.100.10"), CancellationToken.None);
+        await firstInbox.EnqueueAsync(CreateEvent("198.51.100.10"), cancellationToken);
 
         var secondInbox = harness.CreateInbox();
-        await using var enumerator = secondInbox.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+        await using var enumerator = secondInbox.ReadAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
 
         Assert.True(await enumerator.MoveNextAsync());
         Assert.Equal("198.51.100.10", enumerator.Current.Event.Details.IpAddress);
@@ -28,18 +29,19 @@ public sealed class WebhookEventInboxTests
     [Fact]
     public async Task Abandon_RequeuesClaimedWebhookEvent()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         using var harness = SqliteInboxHarness.Create();
         var inbox = harness.CreateInbox();
-        await inbox.EnqueueAsync(CreateEvent("198.51.100.11"), CancellationToken.None);
+        await inbox.EnqueueAsync(CreateEvent("198.51.100.11"), cancellationToken);
 
-        await using var firstEnumerator = inbox.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+        await using var firstEnumerator = inbox.ReadAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
         Assert.True(await firstEnumerator.MoveNextAsync());
         var claimed = firstEnumerator.Current;
         await firstEnumerator.DisposeAsync();
 
-        await inbox.AbandonAsync(claimed.Id, CancellationToken.None);
+        await inbox.AbandonAsync(claimed.Id, cancellationToken);
 
-        await using var secondEnumerator = inbox.ReadAllAsync(CancellationToken.None).GetAsyncEnumerator();
+        await using var secondEnumerator = inbox.ReadAllAsync(cancellationToken).GetAsyncEnumerator(cancellationToken);
         Assert.True(await secondEnumerator.MoveNextAsync());
         Assert.Equal(claimed.Id, secondEnumerator.Current.Id);
     }


### PR DESCRIPTION
## Summary
- pass test cancellation tokens through the IIS unit and integration tests that call cancellable APIs
- update async polling helpers, async enumerators, and HTTP content reads to use the xUnit v3 cancellation context
- remove the xUnit1051 warnings introduced by the framework migration

## Testing
- dotnet test anti-scraping-defense-iis.sln --nologo

Closes #112