### PR TITLE
Refresh .NET test tooling packages

### DIFF
--- a/AiScrapingDefense.IntegrationTests/AiScrapingDefense.IntegrationTests.csproj
+++ b/AiScrapingDefense.IntegrationTests/AiScrapingDefense.IntegrationTests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Npgsql" Version="10.0.2" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="Testcontainers.Redis" Version="4.11.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj
+++ b/RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update the IIS test projects to the latest coverlet collector, Microsoft.NET.Test.Sdk, and xUnit VS runner packages
- keep the existing xUnit v3-based test setup intact
- verify the targeted outdated test tooling findings are cleared

## Testing
- dotnet test anti-scraping-defense-iis.sln --nologo
- dotnet list anti-scraping-defense-iis.sln package --outdated

Closes #114