### PR TITLE
Pin patched SQLite native bundle

### DIFF
--- a/RedisBlocklistMiddlewareApp/RedisBlocklistMiddlewareApp.csproj
+++ b/RedisBlocklistMiddlewareApp/RedisBlocklistMiddlewareApp.csproj
@@ -9,7 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.28" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.29" />
+    <!-- Pin the native SQLite bundle above the versions affected by CVE-2025-6965. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.0" />
     <PackageReference Include="Npgsql" Version="8.0.9" />


### PR DESCRIPTION
## Summary
- update Microsoft.Data.Sqlite to the current 8.0 servicing release
- explicitly pin SQLitePCLRaw.bundle_e_sqlite3 2.1.12 so the native SQLite library is above the versions affected by CVE-2025-6965

## Validation
- `dotnet test RedisBlocklistMiddlewareApp.Tests/RedisBlocklistMiddlewareApp.Tests.csproj -c Release` (141 passed)
- `dotnet list RedisBlocklistMiddlewareApp/RedisBlocklistMiddlewareApp.csproj package --vulnerable --include-transitive` (no vulnerable packages)

Closes #123.