### PR TITLE
Fix macOS package writable paths

### DIFF
--- a/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
+++ b/RedisBlocklistMiddlewareApp.Tests/ManagementEndpointTests.cs
@@ -289,6 +289,57 @@ public sealed class ManagementEndpointTests
     }
 
     [Fact]
+    public void IsMacOsPackagedInstall_ReturnsTrue_ForInstalledMacOsRuntimeRoot()
+    {
+        var packagedInstall = Program.IsMacOsPackagedInstall(
+            "/usr/local/lib/ai-scraping-defense/osx-arm64",
+            isMacOs: true);
+
+        Assert.True(packagedInstall);
+    }
+
+    [Fact]
+    public void ResolveWritableStatePath_UsesWritableMacOsLocation_ForPackagedDefaults()
+    {
+        var resolvedPath = Program.ResolveWritableStatePath(
+            "data/defense-events.db",
+            "data/defense-events.db",
+            "/usr/local/lib/ai-scraping-defense/osx-arm64",
+            "/usr/local/var/lib/ai-scraping-defense/defense-events.db",
+            isMacOs: true);
+
+        Assert.Equal(
+            "/usr/local/var/lib/ai-scraping-defense/defense-events.db",
+            resolvedPath);
+    }
+
+    [Fact]
+    public void ResolveWritableStatePath_PreservesCustomRelativePath_ForPackagedMacOsInstall()
+    {
+        var resolvedPath = Program.ResolveWritableStatePath(
+            "state/custom-events.db",
+            "data/defense-events.db",
+            "/usr/local/lib/ai-scraping-defense/osx-arm64",
+            "/usr/local/var/lib/ai-scraping-defense/defense-events.db",
+            isMacOs: true);
+
+        Assert.Equal("state/custom-events.db", resolvedPath);
+    }
+
+    [Fact]
+    public void ResolveWritableStatePath_PreservesDefaultRelativePath_OutsidePackagedMacOsInstall()
+    {
+        var resolvedPath = Program.ResolveWritableStatePath(
+            "data/tarpit-archives",
+            "data/tarpit-archives",
+            "/opt/ai-scraping-defense",
+            "/usr/local/var/lib/ai-scraping-defense/tarpit-archives",
+            isMacOs: true);
+
+        Assert.Equal("data/tarpit-archives", resolvedPath);
+    }
+
+    [Fact]
     public void MapManagementEndpoints_DoesNotRegisterDefenseEvents_WhenManagementApiKeyIsMissing()
     {
         var app = CreateApp();

--- a/RedisBlocklistMiddlewareApp/Program.cs
+++ b/RedisBlocklistMiddlewareApp/Program.cs
@@ -19,6 +19,7 @@ builder.Host.UseWindowsService(options =>
 });
 
 var redisConnectionString = builder.Configuration.GetConnectionString("RedisConnection");
+var contentRootPath = builder.Environment.ContentRootPath;
 
 builder.Services.AddHttpClient();
 builder.Services.AddDataProtection();
@@ -39,9 +40,12 @@ builder.Services
         options.Tarpit.PathPrefix = NormalizeRoutePrefix(
             options.Tarpit.PathPrefix,
             "/anti-scrape-tarpit");
-        options.Tarpit.ArchiveDirectory = string.IsNullOrWhiteSpace(options.Tarpit.ArchiveDirectory)
-            ? "data/tarpit-archives"
-            : options.Tarpit.ArchiveDirectory.Trim();
+        options.Tarpit.ArchiveDirectory = ResolveWritableStatePath(
+            options.Tarpit.ArchiveDirectory,
+            "data/tarpit-archives",
+            contentRootPath,
+            "/usr/local/var/lib/ai-scraping-defense/tarpit-archives",
+            OperatingSystem.IsMacOS());
         options.Tarpit.ArchiveRotationMinutes = Math.Max(1, options.Tarpit.ArchiveRotationMinutes);
         options.Tarpit.MaximumArchivesToKeep = Math.Max(1, options.Tarpit.MaximumArchivesToKeep);
         options.Tarpit.JavaScriptDecoyFileCount = Math.Max(1, options.Tarpit.JavaScriptDecoyFileCount);
@@ -142,9 +146,12 @@ builder.Services
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        options.Audit.DatabasePath = string.IsNullOrWhiteSpace(options.Audit.DatabasePath)
-            ? "data/defense-events.db"
-            : options.Audit.DatabasePath.Trim();
+        options.Audit.DatabasePath = ResolveWritableStatePath(
+            options.Audit.DatabasePath,
+            "data/defense-events.db",
+            contentRootPath,
+            "/usr/local/var/lib/ai-scraping-defense/defense-events.db",
+            OperatingSystem.IsMacOS());
 
         options.Audit.MaxRecentEvents = Math.Max(1, options.Audit.MaxRecentEvents);
 
@@ -846,6 +853,42 @@ public partial class Program
         return string.IsNullOrWhiteSpace(trimmedActor)
             ? trimmedReason
             : $"{trimmedReason} (operator: {trimmedActor})";
+    }
+
+    public static bool IsMacOsPackagedInstall(string contentRootPath, bool isMacOs)
+    {
+        if (!isMacOs || string.IsNullOrWhiteSpace(contentRootPath))
+        {
+            return false;
+        }
+
+        var normalizedContentRoot = Path.GetFullPath(contentRootPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        return normalizedContentRoot.StartsWith(
+            "/usr/local/lib/ai-scraping-defense/",
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string ResolveWritableStatePath(
+        string? configuredPath,
+        string relativeDefault,
+        string contentRootPath,
+        string macOsInstalledPath,
+        bool isMacOs)
+    {
+        var candidate = string.IsNullOrWhiteSpace(configuredPath)
+            ? relativeDefault
+            : configuredPath.Trim();
+
+        if (!IsMacOsPackagedInstall(contentRootPath, isMacOs) ||
+            Path.IsPathRooted(candidate) ||
+            !string.Equals(candidate, relativeDefault, StringComparison.OrdinalIgnoreCase))
+        {
+            return candidate;
+        }
+
+        return macOsInstalledPath;
     }
 
     private static string NormalizeObservabilityPath(string path)

--- a/docs/macos_installer.md
+++ b/docs/macos_installer.md
@@ -37,6 +37,18 @@ Outputs:
 
 The package does not auto-start the service. That is intentional because a fresh install still needs real production configuration.
 
+The installer also creates writable runtime state directories under:
+
+- `/usr/local/var/lib/ai-scraping-defense`
+- `/usr/local/var/log/ai-scraping-defense`
+
+When the service runs from the packaged macOS install root, the built-in defaults automatically remap to those writable locations:
+
+- `DefenseEngine:Audit:DatabasePath` defaults to `/usr/local/var/lib/ai-scraping-defense/defense-events.db`
+- `DefenseEngine:Tarpit:ArchiveDirectory` defaults to `/usr/local/var/lib/ai-scraping-defense/tarpit-archives`
+
+Explicit custom paths in configuration are preserved.
+
 ## Configuration Notes
 
 Before starting the service, update the installed configuration for:


### PR DESCRIPTION
## Summary
- remap packaged macOS default audit and tarpit paths to the installer-created writable state directory
- add regression tests for packaged install detection and default path preservation
- document the packaged macOS runtime state locations

Closes #92

## Testing
- dotnet test RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj --no-restore
- dotnet test anti-scraping-defense-iis.sln --no-restore